### PR TITLE
Generate files that a third party can use to build software for HelenOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ CONFIG_HEADER = config.h
 ERRNO_HEADER = abi/include/abi/errno.h
 ERRNO_INPUT = abi/include/abi/errno.in
 
-.PHONY: all precheck cscope cscope_parts autotool config_auto config_default config distclean clean check releasefile release common boot kernel uspace
+.PHONY: all precheck cscope cscope_parts autotool config_auto config_default config distclean clean check releasefile release common boot kernel uspace export-posix
 
 all: kernel uspace
 	$(MAKE) -r -C boot PRECHECK=$(PRECHECK)
@@ -59,6 +59,13 @@ kernel: common
 
 uspace: common
 	$(MAKE) -r -C uspace PRECHECK=$(PRECHECK)
+
+export-posix: common
+ifndef EXPORT_DIR
+	@echo ERROR: Variable EXPORT_DIR is not defined. && false
+else
+	$(MAKE) -r -C uspace export EXPORT_DIR=$(abspath $(EXPORT_DIR))
+endif
 
 precheck: clean
 	$(MAKE) -r all PRECHECK=y

--- a/tools/autotool.py
+++ b/tools/autotool.py
@@ -614,6 +614,7 @@ def main():
 					print_error(["Toolchain for target is not installed, or CROSS_PREFIX is not set correctly."])
 				path = "%s/%s/bin" % (cross_prefix, platform)
 		
+		common['TARGET'] = target
 		prefix = "%s-" % target
 		
 		# Compiler

--- a/uspace/Makefile
+++ b/uspace/Makefile
@@ -254,12 +254,15 @@ BUILDS_TESTS := $(addsuffix .build-test,$(DIRS) $(LIBS) $(BASE_LIBS))
 DEPS = $(addsuffix /deps.mk,$(DIRS) $(LIBS))
 CLEANS := $(addsuffix .clean,$(DIRS) $(LIBS) $(BASE_LIBS))
 
-.PHONY: all $(BASE_BUILDS) $(BUILDS) $(BUILDS_TESTS) $(CLEANS) clean
+.PHONY: all $(BASE_BUILDS) $(BUILDS) $(BUILDS_TESTS) $(CLEANS) clean export
 
 all: $(BUILDS) $(BUILDS_TESTS)
 
 $(BUILDS_TESTS): $(BASE_BUILDS) $(BUILDS)
 	$(MAKE) -r -C $(basename $@) all-test PRECHECK=$(PRECHECK)
+
+export: lib/posix.build lib/math.build lib/clui.build
+	$(MAKE) -r -C lib/posix export EXPORT_DIR=$(EXPORT_DIR)
 
 clean: $(CLEANS)
 	find lib app drv srv -name '*.o' -follow -exec rm \{\} \;

--- a/uspace/Makefile.common
+++ b/uspace/Makefile.common
@@ -173,31 +173,57 @@ endif
 	TEST_BINARY_LIBS += $(TEST_LIBS)
 endif
 
-COMMON_CFLAGS = $(INCLUDES_FLAGS) -O$(OPTIMIZATION) -imacros $(CONFIG_HEADER) \
-	-ffreestanding -nostdlib -nostdinc -fexec-charset=UTF-8 \
-	-finput-charset=UTF-8 -D__$(ENDIANESS)__ -D_HELENOS_SOURCE -fno-common \
-	-fdebug-prefix-map=$(realpath $(ROOT_PATH))=.
-
-GCC_CFLAGS = -ffunction-sections -Wall -Wextra -Wno-clobbered \
-	-Wno-unused-parameter -Wmissing-prototypes -std=gnu99 \
-	-Werror-implicit-function-declaration \
-	-Wwrite-strings -pipe
-
-# -Wno-missing-prototypes is there because it warns about main().
-# This should be fixed elsewhere.
-CLANG_CFLAGS = -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wno-typedef-redefinition \
-	-Wno-missing-prototypes -Wno-unused-command-line-argument \
-	-std=gnu99 -Werror-implicit-function-declaration -Wwrite-strings \
-	-pipe -fno-stack-protector -fno-PIC
+# Flags that are not necessary, and can be overriden, but are used by default.
+DEFAULT_CFLAGS = \
+	-O$(OPTIMIZATION) \
+	-ffunction-sections \
+	-pipe \
+	-Wall \
+	-Wextra \
+	-Wno-unused-parameter \
+	-Wmissing-prototypes \
+	-Wwrite-strings \
+	-Werror-implicit-function-declaration
 
 ifeq ($(CONFIG_DEBUG),y)
