### PR TITLE
"Obviously harmless" error handling tweaks.

### DIFF
--- a/uspace/app/bdsh/cmds/builtins/batch/batch.c
+++ b/uspace/app/bdsh/cmds/builtins/batch/batch.c
@@ -84,7 +84,7 @@ int cmd_batch(char **argv, cliuser_t *usr)
 			continue_despite_errors = true;
 	}
 
-	int rc = 0;
+	int rc = EOK;
 	FILE *batch = fopen(argv[1], "r");
 	if (batch == NULL) {
 		printf("%s - Cannot open file %s\n", cmdname, argv[1]);
@@ -103,7 +103,7 @@ int cmd_batch(char **argv, cliuser_t *usr)
 				*cur = '\0';
 				if (cur == fusr.line) {
 					/* skip empty line */
-					rc = 0;
+					rc = EOK;
 					free(cur);
 				} else {
 					printf(">%s\n", fusr.line);

--- a/uspace/app/bdsh/cmds/builtins/cd/cd.c
+++ b/uspace/app/bdsh/cmds/builtins/cd/cd.c
@@ -84,7 +84,8 @@ void help_cmd_cd(unsigned int level)
 
 int cmd_cd(char **argv, cliuser_t *usr)
 {
-	int argc, rc = 0;
+	int argc;
+	int rc = EOK;
 
 	argc = cli_count_args(argv);
 

--- a/uspace/app/bdsh/cmds/modules/mkdir/mkdir.c
+++ b/uspace/app/bdsh/cmds/modules/mkdir/mkdir.c
@@ -93,12 +93,13 @@ create_directory(const char *user_path, bool create_parents)
 	}
 
 	int ret = 0;
+	int rc;
 
 	if (!create_parents) {
-		ret = vfs_link_path(path, KIND_DIRECTORY, NULL);
-		if (ret != EOK) {
+		rc = vfs_link_path(path, KIND_DIRECTORY, NULL);
+		if (rc != EOK) {
 			cli_error(CL_EFAIL, "%s: could not create %s (%s)",
-			    cmdname, path, str_error(ret));
+			    cmdname, path, str_error(rc));
 			ret = 1;
 		}
 	} else {
@@ -134,10 +135,10 @@ create_directory(const char *user_path, bool create_parents)
 			char slash_char = path[prev_off];
 			path[prev_off] = 0;
 
-			ret = vfs_link_path(path, KIND_DIRECTORY, NULL);
-			if (ret != EOK && ret != EEXIST) {
+			rc = vfs_link_path(path, KIND_DIRECTORY, NULL);
+			if (rc != EOK && rc != EEXIST) {
 				cli_error(CL_EFAIL, "%s: could not create %s (%s)",
-				    cmdname, path, str_error(ret));
+				    cmdname, path, str_error(rc));
 				ret = 1;
 				goto leave;
 			}
@@ -145,10 +146,10 @@ create_directory(const char *user_path, bool create_parents)
 			path[prev_off] = slash_char;
 		}
 		/* Create the final directory. */
-		ret = vfs_link_path(path, KIND_DIRECTORY, NULL);
-		if (ret != EOK) {
+		rc = vfs_link_path(path, KIND_DIRECTORY, NULL);
+		if (rc != EOK) {
 			cli_error(CL_EFAIL, "%s: could not create %s (%s)",
-			    cmdname, path, str_error(ret));
+			    cmdname, path, str_error(rc));
 			ret = 1;
 		}
 	}

--- a/uspace/app/bdsh/cmds/modules/mkfile/mkfile.c
+++ b/uspace/app/bdsh/cmds/modules/mkfile/mkfile.c
@@ -191,7 +191,7 @@ int cmd_mkfile(char **argv)
 		to_write = min(file_size - total_written, BUFFER_SIZE);
 		rc = vfs_write(fd, &pos, buffer, to_write, &nwritten);
 		if (rc != EOK) {
-			printf("%s: Error writing file (%s).\n", cmdname, str_error(errno));
+			printf("%s: Error writing file (%s).\n", cmdname, str_error(rc));
 			vfs_put(fd);
 			free(buffer);
 			return CMD_FAILURE;
@@ -201,11 +201,12 @@ int cmd_mkfile(char **argv)
 
 	free(buffer);
 
-	if (vfs_put(fd) != EOK)
+	rc = vfs_put(fd);
+	if (rc != EOK)
 		goto error;
 
 	return CMD_SUCCESS;
 error:
-	printf("%s: Error writing file (%s).\n", cmdname, str_error(errno));
+	printf("%s: Error writing file (%s).\n", cmdname, str_error(rc));
 	return CMD_FAILURE;
 }

--- a/uspace/app/bdsh/cmds/modules/mkfile/mkfile.c
+++ b/uspace/app/bdsh/cmds/modules/mkfile/mkfile.c
@@ -201,7 +201,7 @@ int cmd_mkfile(char **argv)
 
 	free(buffer);
 
-	if (vfs_put(fd) < 0)
+	if (vfs_put(fd) != EOK)
 		goto error;
 
 	return CMD_SUCCESS;

--- a/uspace/app/bdsh/cmds/modules/mount/mount.c
+++ b/uspace/app/bdsh/cmds/modules/mount/mount.c
@@ -131,7 +131,8 @@ int cmd_mount(char **argv)
 	unsigned int argc;
 	const char *mopts = "";
 	const char *dev = "";
-	int rc, c, opt_ind;
+	int rc;
+	int c, opt_ind;
 	unsigned int instance = 0;
 	bool instance_set = false;
 	char **t_argv;

--- a/uspace/app/bdsh/cmds/modules/rm/rm.c
+++ b/uspace/app/bdsh/cmds/modules/rm/rm.c
@@ -208,7 +208,7 @@ static unsigned int rm_recursive(const char *path)
 	/* Delete directory */
 	rc = vfs_unlink_path(path);
 	if (rc == EOK)
-		return EOK;
+		return 0;
 
 	cli_error(CL_ENOTSUP, "Can not remove %s", path);
 

--- a/uspace/app/bdsh/exec.c
+++ b/uspace/app/bdsh/exec.c
@@ -97,7 +97,8 @@ unsigned int try_exec(char *cmd, char **argv, iostate_t *io)
 	task_wait_t twait;
 	task_exit_t texit;
 	char *tmp;
-	int rc, retval, i;
+	int rc;
+	int retval, i;
 	int file_handles[3] = { -1, -1, -1 };
 	FILE *files[3];
 

--- a/uspace/app/bdsh/test/toktest.c
+++ b/uspace/app/bdsh/test/toktest.c
@@ -46,11 +46,11 @@ static void prepare(const char *input, size_t expected_token_count) {
 	str_cpy(input_buffer, MAX_INPUT, input);
 
 	int rc = tok_init(&tokenizer, input_buffer, tokens, MAX_TOKENS);
-	PCUT_ASSERT_INT_EQUALS(EOK, rc);
+	PCUT_ASSERT_ERRNO_VAL(EOK, rc);
 
 	size_t token_count;
 	rc = tok_tokenize(&tokenizer, &token_count);
-	PCUT_ASSERT_INT_EQUALS(EOK, rc);
+	PCUT_ASSERT_ERRNO_VAL(EOK, rc);
 
 
 	PCUT_ASSERT_INT_EQUALS(expected_token_count, token_count);

--- a/uspace/app/blkdump/blkdump.c
+++ b/uspace/app/blkdump/blkdump.c
@@ -160,14 +160,15 @@ devname:
 
 	printf("Device %s has %" PRIuOFF64 " blocks, %" PRIuOFF64 " bytes each\n", dev_path, dev_nblocks, (aoff64_t) block_size);
 
+	int ret;
 	if (toc)
-		rc = print_toc();
+		ret = print_toc();
 	else
-		rc = print_blocks(block_offset, block_count, block_size);
+		ret = print_blocks(block_offset, block_count, block_size);
 
 	block_fini(service_id);
 
-	return rc;
+	return ret;
 }
 
 static int print_blocks(aoff64_t block_offset, aoff64_t block_count, size_t block_size)

--- a/uspace/app/date/date.c
+++ b/uspace/app/date/date.c
@@ -50,7 +50,8 @@ static int days_month[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 int
 main(int argc, char **argv)
 {
-	int rc, c;
+	int rc;
+	int c;
 	category_id_t cat_id;
 	size_t        svc_cnt;
 	service_id_t  *svc_ids = NULL;

--- a/uspace/app/download/main.c
+++ b/uspace/app/download/main.c
@@ -73,6 +73,7 @@ int main(int argc, char *argv[])
 	uri_t *uri = NULL;
 	http_t *http = NULL;
 	int rc;
+	int ret;
 
 	if (argc < 2) {
 		syntax_print();
@@ -154,8 +155,8 @@ int main(int argc, char *argv[])
 			goto error;
 		}
 	} else {
-		rc = asprintf(&server_path, "%s?%s", path, uri->query);
-		if (rc < 0) {
+		ret = asprintf(&server_path, "%s?%s", path, uri->query);
+		if (ret < 0) {
 			fprintf(stderr, "Failed allocating path\n");
 			rc = ENOMEM;
 			goto error;

--- a/uspace/app/edit/edit.c
+++ b/uspace/app/edit/edit.c
@@ -760,7 +760,7 @@ static int file_save_range(char const *fname, spt_t const *spos,
 		sp = bep;
 	} while (!spt_equal(&bep, epos));
 
-	if (fclose(f) != EOK)
+	if (fclose(f) < 0)
 		return EIO;
 
 	return EOK;

--- a/uspace/app/fdisk/fdisk.c
+++ b/uspace/app/fdisk/fdisk.c
@@ -209,8 +209,8 @@ static int fdsk_dev_sel_choice(service_id_t *rsvcid)
 			goto error;
 		}
 
-		rc = asprintf(&dtext, "%s (%s)", svcname, scap);
-		if (rc < 0) {
+		int ret = asprintf(&dtext, "%s (%s)", svcname, scap);
+		if (ret < 0) {
 			rc = ENOMEM;
 			printf("Out of memory.\n");
 			goto error;
@@ -614,16 +614,16 @@ static int fdsk_delete_part(fdisk_dev_t *dev)
 			else
 				label = "(No name)";
 
-			rc = asprintf(&sdesc, "%s %s, %s, %s", label,
+			int ret = asprintf(&sdesc, "%s %s, %s, %s", label,
 			    scap, spkind, sfstype);
-			if (rc < 0) {
+			if (ret < 0) {
 				rc = ENOMEM;
 				goto error;
 			}
 
 		} else {
-			rc = asprintf(&sdesc, "%s, %s", scap, spkind);
-			if (rc < 0) {
+			int ret = asprintf(&sdesc, "%s, %s", scap, spkind);
+			if (ret < 0) {
 				rc = ENOMEM;
 				goto error;
 			}

--- a/uspace/app/gunzip/gunzip.c
+++ b/uspace/app/gunzip/gunzip.c
@@ -57,8 +57,7 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
-	rc = fseek(f, 0, SEEK_END);
-	if (rc != 0) {
+	if (fseek(f, 0, SEEK_END) < 0) {
 		printf("Error determining size of '%s'\n", argv[1]);
 		fclose(f);
 		return 1;
@@ -71,8 +70,7 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
-	rc = fseek(f, 0, SEEK_SET);
-	if (rc != 0) {
+	if (fseek(f, 0, SEEK_SET) < 0) {
 		printf ("Error rewinding '%s'\n", argv[1]);
 		fclose(f);
 		return 1;

--- a/uspace/app/mkexfat/mkexfat.c
+++ b/uspace/app/mkexfat/mkexfat.c
@@ -350,7 +350,8 @@ ebs_write(service_id_t service_id, exfat_cfg_t *cfg, int base,
     uint32_t *chksum)
 {
 	uint32_t *ebs = calloc(cfg->sector_size, sizeof(uint8_t));
-	int i, rc;
+	int i;
+	int rc;
 
 	if (!ebs)
 		return ENOMEM;
@@ -756,7 +757,8 @@ int main (int argc, char **argv)
 	uint32_t next_cls;
 	char *dev_path;
 	service_id_t service_id;
-	int rc, c, opt_ind;
+	int rc;
+	int c, opt_ind;
 	aoff64_t user_fs_size = 0;
 
 	if (argc < 2) {

--- a/uspace/app/mkmfs/mkmfs.c
+++ b/uspace/app/mkmfs/mkmfs.c
@@ -108,7 +108,8 @@ static struct option const long_options[] = {
 
 int main (int argc, char **argv)
 {
-	int rc, c, opt_ind;
+	int rc;
+	int c, opt_ind;
 	char *device_name;
 	size_t devblock_size;
 

--- a/uspace/app/ping/ping.c
+++ b/uspace/app/ping/ping.c
@@ -289,8 +289,7 @@ int main(int argc, char *argv[])
 		goto error;
 	}
 	
-	rc = asprintf(&sdest, "%s (%s)", host, adest);
-	if (rc < 0) {
+	if (asprintf(&sdest, "%s (%s)", host, adest) < 0) {
 		printf("Out of memory.\n");
 		goto error;
 	}

--- a/uspace/app/pkg/pkg.c
+++ b/uspace/app/pkg/pkg.c
@@ -106,6 +106,7 @@ static int pkg_install(int argc, char *argv[])
 	char *fname;
 	char *fnunpack;
 	int rc;
+	int ret;
 
 	if (argc != 3) {
 		print_syntax();
@@ -114,24 +115,24 @@ static int pkg_install(int argc, char *argv[])
 
 	pkg_name = argv[2];
 
-	rc = asprintf(&src_uri, "http://ci.helenos.org/latest/" STRING(UARCH)
+	ret = asprintf(&src_uri, "http://ci.helenos.org/latest/" STRING(UARCH)
 	    "/%s-for-helenos-" STRING(UARCH) ".tar.gz",
 	    pkg_name);
-	if (rc < 0) {
+	if (ret < 0) {
 		printf("Out of memory.\n");
 		return ENOMEM;
 	}
 
-	rc = asprintf(&fname, "/tmp/%s-for-helenos-" STRING(UARCH)
+	ret = asprintf(&fname, "/tmp/%s-for-helenos-" STRING(UARCH)
 	    ".tar.gz", pkg_name);
-	if (rc < 0) {
+	if (ret < 0) {
 		printf("Out of memory.\n");
 		return ENOMEM;
 	}
 
-	rc = asprintf(&fnunpack, "/tmp/%s-for-helenos-" STRING(UARCH) ".tar",
+	ret = asprintf(&fnunpack, "/tmp/%s-for-helenos-" STRING(UARCH) ".tar",
 	    pkg_name);
-	if (rc < 0) {
+	if (ret < 0) {
 		printf("Out of memory.\n");
 		return ENOMEM;
 	}

--- a/uspace/app/sbi/src/os/helenos.c
+++ b/uspace/app/sbi/src/os/helenos.c
@@ -251,7 +251,8 @@ int os_exec(char *const cmd[])
 	task_id_t tid;
 	task_wait_t twait;
 	task_exit_t texit;
-	int rc, retval;
+	int rc;
+	int retval;
 
 	rc = task_spawnv(&tid, &twait, cmd[0], (char const * const *) cmd);
 	if (rc != EOK) {

--- a/uspace/app/sysinst/sysinst.c
+++ b/uspace/app/sysinst/sysinst.c
@@ -141,8 +141,7 @@ static int sysinst_label_dev(const char *dev, char **pdev)
 	}
 
 	/* XXX libfdisk should give us the service name */
-	rc = asprintf(pdev, "%sp1", dev);
-	if (rc < 0)
+	if (asprintf(pdev, "%sp1", dev) < 0)
 		return ENOMEM;
 
 	printf("sysinst_label_dev(): OK\n");

--- a/uspace/app/taskdump/elf_core.c
+++ b/uspace/app/taskdump/elf_core.c
@@ -306,7 +306,7 @@ static int write_mem_area(int fd, aoff64_t *pos, as_area_info_t *area,
 	while (total < area->size) {
 		to_copy = min(area->size - total, BUFFER_SIZE);
 		rc = udebug_mem_read(sess, buffer, addr, to_copy);
-		if (rc < 0) {
+		if (rc != EOK) {
 			printf("Failed reading task memory.\n");
 			return EIO;
 		}

--- a/uspace/app/tester/float/float1.c
+++ b/uspace/app/tester/float/float1.c
@@ -27,6 +27,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stddef.h>
@@ -74,7 +75,7 @@ const char *test_float1(void)
 	
 	TPRINTF("Creating threads");
 	for (unsigned int i = 0; i < THREADS; i++) {
-		if (thread_create(e, NULL, "e", NULL) < 0) {
+		if (thread_create(e, NULL, "e", NULL) != EOK) {
 			TPRINTF("\nCould not create thread %u\n", i);
 			break;
 		}

--- a/uspace/app/tester/thread/thread1.c
+++ b/uspace/app/tester/thread/thread1.c
@@ -31,6 +31,7 @@
 #define DELAY    10
 
 #include <atomic.h>
+#include <errno.h>
 #include <thread.h>
 #include <stdio.h>
 #include <stddef.h>
@@ -60,7 +61,7 @@ const char *test_thread1(void)
 	
 	TPRINTF("Creating threads");
 	for (i = 0; i < THREADS; i++) {
-		if (thread_create(threadtest, NULL, "threadtest", NULL) < 0) {
+		if (thread_create(threadtest, NULL, "threadtest", NULL) != EOK) {
 			TPRINTF("\nCould not create thread %u\n", i);
 			break;
 		}

--- a/uspace/app/trace/trace.c
+++ b/uspace/app/trace/trace.c
@@ -161,13 +161,13 @@ static int connect_task(task_id_t task_id)
 	}
 	
 	int rc = udebug_begin(ksess);
-	if (rc < 0) {
+	if (rc != EOK) {
 		printf("udebug_begin() -> %s\n", str_error_name(rc));
 		return rc;
 	}
 	
 	rc = udebug_set_evmask(ksess, UDEBUG_EM_ALL);
-	if (rc < 0) {
+	if (rc != EOK) {
 		printf("udebug_set_evmask(0x%x) -> %s\n ", UDEBUG_EM_ALL, str_error_name(rc));
 		return rc;
 	}
@@ -185,7 +185,7 @@ static int get_thread_list(void)
 
 	rc = udebug_thread_read(sess, thread_hash_buf,
 		THBUF_SIZE*sizeof(unsigned), &tb_copied, &tb_needed);
-	if (rc < 0) {
+	if (rc != EOK) {
 		printf("udebug_thread_read() -> %s\n", str_error_name(rc));
 		return rc;
 	}
@@ -324,7 +324,7 @@ static void sc_ipc_wait(sysarg_t *sc_args, int sc_rc)
 	memset(&call, 0, sizeof(call));
 	rc = udebug_mem_read(sess, &call, sc_args[0], sizeof(call));
 	
-	if (rc >= 0)
+	if (rc == EOK)
 		ipcp_call_in(&call, sc_rc);
 }
 
@@ -337,7 +337,7 @@ static void event_syscall_b(unsigned thread_id, uintptr_t thread_hash,
 	/* Read syscall arguments */
 	rc = udebug_args_read(sess, thread_hash, sc_args);
 
-	if (rc < 0) {
+	if (rc != EOK) {
 		printf("error\n");
 		return;
 	}
@@ -367,7 +367,7 @@ static void event_syscall_e(unsigned thread_id, uintptr_t thread_hash,
 
 //	printf("[%d] ", thread_id);
 
-	if (rc < 0) {
+	if (rc != EOK) {
 		printf("error\n");
 		return;
 	}
@@ -444,7 +444,7 @@ static int trace_loop(void *thread_hash_arg)
 			break;
 		}
 
-		if (rc >= 0) {
+		if (rc == EOK) {
 			switch (ev_type) {
 			case UDEBUG_EVENT_SYSCALL_B:
 				event_syscall_b(thread_id, thread_hash, val0, (int)val1);
@@ -602,7 +602,7 @@ static void trace_task(task_id_t task_id)
 	ipcp_init();
 
 	rc = get_thread_list();
-	if (rc < 0) {
+	if (rc != EOK) {
 		printf("Failed to get thread list (%s)\n", str_error(rc));
 		return;
 	}
@@ -858,7 +858,7 @@ int main(int argc, char *argv[])
 	main_init();
 
 	rc = connect_task(task_id);
-	if (rc < 0) {
+	if (rc != EOK) {
 		printf("Failed connecting to task %" PRIu64 ".\n", task_id);
 		return 1;
 	}

--- a/uspace/app/wavplay/dplay.c
+++ b/uspace/app/wavplay/dplay.c
@@ -328,7 +328,7 @@ static void play(playback_t *pb)
  * Play audio file usign direct device access.
  * @param device The device.
  * @param file The file.
- * @return Error code.
+ * @return 0 on success, non-zero on failure.
  */
 int dplay(const char *device, const char *file)
 {

--- a/uspace/app/wavplay/drec.c
+++ b/uspace/app/wavplay/drec.c
@@ -169,7 +169,7 @@ static void record_fragment(record_t *rec, pcm_format_t f)
  * Record directly from a device to a file.
  * @param device The device.
  * @param file The file.
- * @return Error code.
+ * @return 0 on succes, non-zero on failure.
  */
 int drecord(const char *device, const char *file)
 {

--- a/uspace/app/websrv/websrv.c
+++ b/uspace/app/websrv/websrv.c
@@ -258,8 +258,7 @@ static int uri_get(const char *uri, tcp_conn_t *conn)
 	if (str_cmp(uri, "/") == 0)
 		uri = "/index.html";
 	
-	rc = asprintf(&fname, "%s%s", WEB_ROOT, uri);
-	if (rc < 0) {
+	if (asprintf(&fname, "%s%s", WEB_ROOT, uri) < 0) {
 		rc = ENOMEM;
 		goto out;
 	}

--- a/uspace/drv/audio/hdaudio/pcm_iface.c
+++ b/uspace/drv/audio/hdaudio/pcm_iface.c
@@ -119,7 +119,7 @@ static unsigned hda_query_cap(ddf_fun_t *fun, audio_cap_t cap)
 	case AUDIO_CAP_INTERRUPT_MAX_FRAMES:
 		return 16384;
 	default:
-		return ENOTSUP;
+		return -1;
 	}
 }
 

--- a/uspace/drv/audio/sb16/dsp.c
+++ b/uspace/drv/audio/sb16/dsp.c
@@ -289,7 +289,7 @@ unsigned sb_dsp_query_cap(sb_dsp_t *dsp, audio_cap_t cap)
 	case AUDIO_CAP_INTERRUPT_MAX_FRAMES:
 		return 16535;
 	default:
-		return ENOTSUP;
+		return -1;
 	}
 }
 

--- a/uspace/drv/block/ata_bd/ata_bd.c
+++ b/uspace/drv/block/ata_bd/ata_bd.c
@@ -144,7 +144,8 @@ static int disk_dev_idx(disk_t *disk)
 /** Initialize ATA controller. */
 int ata_ctrl_init(ata_ctrl_t *ctrl, ata_base_t *res)
 {
-	int i, rc;
+	int i;
+	int rc;
 	int n_disks;
 
 	ddf_msg(LVL_DEBUG, "ata_ctrl_init()");
@@ -209,7 +210,8 @@ error:
 /** Remove ATA controller. */
 int ata_ctrl_remove(ata_ctrl_t *ctrl)
 {
-	int i, rc;
+	int i;
+	int rc;
 
 	ddf_msg(LVL_DEBUG, ": ata_ctrl_remove()");
 
@@ -233,7 +235,8 @@ int ata_ctrl_remove(ata_ctrl_t *ctrl)
 /** Surprise removal of ATA controller. */
 int ata_ctrl_gone(ata_ctrl_t *ctrl)
 {
-	int i, rc;
+	int i;
+	int rc;
 
 	ddf_msg(LVL_DEBUG, "ata_ctrl_gone()");
 

--- a/uspace/drv/block/usbmast/bo_trans.c
+++ b/uspace/drv/block/usbmast/bo_trans.c
@@ -227,7 +227,7 @@ void usb_massstor_reset_recovery(usbmast_dev_t *mdev)
  * You shall rather use usb_masstor_get_lun_count.
  *
  * @param mfun		Mass storage function
- * @return		Error code of maximum LUN (index, not count)
+ * @return		Maximum LUN (index, not count), or -1
  */
 int usb_massstor_get_max_lun(usbmast_dev_t *mdev)
 {
@@ -239,12 +239,12 @@ int usb_massstor_get_max_lun(usbmast_dev_t *mdev)
 	    0xFE, 0, usb_device_get_iface_number(mdev->usb_dev), &max_lun, 1,
 	    &data_recv_len);
 	if (rc != EOK) {
-		return rc;
+		return -1;
 	}
 	if (data_recv_len != 1) {
-		return EEMPTY;
+		return -1;
 	}
-	return (int) max_lun;
+	return max_lun;
 }
 
 /** Get number of LUNs supported by mass storage device.

--- a/uspace/drv/bus/pci/pciintel/pci.c
+++ b/uspace/drv/bus/pci/pciintel/pci.c
@@ -98,7 +98,7 @@ static hw_resource_list_t *pciintel_get_resources(ddf_fun_t *fnode)
 	return &fun->hw_resources;
 }
 
-static int pciintel_fun_owns_interrupt(pci_fun_t *fun, int irq)
+static bool pciintel_fun_owns_interrupt(pci_fun_t *fun, int irq)
 {
 	size_t i;
 	hw_resource_list_t *res = &fun->hw_resources;
@@ -382,14 +382,14 @@ void pci_conf_write_32(pci_fun_t *fun, int reg, uint32_t val)
 void pci_fun_create_match_ids(pci_fun_t *fun)
 {
 	int rc;
+	int ret;
 	char match_id_str[ID_MAX_STR_LEN];
 
 	/* Vendor ID & Device ID, length(incl \0) 22 */
-	rc = snprintf(match_id_str, ID_MAX_STR_LEN, "pci/ven=%04"
+	ret = snprintf(match_id_str, ID_MAX_STR_LEN, "pci/ven=%04"
 	    PRIx16 "&dev=%04" PRIx16, fun->vendor_id, fun->device_id);
-	if (rc < 0) {
-		ddf_msg(LVL_ERROR, "Failed creating match ID str: %s",
-		    str_error(rc));
+	if (ret < 0) {
+		ddf_msg(LVL_ERROR, "Failed creating match ID str");
 	}
 
 	rc = ddf_fun_add_match_id(fun->fnode, match_id_str, 90);
@@ -398,12 +398,11 @@ void pci_fun_create_match_ids(pci_fun_t *fun)
 	}
 
 	/* Class, subclass, prog IF, revision, length(incl \0) 47 */
-	rc = snprintf(match_id_str, ID_MAX_STR_LEN,
+	ret = snprintf(match_id_str, ID_MAX_STR_LEN,
 	    "pci/class=%02x&subclass=%02x&progif=%02x&revision=%02x",
 	    fun->class_code, fun->subclass_code, fun->prog_if, fun->revision);
-	if (rc < 0) {
-		ddf_msg(LVL_ERROR, "Failed creating match ID str: %s",
-		    str_error(rc));
+	if (ret < 0) {
+		ddf_msg(LVL_ERROR, "Failed creating match ID str");
 	}
 
 	rc = ddf_fun_add_match_id(fun->fnode, match_id_str, 70);
@@ -412,12 +411,11 @@ void pci_fun_create_match_ids(pci_fun_t *fun)
 	}
 
 	/* Class, subclass, prog IF, length(incl \0) 35 */
-	rc = snprintf(match_id_str, ID_MAX_STR_LEN,
+	ret = snprintf(match_id_str, ID_MAX_STR_LEN,
 	    "pci/class=%02x&subclass=%02x&progif=%02x",
 	    fun->class_code, fun->subclass_code, fun->prog_if);
-	if (rc < 0) {
-		ddf_msg(LVL_ERROR, "Failed creating match ID str: %s",
-		    str_error(rc));
+	if (ret < 0) {
+		ddf_msg(LVL_ERROR, "Failed creating match ID str");
 	}
 
 	rc = ddf_fun_add_match_id(fun->fnode, match_id_str, 60);
@@ -426,12 +424,11 @@ void pci_fun_create_match_ids(pci_fun_t *fun)
 	}
 
 	/* Class, subclass, length(incl \0) 25 */
-	rc = snprintf(match_id_str, ID_MAX_STR_LEN,
+	ret = snprintf(match_id_str, ID_MAX_STR_LEN,
 	    "pci/class=%02x&subclass=%02x",
 	    fun->class_code, fun->subclass_code);
-	if (rc < 0) {
-		ddf_msg(LVL_ERROR, "Failed creating match ID str: %s",
-		    str_error(rc));
+	if (ret < 0) {
+		ddf_msg(LVL_ERROR, "Failed creating match ID str");
 	}
 
 	rc = ddf_fun_add_match_id(fun->fnode, match_id_str, 50);
@@ -440,11 +437,10 @@ void pci_fun_create_match_ids(pci_fun_t *fun)
 	}
 
 	/* Class, length(incl \0) 13 */
-	rc = snprintf(match_id_str, ID_MAX_STR_LEN, "pci/class=%02x",
+	ret = snprintf(match_id_str, ID_MAX_STR_LEN, "pci/class=%02x",
 	    fun->class_code);
-	if (rc < 0) {
-		ddf_msg(LVL_ERROR, "Failed creating match ID str: %s",
-		    str_error(rc));
+	if (ret < 0) {
+		ddf_msg(LVL_ERROR, "Failed creating match ID str");
 	}
 
 	rc = ddf_fun_add_match_id(fun->fnode, match_id_str, 40);

--- a/uspace/drv/bus/usb/ohci/hw_struct/completion_codes.h
+++ b/uspace/drv/bus/usb/ohci/hw_struct/completion_codes.h
@@ -53,7 +53,7 @@ enum {
 	CC_NOACCESS2 = 0xf,
 };
 
-inline static unsigned int cc_to_rc(unsigned int cc)
+inline static int cc_to_rc(unsigned int cc)
 {
 	switch (cc) {
 	case CC_NOERROR:

--- a/uspace/drv/bus/usb/usbmid/usbmid.c
+++ b/uspace/drv/bus/usb/usbmid/usbmid.c
@@ -116,10 +116,10 @@ int usbmid_spawn_interface_child(usb_device_t *parent,
 	 * The interface number shall provide uniqueness while the
 	 * class name something humanly understandable.
 	 */
-	rc = asprintf(&child_name, "%s%hhu",
+	int ret = asprintf(&child_name, "%s%hhu",
 	    usb_str_class(interface_descriptor->interface_class),
 	    interface_descriptor->interface_number);
-	if (rc < 0) {
+	if (ret < 0) {
 		return ENOMEM;
 	}
 

--- a/uspace/drv/test/test3/test3.c
+++ b/uspace/drv/test/test3/test3.c
@@ -70,9 +70,9 @@ static int register_fun_and_add_to_category(ddf_dev_t *parent,
 	int rc;
 	char *fun_name = NULL;
 	
-	rc = asprintf(&fun_name, "%s%zu", base_name, index);
-	if (rc < 0) {
-		ddf_msg(LVL_ERROR, "Failed to format string: %s", str_error(rc));
+	if (asprintf(&fun_name, "%s%zu", base_name, index) < 0) {
+		ddf_msg(LVL_ERROR, "Failed to format string: No memory");
+		rc = ENOMEM;
 		goto leave;
 	}
 	
@@ -160,9 +160,8 @@ static int test3_dev_remove(ddf_dev_t *dev)
 	size_t i;
 
 	for (i = 0; i < NUM_FUNCS; i++) {
-		rc = asprintf(&fun_name, "test3_%zu", i);
-		if (rc < 0) {
-			ddf_msg(LVL_ERROR, "Failed to format string: %s", str_error(rc));
+		if (asprintf(&fun_name, "test3_%zu", i) < 0) {
+			ddf_msg(LVL_ERROR, "Failed to format string: No memory");
 			return ENOMEM;
 		}
 

--- a/uspace/lib/c/generic/as.c
+++ b/uspace/lib/c/generic/as.c
@@ -75,7 +75,7 @@ void *as_area_create(void *base, size_t size, unsigned int flags,
  */
 int as_area_resize(void *address, size_t size, unsigned int flags)
 {
-	return __SYSCALL3(SYS_AS_AREA_RESIZE, (sysarg_t) address,
+	return (int) __SYSCALL3(SYS_AS_AREA_RESIZE, (sysarg_t) address,
 	    (sysarg_t) size, (sysarg_t) flags);
 }
 
@@ -89,7 +89,7 @@ int as_area_resize(void *address, size_t size, unsigned int flags)
  */
 int as_area_destroy(void *address)
 {
-	return __SYSCALL1(SYS_AS_AREA_DESTROY, (sysarg_t) address);
+	return (int) __SYSCALL1(SYS_AS_AREA_DESTROY, (sysarg_t) address);
 }
 
 /** Change address-space area flags.
@@ -103,7 +103,7 @@ int as_area_destroy(void *address)
  */
 int as_area_change_flags(void *address, unsigned int flags)
 {
-	return __SYSCALL2(SYS_AS_AREA_CHANGE_FLAGS, (sysarg_t) address,
+	return (int) __SYSCALL2(SYS_AS_AREA_CHANGE_FLAGS, (sysarg_t) address,
 	    (sysarg_t) flags);
 }
 

--- a/uspace/lib/c/generic/async.c
+++ b/uspace/lib/c/generic/async.c
@@ -762,7 +762,7 @@ static int connection_fibril(void *arg)
 		ipc_answer_0(fibril_connection->close_chandle, EOK);
 	
 	free(fibril_connection);
-	return 0;
+	return EOK;
 }
 
 /** Create a new fibril for a new connection.

--- a/uspace/lib/c/generic/cap.c
+++ b/uspace/lib/c/generic/cap.c
@@ -177,6 +177,7 @@ void cap_simplify(cap_spec_t *cap)
 int cap_format(cap_spec_t *cap, char **rstr)
 {
 	int rc;
+	int ret;
 	const char *sunit;
 	uint64_t ipart;
 	uint64_t fpart;
@@ -195,12 +196,12 @@ int cap_format(cap_spec_t *cap, char **rstr)
 
 	sunit = cu_str[cap->cunit];
 	if (cap->dp > 0) {
-		rc = asprintf(rstr, "%" PRIu64 ".%0*" PRIu64 " %s", ipart,
+		ret = asprintf(rstr, "%" PRIu64 ".%0*" PRIu64 " %s", ipart,
 		    (int)cap->dp, fpart, sunit);
 	} else {
-		rc = asprintf(rstr, "%" PRIu64 " %s", ipart, sunit);
+		ret = asprintf(rstr, "%" PRIu64 " %s", ipart, sunit);
 	}
-	if (rc < 0)
+	if (ret < 0)
 		return ENOMEM;
 
 	return EOK;

--- a/uspace/lib/c/generic/ddi.c
+++ b/uspace/lib/c/generic/ddi.c
@@ -70,7 +70,7 @@
  */
 int physmem_map(uintptr_t phys, size_t pages, unsigned int flags, void **virt)
 {
-	return __SYSCALL5(SYS_PHYSMEM_MAP, (sysarg_t) phys,
+	return (int) __SYSCALL5(SYS_PHYSMEM_MAP, (sysarg_t) phys,
 	    pages, flags, (sysarg_t) virt, (sysarg_t) __entry);
 }
 
@@ -86,7 +86,7 @@ int physmem_map(uintptr_t phys, size_t pages, unsigned int flags, void **virt)
  */
 int physmem_unmap(void *virt)
 {
-	return __SYSCALL1(SYS_PHYSMEM_UNMAP, (sysarg_t) virt);
+	return (int) __SYSCALL1(SYS_PHYSMEM_UNMAP, (sysarg_t) virt);
 }
 
 /** Lock a piece physical memory for DMA transfers.
@@ -149,12 +149,12 @@ int dmamem_map_anonymous(size_t size, uintptr_t constraint,
 
 int dmamem_unmap(void *virt, size_t size)
 {
-	return __SYSCALL3(SYS_DMAMEM_UNMAP, (sysarg_t) virt, (sysarg_t) size, 0);
+	return (int) __SYSCALL3(SYS_DMAMEM_UNMAP, (sysarg_t) virt, (sysarg_t) size, 0);
 }
 
 int dmamem_unmap_anonymous(void *virt)
 {
-	return __SYSCALL3(SYS_DMAMEM_UNMAP, (sysarg_t) virt, 0,
+	return (int) __SYSCALL3(SYS_DMAMEM_UNMAP, (sysarg_t) virt, 0,
 	    DMAMEM_FLAGS_ANONYMOUS);
 }
 
@@ -180,7 +180,7 @@ static int iospace_enable(task_id_t id, void *ioaddr, size_t size)
 		.size = size
 	};
 	
-	return __SYSCALL1(SYS_IOSPACE_ENABLE, (sysarg_t) &arg);
+	return (int) __SYSCALL1(SYS_IOSPACE_ENABLE, (sysarg_t) &arg);
 }
 
 /** Disable I/O space range to task.
@@ -204,7 +204,7 @@ static int iospace_disable(task_id_t id, void *ioaddr, size_t size)
 		.size = size
 	};
 	
-	return __SYSCALL1(SYS_IOSPACE_DISABLE, (sysarg_t) &arg);
+	return (int) __SYSCALL1(SYS_IOSPACE_DISABLE, (sysarg_t) &arg);
 }
 
 /** Enable PIO for specified address range.

--- a/uspace/lib/c/generic/event.c
+++ b/uspace/lib/c/generic/event.c
@@ -44,12 +44,12 @@
  * @param evno    Event type to subscribe.
  * @param imethod Use this interface and method for notifying me.
  *
- * @return Value returned by the kernel.
+ * @return Error code returned by the kernel.
  *
  */
 int ipc_event_subscribe(event_type_t evno, sysarg_t imethod)
 {
-	return __SYSCALL2(SYS_IPC_EVENT_SUBSCRIBE, (sysarg_t) evno,
+	return (int) __SYSCALL2(SYS_IPC_EVENT_SUBSCRIBE, (sysarg_t) evno,
 	    (sysarg_t) imethod);
 }
 
@@ -58,12 +58,12 @@ int ipc_event_subscribe(event_type_t evno, sysarg_t imethod)
  * @param evno    Event type to subscribe.
  * @param imethod Use this interface and method for notifying me.
  *
- * @return Value returned by the kernel.
+ * @return Error code returned by the kernel.
  *
  */
 int ipc_event_task_subscribe(event_task_type_t evno, sysarg_t imethod)
 {
-	return __SYSCALL2(SYS_IPC_EVENT_SUBSCRIBE, (sysarg_t) evno,
+	return (int) __SYSCALL2(SYS_IPC_EVENT_SUBSCRIBE, (sysarg_t) evno,
 	    (sysarg_t) imethod);
 }
 
@@ -71,48 +71,48 @@ int ipc_event_task_subscribe(event_task_type_t evno, sysarg_t imethod)
  *
  * @param evno    Event type to unsubscribe.
  *
- * @return Value returned by the kernel.
+ * @return Error code returned by the kernel.
  *
  */
 int ipc_event_unsubscribe(event_type_t evno)
 {
-	return __SYSCALL1(SYS_IPC_EVENT_UNSUBSCRIBE, (sysarg_t) evno);
+	return (int) __SYSCALL1(SYS_IPC_EVENT_UNSUBSCRIBE, (sysarg_t) evno);
 }
 
 /** Unsubscribe from task event notifications.
  *
  * @param evno    Event type to unsubscribe.
  *
- * @return Value returned by the kernel.
+ * @return Error code returned by the kernel.
  *
  */
 int ipc_event_task_unsubscribe(event_task_type_t evno)
 {
-	return __SYSCALL1(SYS_IPC_EVENT_UNSUBSCRIBE, (sysarg_t) evno);
+	return (int) __SYSCALL1(SYS_IPC_EVENT_UNSUBSCRIBE, (sysarg_t) evno);
 }
 
 /** Unmask event notifications.
  *
  * @param evno Event type to unmask.
  *
- * @return Value returned by the kernel.
+ * @return Error code returned by the kernel.
  *
  */
 int ipc_event_unmask(event_type_t evno)
 {
-	return __SYSCALL1(SYS_IPC_EVENT_UNMASK, (sysarg_t) evno);
+	return (int) __SYSCALL1(SYS_IPC_EVENT_UNMASK, (sysarg_t) evno);
 }
 
 /** Unmask task event notifications.
  *
  * @param evno Event type to unmask.
  *
- * @return Value returned by the kernel.
+ * @return Error code returned by the kernel.
  *
  */
 int ipc_event_task_unmask(event_task_type_t evno)
 {
-	return __SYSCALL1(SYS_IPC_EVENT_UNMASK, (sysarg_t) evno);
+	return (int) __SYSCALL1(SYS_IPC_EVENT_UNMASK, (sysarg_t) evno);
 }
 
 /** @}

--- a/uspace/lib/c/generic/inet/addr.c
+++ b/uspace/lib/c/generic/inet/addr.c
@@ -583,13 +583,14 @@ static int inet_addr_format_v6(const addr128_t addr, char **bufp)
 int inet_addr_format(const inet_addr_t *addr, char **bufp)
 {
 	int rc;
+	int ret;
 
 	rc = ENOTSUP;
 
 	switch (addr->version) {
 	case ip_any:
-		rc = asprintf(bufp, "none");
-		if (rc < 0)
+		ret = asprintf(bufp, "none");
+		if (ret < 0)
 			return ENOMEM;
 		rc = EOK;
 		break;
@@ -617,14 +618,15 @@ int inet_addr_format(const inet_addr_t *addr, char **bufp)
 int inet_naddr_format(const inet_naddr_t *naddr, char **bufp)
 {
 	int rc;
+	int ret;
 	char *astr;
 
 	rc = ENOTSUP;
 
 	switch (naddr->version) {
 	case ip_any:
-		rc = asprintf(bufp, "none");
-		if (rc < 0)
+		ret = asprintf(bufp, "none");
+		if (ret < 0)
 			return ENOMEM;
 		rc = EOK;
 		break;
@@ -633,8 +635,8 @@ int inet_naddr_format(const inet_naddr_t *naddr, char **bufp)
 		if (rc != EOK)
 			return ENOMEM;
 
-		rc = asprintf(bufp, "%s/%" PRIu8, astr, naddr->prefix);
-		if (rc < 0) {
+		ret = asprintf(bufp, "%s/%" PRIu8, astr, naddr->prefix);
+		if (ret < 0) {
 			free(astr);
 			return ENOMEM;
 		}
@@ -646,8 +648,8 @@ int inet_naddr_format(const inet_naddr_t *naddr, char **bufp)
 		if (rc != EOK)
 			return ENOMEM;
 
-		rc = asprintf(bufp, "%s/%" PRIu8, astr, naddr->prefix);
-		if (rc < 0) {
+		ret = asprintf(bufp, "%s/%" PRIu8, astr, naddr->prefix);
+		if (ret < 0) {
 			free(astr);
 			return ENOMEM;
 		}

--- a/uspace/lib/c/generic/inet/hostport.c
+++ b/uspace/lib/c/generic/inet/hostport.c
@@ -139,6 +139,7 @@ have_host:
 int inet_hostport_format(inet_hostport_t *hp, char **rstr)
 {
 	int rc;
+	int ret;
 	char *astr, *str;
 	char *hstr = NULL;
 
@@ -153,8 +154,8 @@ int inet_hostport_format(inet_hostport_t *hp, char **rstr)
 		if (hp->host.addr.version != ip_v4) {
 			hstr = astr;
 		} else {
-			rc = asprintf(&hstr, "[%s]", astr);
-			if (rc < 0) {
+			ret = asprintf(&hstr, "[%s]", astr);
+			if (ret < 0) {
 				free(astr);
 				return ENOMEM;
 			}
@@ -170,8 +171,8 @@ int inet_hostport_format(inet_hostport_t *hp, char **rstr)
 		break;
 	}
 
-	rc = asprintf(&str, "%s:%u", hstr, hp->port);
-	if (rc < 0)
+	ret = asprintf(&str, "%s:%u", hstr, hp->port);
+	if (ret < 0)
 		return ENOMEM;
 
 	free(hstr);

--- a/uspace/lib/c/generic/io/chardev.c
+++ b/uspace/lib/c/generic/io/chardev.c
@@ -123,7 +123,7 @@ int chardev_read(chardev_t *chardev, void *buf, size_t size, size_t *nread)
 
 	*nread = IPC_GET_ARG2(answer);
 	/* In case of partial success, ARG1 contains the error code */
-	return IPC_GET_ARG1(answer);
+	return (int) IPC_GET_ARG1(answer);
 
 }
 
@@ -174,7 +174,7 @@ static int chardev_write_once(chardev_t *chardev, const void *data,
 
 	*nwritten = IPC_GET_ARG2(answer);
 	/* In case of partial success, ARG1 contains the error code */
-	return IPC_GET_ARG1(answer);
+	return (int) IPC_GET_ARG1(answer);
 }
 
 /** Write to character device.

--- a/uspace/lib/c/generic/io/chardev_srv.c
+++ b/uspace/lib/c/generic/io/chardev_srv.c
@@ -81,7 +81,7 @@ static void chardev_read_srv(chardev_srv_t *srv, ipc_callid_t callid,
 	async_data_read_finalize(rcallid, buf, nread);
 
 	free(buf);
-	async_answer_2(callid, EOK, rc, nread);
+	async_answer_2(callid, EOK, (sysarg_t) rc, nread);
 }
 
 static void chardev_write_srv(chardev_srv_t *srv, ipc_callid_t callid,
@@ -110,7 +110,7 @@ static void chardev_write_srv(chardev_srv_t *srv, ipc_callid_t callid,
 		return;
 	}
 
-	async_answer_2(callid, EOK, rc, nwr);
+	async_answer_2(callid, EOK, (sysarg_t) rc, nwr);
 }
 
 static chardev_srv_t *chardev_srv_create(chardev_srvs_t *srvs)

--- a/uspace/lib/c/generic/io/table.c
+++ b/uspace/lib/c/generic/io/table.c
@@ -477,6 +477,7 @@ int table_printf(table_t *table, const char *fmt, ...)
 {
 	va_list args;
 	int rc;
+	int ret;
 	char *str;
 	char *sp, *ep;
 	size_t width;
@@ -485,10 +486,10 @@ int table_printf(table_t *table, const char *fmt, ...)
 		return table->error;
 
 	va_start(args, fmt);
-	rc = vasprintf(&str, fmt, args);
+	ret = vasprintf(&str, fmt, args);
 	va_end(args);
 
-	if (rc < 0) {
+	if (ret < 0) {
 		table->error = ENOMEM;
 		return table->error;
 	}

--- a/uspace/lib/c/generic/ipc.c
+++ b/uspace/lib/c/generic/ipc.c
@@ -135,7 +135,7 @@ void ipc_call_async_fast(cap_handle_t phandle, sysarg_t imethod, sysarg_t arg1,
 	if (!call)
 		return;
 	
-	int rc = __SYSCALL6(SYS_IPC_CALL_ASYNC_FAST, phandle, imethod, arg1,
+	int rc = (int) __SYSCALL6(SYS_IPC_CALL_ASYNC_FAST, phandle, imethod, arg1,
 	    arg2, arg3, (sysarg_t) call);
 	
 	ipc_finish_async(rc, call);
@@ -174,7 +174,7 @@ void ipc_call_async_slow(int phandle, sysarg_t imethod, sysarg_t arg1,
 	IPC_SET_ARG4(call->msg.data, arg4);
 	IPC_SET_ARG5(call->msg.data, arg5);
 	
-	int rc = __SYSCALL3(SYS_IPC_CALL_ASYNC_SLOW, phandle,
+	int rc = (int) __SYSCALL3(SYS_IPC_CALL_ASYNC_SLOW, phandle,
 	    (sysarg_t) &call->msg.data, (sysarg_t) call);
 	
 	ipc_finish_async(rc, call);
@@ -199,7 +199,7 @@ void ipc_call_async_slow(int phandle, sysarg_t imethod, sysarg_t arg1,
 int ipc_answer_fast(cap_handle_t chandle, int retval, sysarg_t arg1,
     sysarg_t arg2, sysarg_t arg3, sysarg_t arg4)
 {
-	return __SYSCALL6(SYS_IPC_ANSWER_FAST, chandle, retval, arg1, arg2,
+	return (int) __SYSCALL6(SYS_IPC_ANSWER_FAST, chandle, (sysarg_t) retval, arg1, arg2,
 	    arg3, arg4);
 }
 
@@ -229,7 +229,7 @@ int ipc_answer_slow(cap_handle_t chandle, int retval, sysarg_t arg1,
 	IPC_SET_ARG4(data, arg4);
 	IPC_SET_ARG5(data, arg5);
 	
-	return __SYSCALL2(SYS_IPC_ANSWER_SLOW, chandle, (sysarg_t) &data);
+	return (int) __SYSCALL2(SYS_IPC_ANSWER_SLOW, chandle, (sysarg_t) &data);
 }
 
 /** Handle received answer.
@@ -259,7 +259,7 @@ static void handle_answer(ipc_call_t *data)
  */
 int ipc_wait_cycle(ipc_call_t *call, sysarg_t usec, unsigned int flags)
 {
-	int rc = __SYSCALL3(SYS_IPC_WAIT, (sysarg_t) call, usec, flags);
+	int rc = (int) __SYSCALL3(SYS_IPC_WAIT, (sysarg_t) call, usec, flags);
 	
 	/* Handle received answers */
 	if ((rc == EOK) && (call->cap_handle == CAP_NIL) &&
@@ -329,7 +329,7 @@ int ipc_trywait_for_call(ipc_call_t *call)
  */
 int ipc_hangup(cap_handle_t phandle)
 {
-	return __SYSCALL1(SYS_IPC_HANGUP, phandle);
+	return (int) __SYSCALL1(SYS_IPC_HANGUP, phandle);
 }
 
 /** Forward a received call to another destination.
@@ -352,7 +352,7 @@ int ipc_hangup(cap_handle_t phandle)
 int ipc_forward_fast(cap_handle_t chandle, cap_handle_t phandle,
     sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, unsigned int mode)
 {
-	return __SYSCALL6(SYS_IPC_FORWARD_FAST, chandle, phandle, imethod, arg1,
+	return (int) __SYSCALL6(SYS_IPC_FORWARD_FAST, chandle, phandle, imethod, arg1,
 	    arg2, mode);
 }
 
@@ -369,7 +369,7 @@ int ipc_forward_slow(cap_handle_t chandle, cap_handle_t phandle,
 	IPC_SET_ARG4(data, arg4);
 	IPC_SET_ARG5(data, arg5);
 	
-	return __SYSCALL4(SYS_IPC_FORWARD_SLOW, chandle, phandle,
+	return (int) __SYSCALL4(SYS_IPC_FORWARD_SLOW, chandle, phandle,
 	    (sysarg_t) &data, mode);
 }
 
@@ -378,7 +378,7 @@ int ipc_forward_slow(cap_handle_t chandle, cap_handle_t phandle,
  */
 int ipc_connect_kbox(task_id_t id, cap_handle_t *phone)
 {
-	return __SYSCALL2(SYS_IPC_CONNECT_KBOX, (sysarg_t) &id, (sysarg_t) phone);
+	return (int) __SYSCALL2(SYS_IPC_CONNECT_KBOX, (sysarg_t) &id, (sysarg_t) phone);
 }
 
 /** @}

--- a/uspace/lib/c/generic/irq.c
+++ b/uspace/lib/c/generic/irq.c
@@ -68,7 +68,7 @@ int ipc_irq_subscribe(int inr, sysarg_t method, const irq_code_t *ucode,
 	if (ucode == NULL)
 		ucode = &default_ucode;
 	
-	return __SYSCALL4(SYS_IPC_IRQ_SUBSCRIBE, inr, method, (sysarg_t) ucode,
+	return (int) __SYSCALL4(SYS_IPC_IRQ_SUBSCRIBE, inr, method, (sysarg_t) ucode,
 	    (sysarg_t) out_handle);
 }
 
@@ -81,7 +81,7 @@ int ipc_irq_subscribe(int inr, sysarg_t method, const irq_code_t *ucode,
  */
 int ipc_irq_unsubscribe(cap_handle_t cap)
 {
-	return __SYSCALL1(SYS_IPC_IRQ_UNSUBSCRIBE, cap);
+	return (int) __SYSCALL1(SYS_IPC_IRQ_UNSUBSCRIBE, cap);
 }
 
 /** @}

--- a/uspace/lib/c/generic/loader.c
+++ b/uspace/lib/c/generic/loader.c
@@ -55,7 +55,7 @@
  */
 int loader_spawn(const char *name)
 {
-	return __SYSCALL2(SYS_PROGRAM_SPAWN_LOADER,
+	return (int) __SYSCALL2(SYS_PROGRAM_SPAWN_LOADER,
 	    (sysarg_t) name, str_size(name));
 }
 

--- a/uspace/lib/c/generic/loc.c
+++ b/uspace/lib/c/generic/loc.c
@@ -573,6 +573,9 @@ async_sess_t *loc_service_connect(service_id_t handle, iface_t iface,
 	return sess;
 }
 
+/**
+ * @return ID of a new NULL device, or -1 if failed.
+ */
 int loc_null_create(void)
 {
 	async_exch_t *exch = loc_exchange_begin_blocking(INTERFACE_LOC_CONSUMER);

--- a/uspace/lib/c/generic/perm.c
+++ b/uspace/lib/c/generic/perm.c
@@ -51,11 +51,11 @@ int perm_grant(task_id_t id, unsigned int perms)
 {
 #ifdef __32_BITS__
 	sysarg64_t arg = (sysarg64_t) id;
-	return __SYSCALL2(SYS_PERM_GRANT, (sysarg_t) &arg, (sysarg_t) perms);
+	return (int) __SYSCALL2(SYS_PERM_GRANT, (sysarg_t) &arg, (sysarg_t) perms);
 #endif
 	
 #ifdef __64_BITS__
-	return __SYSCALL2(SYS_PERM_GRANT, (sysarg_t) id, (sysarg_t) perms);
+	return (int) __SYSCALL2(SYS_PERM_GRANT, (sysarg_t) id, (sysarg_t) perms);
 #endif
 }
 
@@ -71,11 +71,11 @@ int perm_revoke(task_id_t id, unsigned int perms)
 {
 #ifdef __32_BITS__
 	sysarg64_t arg = (sysarg64_t) id;
-	return __SYSCALL2(SYS_PERM_REVOKE, (sysarg_t) &arg, (sysarg_t) perms);
+	return (int) __SYSCALL2(SYS_PERM_REVOKE, (sysarg_t) &arg, (sysarg_t) perms);
 #endif
 	
 #ifdef __64_BITS__
-	return __SYSCALL2(SYS_PERM_REVOKE, (sysarg_t) id, (sysarg_t) perms);
+	return (int) __SYSCALL2(SYS_PERM_REVOKE, (sysarg_t) id, (sysarg_t) perms);
 #endif
 }
 

--- a/uspace/lib/c/generic/smc.c
+++ b/uspace/lib/c/generic/smc.c
@@ -38,7 +38,7 @@
 
 int smc_coherence(void *address, size_t size)
 {
-	return __SYSCALL2(SYS_SMC_COHERENCE, (sysarg_t) address,
+	return (int) __SYSCALL2(SYS_SMC_COHERENCE, (sysarg_t) address,
 	    (sysarg_t) size);
 }
 

--- a/uspace/lib/c/generic/sysinfo.c
+++ b/uspace/lib/c/generic/sysinfo.c
@@ -91,7 +91,7 @@ char *sysinfo_get_keys(const char *path, size_t *size)
 	
 	/* Get the data */
 	size_t sz;
-	ret = __SYSCALL5(SYS_SYSINFO_GET_KEYS, (sysarg_t) path,
+	ret = (int) __SYSCALL5(SYS_SYSINFO_GET_KEYS, (sysarg_t) path,
 	    (sysarg_t) str_size(path), (sysarg_t) data, (sysarg_t) *size,
 	    (sysarg_t) &sz);
 	if (ret == EOK) {
@@ -185,7 +185,7 @@ void *sysinfo_get_data(const char *path, size_t *size)
 	
 	/* Get the data */
 	size_t sz;
-	ret = __SYSCALL5(SYS_SYSINFO_GET_DATA, (sysarg_t) path,
+	ret = (int) __SYSCALL5(SYS_SYSINFO_GET_DATA, (sysarg_t) path,
 	    (sysarg_t) str_size(path), (sysarg_t) data, (sysarg_t) *size,
 	    (sysarg_t) &sz);
 	if (ret == EOK) {

--- a/uspace/lib/c/generic/task.c
+++ b/uspace/lib/c/generic/task.c
@@ -74,7 +74,7 @@ int task_set_name(const char *name)
 {
 	assert(name);
 	
-	return __SYSCALL2(SYS_TASK_SET_NAME, (sysarg_t) name, str_size(name));
+	return (int) __SYSCALL2(SYS_TASK_SET_NAME, (sysarg_t) name, str_size(name));
 }
 
 /** Kill a task.

--- a/uspace/lib/c/generic/thread.c
+++ b/uspace/lib/c/generic/thread.c
@@ -131,7 +131,7 @@ int thread_create(void (* function)(void *), void *arg, const char *name,
 	uarg->uspace_thread_arg = arg;
 	uarg->uspace_uarg = uarg;
 	
-	int rc = __SYSCALL4(SYS_THREAD_CREATE, (sysarg_t) uarg,
+	int rc = (int) __SYSCALL4(SYS_THREAD_CREATE, (sysarg_t) uarg,
 	    (sysarg_t) name, (sysarg_t) str_size(name), (sysarg_t) tid);
 	
 	if (rc != EOK) {

--- a/uspace/lib/c/generic/vfs/mtab.c
+++ b/uspace/lib/c/generic/vfs/mtab.c
@@ -75,11 +75,12 @@ static int vfs_get_mtab_visit(const char *path, list_t *mtab_list,
 		char *child;
 		struct stat st;
 		int rc;
+		int ret;
 
-		rc = asprintf(&child, "%s/%s", path, dirent->d_name);
-		if (rc < 0) {
+		ret = asprintf(&child, "%s/%s", path, dirent->d_name);
+		if (ret < 0) {
 			closedir(dir);
-			return rc;
+			return ENOMEM;
 		}
 
 		char *pa = vfs_absolutize(child, NULL);

--- a/uspace/lib/c/include/async.h
+++ b/uspace/lib/c/include/async.h
@@ -169,7 +169,7 @@ extern int async_create_callback_port(async_exch_t *, iface_t, sysarg_t,
 
 extern int async_irq_subscribe(int, async_notification_handler_t, void *,
     const irq_code_t *, cap_handle_t *);
-extern int async_irq_unsubscribe(int);
+extern int async_irq_unsubscribe(cap_handle_t);
 
 extern int async_event_subscribe(event_type_t, async_notification_handler_t,
     void *);

--- a/uspace/lib/c/include/futex.h
+++ b/uspace/lib/c/include/futex.h
@@ -107,11 +107,11 @@ extern void futex_upgrade_all_and_wait(void);
  *
  * @param futex Futex.
  *
- * @return Non-zero if the futex was acquired.
- * @return Zero if the futex was not acquired.
+ * @return true if the futex was acquired.
+ * @return false if the futex was not acquired.
  *
  */
-static inline int futex_trydown(futex_t *futex)
+static inline bool futex_trydown(futex_t *futex)
 {
 	return cas(&futex->val, 1, 0);
 }
@@ -128,7 +128,7 @@ static inline int futex_trydown(futex_t *futex)
 static inline int futex_down(futex_t *futex)
 {
 	if ((atomic_signed_t) atomic_predec(&futex->val) < 0)
-		return __SYSCALL1(SYS_FUTEX_SLEEP, (sysarg_t) &futex->val.count);
+		return (int) __SYSCALL1(SYS_FUTEX_SLEEP, (sysarg_t) &futex->val.count);
 	
 	return EOK;
 }
@@ -145,7 +145,7 @@ static inline int futex_down(futex_t *futex)
 static inline int futex_up(futex_t *futex)
 {
 	if ((atomic_signed_t) atomic_postinc(&futex->val) < 0)
-		return __SYSCALL1(SYS_FUTEX_WAKEUP, (sysarg_t) &futex->val.count);
+		return (int) __SYSCALL1(SYS_FUTEX_WAKEUP, (sysarg_t) &futex->val.count);
 	
 	return EOK;
 }

--- a/uspace/lib/c/include/io/table.h
+++ b/uspace/lib/c/include/io/table.h
@@ -39,6 +39,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <errno.h>
 
 /** Table metrics */
 typedef struct {

--- a/uspace/lib/clui/nchoice.c
+++ b/uspace/lib/clui/nchoice.c
@@ -130,6 +130,7 @@ int nchoice_get(nchoice_t *choice, void **rarg)
 {
 	int i;
 	int rc;
+	int ret;
 	char *str;
 	unsigned long c;
 	char *eptr;
@@ -150,8 +151,8 @@ again:
 	}
 
 	if (def_i > 0) {
-		rc = asprintf(&istr, "%d", def_i);
-		if (rc < 0)
+		ret = asprintf(&istr, "%d", def_i);
+		if (ret < 0)
 			return ENOMEM;
 	} else {
 		istr = str_dup("");

--- a/uspace/lib/compress/inflate.c
+++ b/uspace/lib/compress/inflate.c
@@ -636,7 +636,7 @@ int inflate(void *src, size_t srclen, void *dest, size_t destlen)
 	state.overrun = false;
 	
 	uint16_t last;
-	int ret = 0;
+	int ret = EOK;
 	
 	do {
 		/* Last block is indicated by a non-zero bit */

--- a/uspace/lib/draw/font/pcf.c
+++ b/uspace/lib/draw/font/pcf.c
@@ -267,8 +267,7 @@ static int pcf_load_glyph_surface(void *opaque_data, glyph_id_t glyph_id,
 	aoff64_t offset = data->bitmap_table.offset + (2 * sizeof(uint32_t)) +
 	    (glyph_id * sizeof(uint32_t));
 	
-	rc = fseek(data->file, offset, SEEK_SET);
-	if (rc != 0)
+	if (fseek(data->file, offset, SEEK_SET) < 0)
 		return errno;
 	
 	uint32_t bitmap_offset = 0;
@@ -283,8 +282,7 @@ static int pcf_load_glyph_surface(void *opaque_data, glyph_id_t glyph_id,
 	    (data->glyph_count * sizeof(uint32_t)) + (4 * sizeof(uint32_t))
 	    + bitmap_offset;
 	
-	rc = fseek(data->file, offset, SEEK_SET);
-	if (rc != 0)
+	if (fseek(data->file, offset, SEEK_SET) < 0)
 		return errno;
 	
 	surface_coord_t width = pcf_metrics.character_width;

--- a/uspace/lib/drv/generic/interrupt.c
+++ b/uspace/lib/drv/generic/interrupt.c
@@ -50,7 +50,7 @@ int register_interrupt_handler(ddf_dev_t *dev, int irq,
 	    dev, irq_code, handle);
 }
 
-int unregister_interrupt_handler(ddf_dev_t *dev, int cap)
+int unregister_interrupt_handler(ddf_dev_t *dev, cap_handle_t cap)
 {
 	return async_irq_unsubscribe(cap);
 }

--- a/uspace/lib/drv/generic/remote_nic.c
+++ b/uspace/lib/drv/generic/remote_nic.c
@@ -215,7 +215,7 @@ int nic_get_address(async_sess_t *dev_sess, nic_address_t *address)
 	if (rc != EOK)
 		return rc;
 	
-	return (int) res;
+	return res;
 }
 
 /** Set the address of the device (e.g. MAC on Ethernet)
@@ -242,7 +242,7 @@ int nic_set_address(async_sess_t *dev_sess, const nic_address_t *address)
 	if (rc != EOK)
 		return rc;
 	
-	return (int) res;
+	return res;
 }
 
 /** Request statistic data about NIC operation.
@@ -300,7 +300,7 @@ int nic_get_device_info(async_sess_t *dev_sess, nic_device_info_t *device_info)
 	if (rc != EOK)
 		return rc;
 	
-	return (int) res;
+	return res;
 }
 
 /** Request status of the cable (plugged/unplugged)
@@ -634,7 +634,7 @@ int nic_unicast_set_mode(async_sess_t *dev_sess, nic_unicast_mode_t mode,
 	if (rc != EOK)
 		return rc;
 	
-	return (int) res;
+	return res;
 }
 
 /** Retrieve current settings of multicast frames reception.
@@ -722,7 +722,7 @@ int nic_multicast_set_mode(async_sess_t *dev_sess, nic_multicast_mode_t mode,
 	if (rc != EOK)
 		return rc;
 	
-	return (int) res;
+	return res;
 }
 
 /** Determine if broadcast packets are received.
@@ -883,7 +883,7 @@ int nic_blocked_sources_set(async_sess_t *dev_sess,
 	if (rc != EOK)
 		return rc;
 	
-	return (int) res;
+	return res;
 }
 
 /** Request current VLAN filtering mask.
@@ -943,7 +943,7 @@ int nic_vlan_set_mask(async_sess_t *dev_sess, const nic_vlan_mask_t *mask)
 	if (rc != EOK)
 		return rc;
 	
-	return (int) res;
+	return res;
 }
 
 /** Set VLAN (802.1q) tag.
@@ -1010,7 +1010,7 @@ int nic_wol_virtue_add(async_sess_t *dev_sess, nic_wv_type_t type,
 	async_wait_for(message_id, &res);
 	
 	*id = IPC_GET_ARG1(result);
-	return (int) res;
+	return res;
 }
 
 /** Remove Wake-On-LAN virtue.
@@ -1316,7 +1316,7 @@ int nic_poll_set_mode(async_sess_t *dev_sess, nic_poll_mode_t mode,
 	if (rc != EOK)
 		return rc;
 	
-	return (int) res;
+	return res;
 }
 
 /** Request the driver to poll the NIC.

--- a/uspace/lib/drv/include/ddf/interrupt.h
+++ b/uspace/lib/drv/include/ddf/interrupt.h
@@ -51,7 +51,7 @@ typedef void interrupt_handler_t(ipc_call_t *, ddf_dev_t *);
 
 extern int register_interrupt_handler(ddf_dev_t *, int, interrupt_handler_t *,
     const irq_code_t *, cap_handle_t *);
-extern int unregister_interrupt_handler(ddf_dev_t *, int);
+extern int unregister_interrupt_handler(ddf_dev_t *, cap_handle_t);
 
 #endif
 

--- a/uspace/lib/http/src/response.c
+++ b/uspace/lib/http/src/response.c
@@ -53,7 +53,7 @@ static int receive_number(receive_buffer_t *rb, char **str)
 	
 	recv_mark(rb, &start);
 	int rc = recv_while(rb, is_digit);
-	if (rc < 0) {
+	if (rc != EOK) {
 		recv_unmark(rb, &start);
 		return rc;
 	}
@@ -148,7 +148,7 @@ int http_receive_status(receive_buffer_t *rb, http_version_t *out_version,
 	recv_mark(rb, &msg_start);
 	
 	rc = recv_while(rb, is_not_newline);
-	if (rc < 0) {
+	if (rc != EOK) {
 		recv_unmark(rb, &msg_start);
 		return rc;
 	}

--- a/uspace/lib/nic/include/nic_addr_db.h
+++ b/uspace/lib/nic/include/nic_addr_db.h
@@ -59,7 +59,7 @@ extern void nic_addr_db_clear(nic_addr_db_t *db);
 extern void nic_addr_db_destroy(nic_addr_db_t *db);
 extern int nic_addr_db_insert(nic_addr_db_t *db, const uint8_t *addr);
 extern int nic_addr_db_remove(nic_addr_db_t *db, const uint8_t *addr);
-extern int nic_addr_db_contains(const nic_addr_db_t *db, const uint8_t *addr);
+extern bool nic_addr_db_contains(const nic_addr_db_t *db, const uint8_t *addr);
 extern void nic_addr_db_foreach(const nic_addr_db_t *db,
 	void (*func)(const uint8_t *, void *), void *arg);
 

--- a/uspace/lib/nic/include/nic_rx_control.h
+++ b/uspace/lib/nic/include/nic_rx_control.h
@@ -117,7 +117,7 @@ extern int nic_rxc_init(nic_rxc_t *rxc);
 extern int nic_rxc_clear(nic_rxc_t *rxc);
 extern int nic_rxc_set_addr(nic_rxc_t *rxc,
 	const nic_address_t *prev_addr, const nic_address_t *curr_addr);
-extern int nic_rxc_check(const nic_rxc_t *rxc,
+extern bool nic_rxc_check(const nic_rxc_t *rxc,
 	const void *data, size_t size, nic_frame_type_t *frame_type);
 extern void nic_rxc_hw_filtering(nic_rxc_t *rxc,
 	int unicast_exact, int multicast_exact, int vlan_exact);

--- a/uspace/lib/nic/src/nic_addr_db.c
+++ b/uspace/lib/nic/src/nic_addr_db.c
@@ -222,7 +222,7 @@ int nic_addr_db_remove(nic_addr_db_t *db, const uint8_t *addr)
  *
  * @return true if the address is in the db, false otherwise
  */
-int nic_addr_db_contains(const nic_addr_db_t *db, const uint8_t *addr)
+bool nic_addr_db_contains(const nic_addr_db_t *db, const uint8_t *addr)
 {
 	assert(db && addr);
 	

--- a/uspace/lib/nic/src/nic_driver.c
+++ b/uspace/lib/nic/src/nic_driver.c
@@ -520,7 +520,7 @@ void nic_received_frame(nic_t *nic_data, nic_frame_t *frame)
 	 * 		 calls it inside send_frame handler (with locked main lock) */
 	fibril_rwlock_read_lock(&nic_data->rxc_lock);
 	nic_frame_type_t frame_type;
-	int check = nic_rxc_check(&nic_data->rx_control, frame->data,
+	bool check = nic_rxc_check(&nic_data->rx_control, frame->data,
 	    frame->size, &frame_type);
 	fibril_rwlock_read_unlock(&nic_data->rxc_lock);
 	/* Update statistics */
@@ -1091,7 +1091,7 @@ static int period_fibril_fun(void *data)
 		}
 		fibril_rwlock_read_unlock(&nic->main_lock);
 	}
-	return 0;
+	return EOK;
 }
 
 /** Starts software periodic polling

--- a/uspace/lib/nic/src/nic_rx_control.c
+++ b/uspace/lib/nic/src/nic_rx_control.c
@@ -393,7 +393,7 @@ int nic_rxc_vlan_set_mask(nic_rxc_t *rxc, const nic_vlan_mask_t *mask)
  *
  * @return True if the frame passes, false if it does not
  */
-int nic_rxc_check(const nic_rxc_t *rxc, const void *data, size_t size,
+bool nic_rxc_check(const nic_rxc_t *rxc, const void *data, size_t size,
 	nic_frame_type_t *frame_type)
 {
 	assert(frame_type != NULL);

--- a/uspace/lib/trackmod/protracker.c
+++ b/uspace/lib/trackmod/protracker.c
@@ -301,8 +301,7 @@ int trackmod_protracker_load(char *fname, trackmod_module_t **rmodule)
 	if (samples == 15) {
 		memcpy(&mod15, &mod31, sizeof(protracker_15smp_t));
 
-		rc = fseek(f, sizeof(protracker_15smp_t), SEEK_SET);
-		if (rc != 0) {
+		if (fseek(f, sizeof(protracker_15smp_t), SEEK_SET) < 0) {
 			printf("Error seeking.\n");
 			rc = EIO;
 			goto error;

--- a/uspace/lib/trackmod/xm.c
+++ b/uspace/lib/trackmod/xm.c
@@ -173,6 +173,7 @@ static int trackmod_xm_load_patterns(FILE *f, trackmod_module_t *module)
 	uint8_t *buf = NULL;
 	long seek_amount;
 	int rc;
+	int ret;
 
 	module->pattern = calloc(sizeof(trackmod_pattern_t), module->patterns);
 	if (module->pattern == NULL) {
@@ -181,8 +182,8 @@ static int trackmod_xm_load_patterns(FILE *f, trackmod_module_t *module)
 	}
 
 	for (i = 0; i < module->patterns; i++) {
-		rc = fread(&pattern, 1, sizeof(xm_pattern_t), f);
-		if (rc != sizeof(xm_pattern_t)) {
+		ret = fread(&pattern, 1, sizeof(xm_pattern_t), f);
+		if (ret != sizeof(xm_pattern_t)) {
 			rc = EIO;
 			goto error;
 		}
@@ -296,6 +297,7 @@ static int trackmod_xm_load_instruments(xm_hdr_t *xm_hdr, FILE *f,
 	void *smp_data;
 	long pos;
 	int rc;
+	int ret;
 
 	module->instrs = uint16_t_le2host(xm_hdr->instruments);
 	module->instr = calloc(module->instrs, sizeof(trackmod_instr_t));
@@ -304,8 +306,8 @@ static int trackmod_xm_load_instruments(xm_hdr_t *xm_hdr, FILE *f,
 
 	for (i = 0; i < module->instrs; i++) {
 		pos = ftell(f);
-		rc = fread(&instr, 1, sizeof(xm_instr_t), f);
-		if (rc != sizeof(xm_instr_t)) {
+		ret = fread(&instr, 1, sizeof(xm_instr_t), f);
+		if (ret != sizeof(xm_instr_t)) {
 			rc = EIO;
 			goto error;
 		}
@@ -314,8 +316,8 @@ static int trackmod_xm_load_instruments(xm_hdr_t *xm_hdr, FILE *f,
 		instr_size = (size_t)uint32_t_le2host(instr.size);
 
 		if (samples > 0) {
-			rc = fread(&instrx, 1, sizeof(xm_instr_ext_t), f);
-			if (rc != sizeof(xm_instr_ext_t)) {
+			ret = fread(&instrx, 1, sizeof(xm_instr_ext_t), f);
+			if (ret != sizeof(xm_instr_ext_t)) {
 				rc = EIO;
 				goto error;
 			}
@@ -345,8 +347,8 @@ static int trackmod_xm_load_instruments(xm_hdr_t *xm_hdr, FILE *f,
 			sample = &module->instr[i].sample[j];
 			pos = ftell(f);
 
-			rc = fread(&smp, 1, sizeof(xm_smp_t), f);
-			if (rc != sizeof(xm_smp_t)) {
+			ret = fread(&smp, 1, sizeof(xm_smp_t), f);
+			if (ret != sizeof(xm_smp_t)) {
 				rc = EIO;
 				goto error;
 			}

--- a/uspace/srv/bd/file_bd/file_bd.c
+++ b/uspace/srv/bd/file_bd/file_bd.c
@@ -221,7 +221,6 @@ static int file_bd_read_blocks(bd_srv_t *bd, uint64_t ba, size_t cnt, void *buf,
     size_t size)
 {
 	size_t n_rd;
-	int rc;
 
 	if (size < cnt * block_size)
 		return EINVAL;
@@ -237,8 +236,7 @@ static int file_bd_read_blocks(bd_srv_t *bd, uint64_t ba, size_t cnt, void *buf,
 	fibril_mutex_lock(&dev_lock);
 
 	clearerr(img);
-	rc = fseek(img, ba * block_size, SEEK_SET);
-	if (rc < 0) {
+	if (fseek(img, ba * block_size, SEEK_SET) < 0) {
 		fibril_mutex_unlock(&dev_lock);
 		return EIO;
 	}
@@ -263,7 +261,6 @@ static int file_bd_write_blocks(bd_srv_t *bd, uint64_t ba, size_t cnt,
     const void *buf, size_t size)
 {
 	size_t n_wr;
-	int rc;
 
 	if (size < cnt * block_size)
 		return EINVAL;
@@ -279,8 +276,7 @@ static int file_bd_write_blocks(bd_srv_t *bd, uint64_t ba, size_t cnt,
 	fibril_mutex_lock(&dev_lock);
 
 	clearerr(img);
-	rc = fseek(img, ba * block_size, SEEK_SET);
-	if (rc < 0) {
+	if (fseek(img, ba * block_size, SEEK_SET) < 0) {
 		fibril_mutex_unlock(&dev_lock);
 		return EIO;
 	}

--- a/uspace/srv/bd/sata_bd/sata_bd.c
+++ b/uspace/srv/bd/sata_bd/sata_bd.c
@@ -250,7 +250,7 @@ int main(int argc, char **argv)
 	
 	async_set_fallback_port_handler(sata_bd_connection, NULL);
 	rc = loc_server_register(NAME);
-	if (rc < 0) {
+	if (rc != EOK) {
 		printf(NAME ": Unable to register driver: %s.\n", str_error(rc));
 		return rc;
 	}

--- a/uspace/srv/bd/vbd/disk.c
+++ b/uspace/srv/bd/vbd/disk.c
@@ -1113,8 +1113,7 @@ static int vbds_part_svc_register(vbds_part_t *part)
 
 	idx = part->lpart->index;
 
-	rc = asprintf(&name, "%sp%u", part->disk->svc_name, idx);
-	if (rc < 0) {
+	if (asprintf(&name, "%sp%u", part->disk->svc_name, idx) < 0) {
 		log_msg(LOG_DEFAULT, LVL_ERROR, "Out of memory.");
 		return ENOMEM;
 	}

--- a/uspace/srv/fs/exfat/exfat_directory.c
+++ b/uspace/srv/fs/exfat/exfat_directory.c
@@ -217,7 +217,8 @@ int exfat_directory_read_file(exfat_directory_t *di, char *name, size_t size,
 {
 	uint16_t wname[EXFAT_FILENAME_LEN + 1];
 	exfat_dentry_t *d = NULL;
-	int rc, i;
+	int rc;
+	int i;
 	size_t offset = 0;
 	aoff64_t start_pos = 0;
 	
@@ -304,7 +305,8 @@ static uint16_t exfat_directory_set_checksum(const uint8_t *bytes, size_t count)
 int exfat_directory_sync_file(exfat_directory_t *di, exfat_file_dentry_t *df, 
     exfat_stream_dentry_t *ds)
 {
-	int rc, i, count;
+	int rc;
+	int i, count;
 	exfat_dentry_t *array = NULL, *de;
 	aoff64_t pos = di->pos;
 
@@ -371,7 +373,8 @@ int exfat_directory_write_file(exfat_directory_t *di, const char *name)
 	uint16_t *uctable;
 	exfat_dentry_t df, ds, *de;
 	uint16_t wname[EXFAT_FILENAME_LEN + 1];
-	int rc, i;
+	int rc;
+	int i;
 	size_t uctable_chars, j;
 	aoff64_t pos;
 
@@ -472,7 +475,8 @@ int exfat_directory_write_file(exfat_directory_t *di, const char *name)
 
 int exfat_directory_erase_file(exfat_directory_t *di, aoff64_t pos)
 {
-	int rc, count;
+	int rc;
+	int count;
 	exfat_dentry_t *de;
 
 	di->pos = pos;

--- a/uspace/srv/fs/mfs/mfs_inode.c
+++ b/uspace/srv/fs/mfs/mfs_inode.c
@@ -82,7 +82,8 @@ mfs_read_inode_raw(const struct mfs_instance *instance,
 	struct mfs_ino_info *ino_i = NULL;
 	struct mfs_sb_info *sbi;
 	block_t *b;
-	int i, r;
+	int i;
+	int r;
 
 	sbi = instance->sbi;
 
@@ -141,7 +142,8 @@ mfs2_read_inode_raw(const struct mfs_instance *instance,
 	struct mfs_ino_info *ino_i = NULL;
 	struct mfs_sb_info *sbi;
 	block_t *b;
-	int i, r;
+	int i;
+	int r;
 
 	ino_i = malloc(sizeof(*ino_i));
 
@@ -223,7 +225,8 @@ out:
 static int
 mfs_write_inode_raw(struct mfs_node *mnode)
 {
-	int i, r;
+	int i;
+	int r;
 	block_t *b;
 	struct mfs_ino_info *ino_i = mnode->ino_i;
 	struct mfs_sb_info *sbi = mnode->instance->sbi;
@@ -269,7 +272,8 @@ mfs2_write_inode_raw(struct mfs_node *mnode)
 	struct mfs_ino_info *ino_i = mnode->ino_i;
 	struct mfs_sb_info *sbi = mnode->instance->sbi;
 	block_t *b;
-	int i, r;
+	int i;
+	int r;
 
 	const uint32_t inum = ino_i->index - 1;
 	const int itable_off = sbi->itable_off;

--- a/uspace/srv/fs/mfs/mfs_rw.c
+++ b/uspace/srv/fs/mfs/mfs_rw.c
@@ -243,7 +243,8 @@ mfs_prune_ind_zones(struct mfs_node *mnode, size_t new_size)
 	struct mfs_instance *inst = mnode->instance;
 	struct mfs_sb_info *sbi = inst->sbi;
 	struct mfs_ino_info *ino_i = mnode->ino_i;
-	int nr_direct, ptrs_per_block, rblock, r;
+	int nr_direct, ptrs_per_block, rblock;
+	int r;
 	int i;
 
 	mfs_version_t fs_version = sbi->fs_version;

--- a/uspace/srv/hid/input/input.c
+++ b/uspace/srv/hid/input/input.c
@@ -485,7 +485,7 @@ static int kbd_add_kbdev(service_id_t service_id, kbd_dev_t **kdevp)
 	
 	list_append(&kdev->link, &kbd_devs);
 	*kdevp = kdev;
-	return EOK;
+	return 0;
 	
 fail:
 	if (kdev->svc_name != NULL)
@@ -522,7 +522,7 @@ static int mouse_add_mousedev(service_id_t service_id, mouse_dev_t **mdevp)
 	
 	list_append(&mdev->link, &mouse_devs);
 	*mdevp = mdev;
-	return EOK;
+	return 0;
 	
 fail:
 	free(mdev);
@@ -598,7 +598,7 @@ static int serial_add_srldev(service_id_t service_id, serial_dev_t **sdevp)
 	}
 	
 	*sdevp = sdev;
-	return EOK;
+	return 0;
 	
 fail:
 	if (sdev->kdev->svc_name != NULL)
@@ -669,7 +669,7 @@ static int dev_check_new_kbdevs(void)
 		
 		if (!already_known) {
 			kbd_dev_t *kdev;
-			if (kbd_add_kbdev(svcs[i], &kdev) == EOK) {
+			if (kbd_add_kbdev(svcs[i], &kdev) == 0) {
 				printf("%s: Connected keyboard device '%s'\n",
 				    NAME, kdev->svc_name);
 			}
@@ -720,7 +720,7 @@ static int dev_check_new_mousedevs(void)
 		
 		if (!already_known) {
 			mouse_dev_t *mdev;
-			if (mouse_add_mousedev(svcs[i], &mdev) == EOK) {
+			if (mouse_add_mousedev(svcs[i], &mdev) == 0) {
 				printf("%s: Connected mouse device '%s'\n",
 				    NAME, mdev->svc_name);
 			}
@@ -771,7 +771,7 @@ static int dev_check_new_serialdevs(void)
 		
 		if (!already_known) {
 			serial_dev_t *sdev;
-			if (serial_add_srldev(svcs[i], &sdev) == EOK) {
+			if (serial_add_srldev(svcs[i], &sdev) == 0) {
 				printf("%s: Connected serial device '%s'\n",
 				    NAME, sdev->kdev->svc_name);
 			}

--- a/uspace/srv/logger/logs.c
+++ b/uspace/srv/logger/logs.c
@@ -56,8 +56,7 @@ static int create_dest(const char *name, logger_dest_t **dest)
 	logger_dest_t *result = malloc(sizeof(logger_dest_t));
 	if (result == NULL)
 		return ENOMEM;
-	int rc = asprintf(&result->filename, "/log/%s", name);
-	if (rc < 0) {
+	if (asprintf(&result->filename, "/log/%s", name) < 0) {
 		free(result);
 		return ENOMEM;
 	}
@@ -90,9 +89,8 @@ static logger_log_t *create_log_no_locking(const char *name, logger_log_t *paren
 		if (rc != EOK)
 			goto error;
 	} else {
-		int rc = asprintf(&result->full_name, "%s/%s",
-		    parent->full_name, name);
-		if (rc < 0)
+		if (asprintf(&result->full_name, "%s/%s",
+		    parent->full_name, name) < 0)
 			goto error;
 		result->dest = parent->dest;
 	}

--- a/uspace/srv/net/ethip/ethip.c
+++ b/uspace/srv/net/ethip/ethip.c
@@ -107,9 +107,9 @@ int ethip_iplink_init(ethip_nic_t *nic)
 	nic->iplink.ops = &ethip_iplink_ops;
 	nic->iplink.arg = nic;
 
-	rc = asprintf(&svc_name, "net/eth%u", ++link_num);
-	if (rc < 0) {
+	if (asprintf(&svc_name, "net/eth%u", ++link_num) < 0) {
 		log_msg(LOG_DEFAULT, LVL_ERROR, "Out of memory.");
+		rc = ENOMEM;
 		goto error;
 	}
 

--- a/uspace/srv/net/tcp/test/rqueue.c
+++ b/uspace/srv/net/tcp/test/rqueue.c
@@ -62,7 +62,7 @@ PCUT_TEST_BEFORE
 
 	/* We will be calling functions that perform logging */
 	rc = log_init("test-tcp");
-	PCUT_ASSERT_INT_EQUALS(EOK, rc);
+	PCUT_ASSERT_ERRNO_VAL(EOK, rc);
 }
 
 /** Test empty queue */

--- a/uspace/srv/ns/clonable.c
+++ b/uspace/srv/ns/clonable.c
@@ -129,7 +129,7 @@ void connect_to_clonable(service_t service, iface_t iface, ipc_call_t *call,
 	/* Spawn a loader. */
 	int rc = loader_spawn("loader");
 	
-	if (rc < 0) {
+	if (rc != EOK) {
 		free(csr);
 		async_answer_0(callid, rc);
 		return;


### PR DESCRIPTION
This is a subset of changes necessary to introduce `errno_t` as a typechecking aid. A few of these changes are bug fixes, but most are simple modifications with no semantic effect (e.g. converting EOK to 0 and vice versa, splitting `int rc` into two separate variables, separating `rc` from variables declared on the same line, etc).

The intention is that all the changes in this set are obviously harmless, i.e. one can trivially see they won't cause any regressions, without having to look up surrounding code. Their actual _correctness_ may not be obvious at a glance, but I'm fairly confident they are.

I'll leave this open until I get enough sleep to give this another thorough review (probably late afternoon tomorrow), then I'll merge this as is unless I discover new mistakes.