### PR TITLE
libdrv: fix leaking ddf_dev_t reference

### DIFF
--- a/uspace/lib/drv/generic/driver.c
+++ b/uspace/lib/drv/generic/driver.c
@@ -198,6 +198,7 @@ static void driver_dev_remove(ipc_callid_t iid, ipc_call_t *icall)
 	if (rc == EOK)
 		dev_del_ref(dev);
 	
+	dev_del_ref(dev);
 	async_answer_0(iid, rc);
 }
 
@@ -226,6 +227,7 @@ static void driver_dev_gone(ipc_callid_t iid, ipc_call_t *icall)
 	if (rc == EOK)
 		dev_del_ref(dev);
 	
+	dev_del_ref(dev);
 	async_answer_0(iid, rc);
 }
 

--- a/uspace/lib/drv/generic/driver.c
+++ b/uspace/lib/drv/generic/driver.c
@@ -195,8 +195,12 @@ static void driver_dev_remove(ipc_callid_t iid, ipc_call_t *icall)
 	else
 		rc = ENOTSUP;
 	
-	if (rc == EOK)
+	if (rc == EOK) {
+		fibril_mutex_lock(&devices_mutex);
+		list_remove(&dev->link);
+		fibril_mutex_unlock(&devices_mutex);
 		dev_del_ref(dev);
+	}
 	
 	dev_del_ref(dev);
 	async_answer_0(iid, rc);
@@ -224,8 +228,12 @@ static void driver_dev_gone(ipc_callid_t iid, ipc_call_t *icall)
 	else
 		rc = ENOTSUP;
 	
-	if (rc == EOK)
+	if (rc == EOK) {
+		fibril_mutex_lock(&devices_mutex);
+		list_remove(&dev->link);
+		fibril_mutex_unlock(&devices_mutex);
 		dev_del_ref(dev);
+	}
 	
 	dev_del_ref(dev);
 	async_answer_0(iid, rc);


### PR DESCRIPTION
Even though the permanent reference held by the device being added is
dropped correctly, the temporary reference added by remove/gone is not.
That caused leaking devices and parent sessions along with them (which
is the way we discovered it).