-	COMMON_CFLAGS += -Werror
+	DEFAULT_CFLAGS += -Werror
+endif
+
+ifeq ($(COMPILER),clang)
+	DEFAULT_CFLAGS += \
+		-Wno-missing-field-initializers \
+		-Wno-typedef-redefinition \
+		-Wno-unused-command-line-argument
+else
+	DEFAULT_CFLAGS += \
+		-Wno-clobbered
 endif
 
 ifeq ($(CONFIG_LINE_DEBUG),y)
-	GCC_CFLAGS += -ggdb
-	CLANG_CFLAGS += -g
+	DEFAULT_CFLAGS += -ggdb
 endif
+
+# Flags that should always be used, even for third-party software.
+COMMON_CFLAGS = \
+	-ffreestanding \
+	-nostdlib \
+	-nostdinc \
+	-D__$(ENDIANESS)__
+
+# Flags that are always used for HelenOS code, but not for third-party.
+HELENOS_CFLAGS = \
+	-std=gnu99 \
+	$(INCLUDES_FLAGS) \
+	-imacros $(CONFIG_HEADER) \
+	-D_HELENOS_SOURCE \
+	-fexec-charset=UTF-8 \
+	-finput-charset=UTF-8 \
+	-fno-common \
+	-fdebug-prefix-map=$(realpath $(ROOT_PATH))=.
+
+# TODO: Use a different name.
+# CFLAGS variable is traditionally used for overridable flags.
+CFLAGS = $(COMMON_CFLAGS) $(HELENOS_CFLAGS) $(DEFAULT_CFLAGS)
 
 ## Setup platform configuration
 #
@@ -213,12 +239,6 @@ ifeq ($(PRECHECK),y)
 	CC_JOB = $(JOBFILE) $(JOB) $(CC) $< -o $@
 else
 	CC_JOB = $(CC) $< -o $@
-endif
-
-ifeq ($(COMPILER),clang)
-	CFLAGS += $(COMMON_CFLAGS) $(CLANG_CFLAGS)
-else
-	CFLAGS += $(COMMON_CFLAGS) $(GCC_CFLAGS)
 endif
 
 ifeq ($(CONFIG_STRIP_BINARIES),y)
@@ -245,14 +265,13 @@ all: tag $(OUTPUTS)
 
 all-test: $(TEST_OUTPUTS)
 
-clean:
-	rm -f $(JOB) $(OUTPUTS) $(EXTRA_CLEAN) tag deps.mk
+clean: fasterclean
 	find . -name '*.o' -follow -exec rm \{\} \;
 	find . -name '*.lo' -follow -exec rm \{\} \;
 	find . -name '*.d' -follow -exec rm \{\} \;
 
 fasterclean:
-	rm -f $(JOB) $(OUTPUTS) $(EXTRA_CLEAN) tag deps.mk
+	rm -rf $(JOB) $(OUTPUTS) $(EXTRA_CLEAN) tag deps.mk
 
 depend: $(PRE_DEPEND)
 

--- a/uspace/lib/c/arch/amd64/Makefile.common
+++ b/uspace/lib/c/arch/amd64/Makefile.common
@@ -30,7 +30,10 @@ COMMON_CFLAGS += -fno-omit-frame-pointer
 
 # XXX: clang doesn't support this flag, but the optimization is OS-specific,
 #      so it isn't used for amd64-unknown-elf target.
-GCC_CFLAGS += -mno-tls-direct-seg-refs
+
+ifneq ($(COMPILER),clang)
+	COMMON_CFLAGS += -mno-tls-direct-seg-refs
+endif
 
 LFLAGS += --gc-sections
 

--- a/uspace/lib/posix/Makefile
+++ b/uspace/lib/posix/Makefile
@@ -97,11 +97,11 @@ TEST_SOURCES = \
 	test/scanf.c
 
 EXPORT_CPPFLAGS = \
-	-specs $(EXPORT_DIR)/lib/gcc.specs \
-	-isystem $(EXPORT_DIR)/include
+	-specs $$(HELENOS_EXPORT_ROOT)/lib/gcc.specs \
+	-isystem $$(HELENOS_EXPORT_ROOT)/include
 
 EXPORT_LDFLAGS = \
-	-L$(EXPORT_DIR)/lib \
+	-L$$(HELENOS_EXPORT_ROOT)/lib \
 	--whole-archive -lc -lmath --no-whole-archive \
 	-T link.ld
 
