### PR TITLE
Generalize ns16550 driver to work with more chips.

### DIFF
--- a/kernel/arch/amd64/src/amd64.c
+++ b/kernel/arch/amd64/src/amd64.c
@@ -215,7 +215,7 @@ void amd64_post_smp_init(void)
 	outdev_t **ns16550_out_ptr = NULL;
 #endif
 	ns16550_instance_t *ns16550_instance
-	    = ns16550_init((ns16550_t *) NS16550_BASE, IRQ_NS16550, NULL, NULL,
+	    = ns16550_init(NS16550_BASE, 0, IRQ_NS16550, NULL, NULL,
 	    ns16550_out_ptr);
 	if (ns16550_instance) {
 #ifdef CONFIG_NS16550

--- a/kernel/arch/ia32/src/ia32.c
+++ b/kernel/arch/ia32/src/ia32.c
@@ -200,7 +200,7 @@ void ia32_post_smp_init(void)
 	outdev_t **ns16550_out_ptr = NULL;
 #endif
 	ns16550_instance_t *ns16550_instance
-	    = ns16550_init((ns16550_t *) NS16550_BASE, IRQ_NS16550, NULL, NULL,
+	    = ns16550_init(NS16550_BASE, 0, IRQ_NS16550, NULL, NULL,
 	    ns16550_out_ptr);
 	if (ns16550_instance) {
 #ifdef CONFIG_NS16550

--- a/kernel/arch/ia64/src/ia64.c
+++ b/kernel/arch/ia64/src/ia64.c
@@ -180,7 +180,7 @@ void ia64_post_smp_init(void)
 	
 #ifdef CONFIG_NS16550
 	ns16550_instance_t *ns16550_instance
-	    = ns16550_init((ns16550_t *) NS16550_BASE, NS16550_IRQ, NULL, NULL,
+	    = ns16550_init(NS16550_BASE, 0, NS16550_IRQ, NULL, NULL,
 	    NULL);
 	if (ns16550_instance) {
 		srln_instance_t *srln_instance = srln_init();

--- a/kernel/arch/sparc64/src/drivers/kbd.c
+++ b/kernel/arch/sparc64/src/drivers/kbd.c
@@ -117,10 +117,10 @@ static bool kbd_ns16550_init(ofw_tree_node_t *node)
 	uintptr_t aligned_addr = ALIGN_DOWN(pa, PAGE_SIZE);
 	size_t offset = pa - aligned_addr;
 	
-	ns16550_t *ns16550 = (ns16550_t *) (km_map(aligned_addr, offset + size,
+	ioport8_t *ns16550 = (ioport8_t *) (km_map(aligned_addr, offset + size,
 	    PAGE_WRITE | PAGE_NOT_CACHEABLE) + offset);
 	
-	ns16550_instance_t *ns16550_instance = ns16550_init(ns16550, inr, cir,
+	ns16550_instance_t *ns16550_instance = ns16550_init(ns16550, 0, inr, cir,
 	    cir_arg, NULL);
 	if (ns16550_instance) {
 		kbrd_instance_t *kbrd_instance = kbrd_init();

--- a/kernel/genarch/include/genarch/drivers/ns16550/ns16550.h
+++ b/kernel/genarch/include/genarch/drivers/ns16550/ns16550.h
@@ -49,31 +49,28 @@
 #define MCR_OUT2   0x08  /** OUT2. */
 
 /** NS16550 registers. */
-typedef struct {
-	union {
-		ioport8_t rbr;      /**< Receiver Buffer Register (read). */
-		ioport8_t thr;      /**< Transmitter Holder Register (write). */
-	} __attribute__ ((packed));
-	ioport8_t ier;      /**< Interrupt Enable Register. */
-	union {
-		ioport8_t iir;  /**< Interrupt Ident Register (read). */
-		ioport8_t fcr;  /**< FIFO control register (write). */
-	} __attribute__ ((packed));
-	ioport8_t lcr;      /**< Line Control register. */
-	ioport8_t mcr;      /**< Modem Control Register. */
-	ioport8_t lsr;      /**< Line Status Register. */
-} __attribute__ ((packed)) ns16550_t;
+enum {
+	NS16550_REG_RBR = 0,  /**< Receiver Buffer Register (read). */
+	NS16550_REG_THR = 0,  /**< Transmitter Holder Register (write). */
+	NS16550_REG_IER = 1,  /**< Interrupt Enable Register. */
+	NS16550_REG_IIR = 2,  /**< Interrupt Ident Register (read). */
+	NS16550_REG_FCR = 2,  /**< FIFO control register (write). */
+	NS16550_REG_LCR = 3,  /**< Line Control register. */
+	NS16550_REG_MCR = 4,  /**< Modem Control Register. */
+	NS16550_REG_LSR = 5,  /**< Line Status Register. */
+};
 
 /** Structure representing the ns16550 device. */
 typedef struct {
 	irq_t irq;
-	ns16550_t *ns16550;
+	volatile ioport8_t *ns16550;
 	indev_t *input;
 	outdev_t *output;
 	parea_t parea;
+	int reg_shift;
 } ns16550_instance_t;
 
-extern ns16550_instance_t *ns16550_init(ns16550_t *, inr_t, cir_t, void *,
+extern ns16550_instance_t *ns16550_init(ioport8_t *, int, inr_t, cir_t, void *,
     outdev_t **);
 extern void ns16550_wire(ns16550_instance_t *, indev_t *);
 

--- a/kernel/genarch/src/drivers/ns16550/ns16550.c
+++ b/kernel/genarch/src/drivers/ns16550/ns16550.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2009 Jakub Jermar
+ * Copyright (c) 2018 CZ.NIC, z.s.p.o.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -45,12 +46,19 @@
 #define LSR_DATA_READY  0x01
 #define LSR_TH_READY    0x20
 
+static inline uint8_t _read(ns16550_instance_t *inst, int reg) {
+	return pio_read_8(&inst->ns16550[reg << inst->reg_shift]);
+}
+
+static inline void _write(ns16550_instance_t *inst, int reg, uint8_t val) {
+	pio_write_8(&inst->ns16550[reg << inst->reg_shift], val);
+}
+
 static irq_ownership_t ns16550_claim(irq_t *irq)
 {
 	ns16550_instance_t *instance = irq->instance;
-	ns16550_t *dev = instance->ns16550;
-	
-	if (pio_read_8(&dev->lsr) & LSR_DATA_READY)
+
+	if (_read(instance, NS16550_REG_LSR) & LSR_DATA_READY)
 		return IRQ_ACCEPT;
 	else
 		return IRQ_DECLINE;
@@ -59,26 +67,25 @@ static irq_ownership_t ns16550_claim(irq_t *irq)
 static void ns16550_irq_handler(irq_t *irq)
 {
 	ns16550_instance_t *instance = irq->instance;
-	ns16550_t *dev = instance->ns16550;
 	
-	if (pio_read_8(&dev->lsr) & LSR_DATA_READY) {
-		uint8_t data = pio_read_8(&dev->rbr);
+	while (_read(instance, NS16550_REG_LSR) & LSR_DATA_READY) {
+		uint8_t data = _read(instance, NS16550_REG_RBR);
 		indev_push_character(instance->input, data);
 	}
 }
 
 /**< Clear input buffer. */
-static void ns16550_clear_buffer(ns16550_t *dev)
+static void ns16550_clear_buffer(ns16550_instance_t *instance)
 {
-	while ((pio_read_8(&dev->lsr) & LSR_DATA_READY))
-		(void) pio_read_8(&dev->rbr);
+	while (_read(instance, NS16550_REG_LSR) & LSR_DATA_READY)
+		(void) _read(instance, NS16550_REG_RBR);
 }
 
-static void ns16550_sendb(ns16550_t *dev, uint8_t byte)
+static void ns16550_sendb(ns16550_instance_t *instance, uint8_t byte)
 {
-	while (!(pio_read_8(&dev->lsr) & LSR_TH_READY))
+	while (!(_read(instance, NS16550_REG_LSR) & LSR_TH_READY))
 		;
-	pio_write_8(&dev->thr, byte);
+	_write(instance, NS16550_REG_THR, byte);
 }
 
 static void ns16550_putchar(outdev_t *dev, wchar_t ch)
@@ -87,9 +94,9 @@ static void ns16550_putchar(outdev_t *dev, wchar_t ch)
 	
 	if ((!instance->parea.mapped) || (console_override)) {
 		if (ascii_check(ch))
-			ns16550_sendb(instance->ns16550, (uint8_t) ch);
+			ns16550_sendb(instance, (uint8_t) ch);
 		else
-			ns16550_sendb(instance->ns16550, U_SPECIAL);
+			ns16550_sendb(instance, U_SPECIAL);
 	}
 }
 
@@ -100,24 +107,28 @@ static outdev_operations_t ns16550_ops = {
 
 /** Initialize ns16550.
  *
- * @param dev      Addrress of the beginning of the device in I/O space.
- * @param inr      Interrupt number.
- * @param cir      Clear interrupt function.
- * @param cir_arg  First argument to cir.
- * @param output   Where to store pointer to the output device
- *                 or NULL if the caller is not interested in
- *                 writing to the serial port.
+ * @param dev        Address of the beginning of the device in I/O space.
+ * @param reg_shift  Spacing between individual register addresses, in log2.
+ *                   The individual register location is calculated as
+ *                   `base + (register offset << reg_shift)`.
+ * @param inr        Interrupt number.
+ * @param cir        Clear interrupt function.
+ * @param cir_arg    First argument to cir.
+ * @param output     Where to store pointer to the output device
+ *                   or NULL if the caller is not interested in
+ *                   writing to the serial port.
  *
  * @return Keyboard instance or NULL on failure.
  *
  */
-ns16550_instance_t *ns16550_init(ns16550_t *dev, inr_t inr, cir_t cir,
-    void *cir_arg, outdev_t **output)
+ns16550_instance_t *ns16550_init(ioport8_t *dev, int reg_shift, inr_t inr,
+    cir_t cir, void *cir_arg, outdev_t **output)
 {
 	ns16550_instance_t *instance
 	    = malloc(sizeof(ns16550_instance_t), FRAME_ATOMIC);
 	if (instance) {
 		instance->ns16550 = dev;
+		instance->reg_shift = reg_shift;
 		instance->input = NULL;
 		instance->output = NULL;
 		
@@ -161,11 +172,11 @@ void ns16550_wire(ns16550_instance_t *instance, indev_t *input)
 	instance->input = input;
 	irq_register(&instance->irq);
 	
-	ns16550_clear_buffer(instance->ns16550);
+	ns16550_clear_buffer(instance);
 	
 	/* Enable interrupts */
-	pio_write_8(&instance->ns16550->ier, IER_ERBFI);
-	pio_write_8(&instance->ns16550->mcr, MCR_OUT2);
+	_write(instance, NS16550_REG_IER, IER_ERBFI);
+	_write(instance, NS16550_REG_MCR, MCR_OUT2);
 }
 
 /** @}


### PR DESCRIPTION
Some UART controllers are compatible with 16550A, but have more spacing
between registers. In particular, ARMADA 385, which is the basis of
Turris Omnia router, has a compatible UART with 32b registers instead of 8b
(with the top three bytes unused).

Note: The device tree file hints that some UARTs may need register reads/writes
that are wider than 8 bits, and this commit does not address that possibility.