@@ -130,16 +130,20 @@ $(INCLUDE_LIBC): $(shell find ../c/include -name '*.h')
 	cp -r -L --remove-destination -T ../c/include $@
 	find ../c/include -type f -and -not -name '*.h' -delete
 
-export: $(EXPORT_DIR)/config
+export: $(EXPORT_DIR)/config.mk $(EXPORT_DIR)/config.rc
 
-$(EXPORT_DIR)/config: export-libs export-includes
+$(EXPORT_DIR)/config.mk: export-libs export-includes
 	echo '# Generated file, do not modify.' >> $@.new
+	echo '# Do not forget to set HELENOS_EXPORT_ROOT.' >> $@.new
 	echo 'HELENOS_CROSS_PATH="$(shell dirname $(CC))"' >> $@.new
 	echo 'HELENOS_TARGET="$(TARGET)"' >> $@.new
 	echo 'HELENOS_CPPFLAGS="$(EXPORT_CPPFLAGS)"' >> $@.new
 	echo 'HELENOS_CFLAGS="$(EXPORT_CFLAGS)"' >> $@.new
 	echo 'HELENOS_LDFLAGS="$(EXPORT_LDFLAGS)"' >> $@.new
 	mv $@.new $@
+
+$(EXPORT_DIR)/config.rc: $(EXPORT_DIR)/config.mk
+	sed 's:$$(HELENOS_EXPORT_ROOT):$$HELENOS_EXPORT_ROOT:g' < $< >$@
 
 export-libs: $(EXPORT_FILES) export-includes
 	mkdir -p $(EXPORT_DIR)/lib

--- a/uspace/lib/posix/Makefile
+++ b/uspace/lib/posix/Makefile
@@ -44,6 +44,20 @@ MERGE_LIBRARIES = \
 	$(LIBSOFTFLOAT_PREFIX)/libsoftfloat.a \
 	$(LIBSOFTINT_PREFIX)/libsoftint.a
 
+SPECS = gcc.specs
+LIBC_LINKER_SCRIPT = $(LIBC_PREFIX)/arch/$(UARCH)/_link.ld
+LIBC_STARTUP_FILE = $(shell sed -n -e 's/^.*STARTUP(\(.*\)).*$$/\1/p' $(LIBC_LINKER_SCRIPT))
+EXPORT_LINKER_SCRIPT = link.ld
+EXPORT_STARTUP_FILE = crt0.o
+
+EXPORT_FILES = \
+	../math/libmath.a \
+	../clui/libclui.a \
+	$(MERGED_C_LIBRARY) \
+	$(EXPORT_STARTUP_FILE) \
+	$(EXPORT_LINKER_SCRIPT) \
+	$(SPECS)
+
 REDEFS_HIDE_LIBC = redefs-hide-libc-symbols.list
 
 PRE_DEPEND = $(INCLUDE_LIBC)
@@ -52,7 +66,7 @@ EXTRA_CLEAN = \
 	$(REDEFS_HIDE_LIBC) \
 	libc.o
 
-EXTRA_OUTPUT = $(FIXED_C_LIBRARY) $(FIXED_POSIX_LIBRARY) $(MERGED_C_LIBRARY)
+EXTRA_OUTPUT = $(FIXED_C_LIBRARY) $(FIXED_POSIX_LIBRARY) $(MERGED_C_LIBRARY) $(SPECS) $(EXPORT_LINKER_SCRIPT) $(EXPORT_STARTUP_FILE)
 
 SOURCES = \
 	src/ctype.c \
@@ -82,10 +96,78 @@ TEST_SOURCES = \
 	test/main.c \
 	test/scanf.c
 
+EXPORT_CPPFLAGS = \
+	-specs $(EXPORT_DIR)/lib/gcc.specs \
+	-isystem $(EXPORT_DIR)/include
+
+EXPORT_LDFLAGS = \
+	-L$(EXPORT_DIR)/lib \
+	--whole-archive -lc -lmath --no-whole-archive \
+	-T link.ld
+
+EXPORT_CFLAGS = \
+	$(EXPORT_CPPFLAGS) \
+	$(addprefix -Xlinker , $(EXPORT_LDFLAGS))
+
 include $(USPACE_PREFIX)/Makefile.common
 
-$(INCLUDE_LIBC): ../c/include
-	ln -s -f -n ../$^ $@
+$(SPECS): $(CONFIG_MAKEFILE)
+	echo '*self_spec:' > $@.new
+	echo '+ $(COMMON_CFLAGS)' >> $@.new
+	echo >> $@.new
+	echo '*lib:' >> $@.new
+	echo '--whole-archive -lc -lmath --no-whole-archive' >> $@.new
+	echo >> $@.new
+	mv $@.new $@
+
+$(EXPORT_LINKER_SCRIPT): $(LIBC_LINKER_SCRIPT)
+	sed 's/STARTUP(.*)/STARTUP(crt0.o)/' $< > $@
+
+$(EXPORT_STARTUP_FILE): $(LIBC_STARTUP_FILE)
+	cp $< $@
+
+$(INCLUDE_LIBC): $(shell find ../c/include -name '*.h')
+	cp -r -L --remove-destination -T ../c/include $@
+	find ../c/include -type f -and -not -name '*.h' -delete
+
+export: $(EXPORT_DIR)/config
+
+$(EXPORT_DIR)/config: export-libs export-includes
+	echo '# Generated file, do not modify.' >> $@.new
+	echo 'HELENOS_CROSS_PATH="$(shell dirname $(CC))"' >> $@.new
+	echo 'HELENOS_TARGET="$(TARGET)"' >> $@.new
+	echo 'HELENOS_CPPFLAGS="$(EXPORT_CPPFLAGS)"' >> $@.new
+	echo 'HELENOS_CFLAGS="$(EXPORT_CFLAGS)"' >> $@.new
+	echo 'HELENOS_LDFLAGS="$(EXPORT_LDFLAGS)"' >> $@.new
+	mv $@.new $@
+
+export-libs: $(EXPORT_FILES) export-includes
+	mkdir -p $(EXPORT_DIR)/lib
+	cp -L $(EXPORT_FILES) $(EXPORT_DIR)/lib
+
+export-includes: $(INCLUDE_LIBC) $(shell find ./include ../c/arch/$(UARCH)/include $(ROOT_PATH)/abi/include -name '*.h')
+	mkdir -p $(EXPORT_DIR)/include
+	rm -rf $(EXPORT_DIR)/include.new
+	cp -r -L -T ./include/posix $(EXPORT_DIR)/include.new
+	cp -r -L -T ./include/libc $(EXPORT_DIR)/include.new/libc
+	cp -r -L ../c/arch/$(UARCH)/include/* $(EXPORT_DIR)/include.new/libc
+	cp -r -L $(ROOT_PATH)/abi/include/* $(EXPORT_DIR)/include.new
+	mkdir -p $(EXPORT_DIR)/include.new/libclui
+	cp -L ../clui/tinput.h $(EXPORT_DIR)/include.new/libclui
+	
+	find "$(EXPORT_DIR)/include.new/libc" "$(EXPORT_DIR)/include.new/libclui" -name '*.h' -exec sed \
+		-e 's:#include <:#include <libc/:' \
+		-e 's:#include <libc/abi/:#include <abi/:' \
+		-e 's:#include <libc/_bits/:#include <_bits/:' \
+		-e 's:#include <libc/libc/:#include <libc/:' \
+		-i {} \;
+	find "$(EXPORT_DIR)/include.new" -name '*.h' -exec sed \
+		-e 's:#include "posix/:#include ":' \
+		-e 's:#include <posix/:#include <:' \
+		-i {} \;
+	
+	rm -rf $(EXPORT_DIR)/include
+	mv $(EXPORT_DIR)/include.new $(EXPORT_DIR)/include
 
 $(FIXED_C_LIBRARY): $(LIBC_FILE) $(REDEFS_HIDE_LIBC)
 	$(OBJCOPY) --redefine-syms=$(REDEFS_HIDE_LIBC) $(LIBC_FILE) $@
@@ -96,4 +178,3 @@ $(MERGED_C_LIBRARY): $(MERGE_LIBRARIES)
 
 $(REDEFS_HIDE_LIBC): $(SOURCES)
 	sed -n -e 's/_HIDE_LIBC_SYMBOL(\(.*\))/\1 __helenos_libc_\1/p' $(SOURCES) >$@
-


### PR DESCRIPTION
without necessarily knowing anything about the build system.

Not yet ideal in terms of forward compatibility, so I expect some small changes will be necessary, but I'm fairly comfortable with this level of abstraction. The main repository doesn't need to know anything about ports, and ports don't need to know anything particular about HelenOS (except where to look for the configuration).