### PR TITLE
Turn context_save/context_restore into standard setjmp/longjmp.

### DIFF
--- a/uspace/lib/c/arch/abs32le/src/fibril.c
+++ b/uspace/lib/c/arch/abs32le/src/fibril.c
@@ -29,15 +29,15 @@
 /** @file
  */
 
-#include <fibril.h>
+#include <setjmp.h>
 #include <stdbool.h>
 
-int context_save(context_t *ctx)
+int setjmp(context_t *ctx)
 {
-	return 1;
+	return 0;
 }
 
-void context_restore(context_t *ctx)
+void __longjmp(context_t *ctx, int val)
 {
 	while (true);
 }

--- a/uspace/lib/c/arch/abs32le/src/fibril.c
+++ b/uspace/lib/c/arch/abs32le/src/fibril.c
@@ -32,7 +32,7 @@
 #include <setjmp.h>
 #include <stdbool.h>
 
-int setjmp(context_t *ctx)
+int __setjmp(context_t *ctx)
 {
 	return 0;
 }

--- a/uspace/lib/c/arch/amd64/src/fibril.S
+++ b/uspace/lib/c/arch/amd64/src/fibril.S
@@ -34,9 +34,9 @@
 ## Save current CPU context
 #
 # Save CPU context to context_t variable
-# pointed by the 1st argument. Returns 0 in EAX.
+# pointed by the 1st argument. Returns 0 in RAX.
 #
-FUNCTION_BEGIN(setjmp)
+FUNCTION_BEGIN(__setjmp)
 	movq (%rsp), %rdx     # the caller's return %eip
 
 	# in %rdi is passed 1st argument
@@ -53,14 +53,14 @@ FUNCTION_BEGIN(setjmp)
 	movq %fs:0, %rax
 	movq %rax, CONTEXT_OFFSET_TLS(%rdi)
 
-	xorq %rax, %rax                      # setjmp returns 0
+	xorq %rax, %rax                      # __setjmp returns 0
 	ret
-FUNCTION_END(setjmp)
+FUNCTION_END(__setjmp)
 
 ## Restore current CPU context
 #
 # Restore CPU context from context_t variable
-# pointed by the 1st argument. Returns RSI in EAX.
+# pointed by the 1st argument. Returns second argument in RAX.
 #
 FUNCTION_BEGIN(__longjmp)
 	movq CONTEXT_OFFSET_R15(%rdi), %r15

--- a/uspace/lib/c/arch/amd64/src/fibril.S
+++ b/uspace/lib/c/arch/amd64/src/fibril.S
@@ -34,9 +34,9 @@
 ## Save current CPU context
 #
 # Save CPU context to context_t variable
-# pointed by the 1st argument. Returns 1 in EAX.
+# pointed by the 1st argument. Returns 0 in EAX.
 #
-FUNCTION_BEGIN(context_save)
+FUNCTION_BEGIN(setjmp)
 	movq (%rsp), %rdx     # the caller's return %eip
 
 	# in %rdi is passed 1st argument
@@ -53,17 +53,16 @@ FUNCTION_BEGIN(context_save)
 	movq %fs:0, %rax
 	movq %rax, CONTEXT_OFFSET_TLS(%rdi)
 
-	xorl %eax, %eax                      # context_save returns 1
-	incl %eax
+	xorq %rax, %rax                      # setjmp returns 0
 	ret
-FUNCTION_END(context_save)
+FUNCTION_END(setjmp)
 
 ## Restore current CPU context
 #
 # Restore CPU context from context_t variable
-# pointed by the 1st argument. Returns 0 in EAX.
+# pointed by the 1st argument. Returns RSI in EAX.
 #
-FUNCTION_BEGIN(context_restore)
+FUNCTION_BEGIN(__longjmp)
 	movq CONTEXT_OFFSET_R15(%rdi), %r15
 	movq CONTEXT_OFFSET_R14(%rdi), %r14
 	movq CONTEXT_OFFSET_R13(%rdi), %r13
@@ -80,7 +79,7 @@ FUNCTION_BEGIN(context_restore)
 	movq CONTEXT_OFFSET_TLS(%rdi), %rdi
 	movq %rdi, %fs:0
 
-	xorl %eax, %eax                      # context_restore returns 0
+	movq %rsi, %rax                      # __longjmp returns second argument
 	ret
-FUNCTION_END(context_restore)
+FUNCTION_END(__longjmp)
 

--- a/uspace/lib/c/arch/arm32/src/fibril.S
+++ b/uspace/lib/c/arch/arm32/src/fibril.S
@@ -30,14 +30,14 @@
 
 .text
 
-FUNCTION_BEGIN(setjmp)
+FUNCTION_BEGIN(__setjmp)
 	stmia r0!, {sp, lr}
 	stmia r0!, {r4-r11}
 
 	# return 0
 	mov r0, #0
 	mov pc, lr
-FUNCTION_END(setjmp)
+FUNCTION_END(__setjmp)
 
 FUNCTION_BEGIN(__longjmp)
 	ldmia r0!, {sp, lr}

--- a/uspace/lib/c/arch/arm32/src/fibril.S
+++ b/uspace/lib/c/arch/arm32/src/fibril.S
@@ -30,21 +30,21 @@
 
 .text
 
-FUNCTION_BEGIN(context_save)
+FUNCTION_BEGIN(setjmp)
 	stmia r0!, {sp, lr}
 	stmia r0!, {r4-r11}
-
-	# return 1
-	mov r0, #1
-	mov pc, lr
-FUNCTION_END(context_save)
-
-FUNCTION_BEGIN(context_restore)
-	ldmia r0!, {sp, lr}
-	ldmia r0!, {r4-r11}
 
 	# return 0
 	mov r0, #0
 	mov pc, lr
-FUNCTION_END(context_restore)
+FUNCTION_END(setjmp)
+
+FUNCTION_BEGIN(__longjmp)
+	ldmia r0!, {sp, lr}
+	ldmia r0!, {r4-r11}
+
+	# return second argument
+	mov r0, r1
+	mov pc, lr
+FUNCTION_END(__longjmp)
 

--- a/uspace/lib/c/arch/ia32/src/fibril.S
+++ b/uspace/lib/c/arch/ia32/src/fibril.S
@@ -36,7 +36,7 @@
 # Save CPU context to the context_t variable
 # pointed by the 1st argument. Returns 0 in EAX.
 #
-FUNCTION_BEGIN(setjmp)
+FUNCTION_BEGIN(__setjmp)
 	movl 0(%esp), %eax  # the caller's return %eip
 	movl 4(%esp), %edx  # address of the context variable to save context to
 
@@ -52,9 +52,9 @@ FUNCTION_BEGIN(setjmp)
 	movl %gs:0, %eax
 	movl %eax, CONTEXT_OFFSET_TLS(%edx)	# tls -> ctx->tls
 
-	xorl %eax, %eax		# setjmp returns 0
+	xorl %eax, %eax		# __setjmp returns 0
 	ret
-FUNCTION_END(setjmp)
+FUNCTION_END(__setjmp)
 
 ## Restore saved CPU context
 #

--- a/uspace/lib/c/arch/ia32/src/fibril.S
+++ b/uspace/lib/c/arch/ia32/src/fibril.S
@@ -34,9 +34,9 @@
 ## Save current CPU context
 #
 # Save CPU context to the context_t variable
-# pointed by the 1st argument. Returns 1 in EAX.
+# pointed by the 1st argument. Returns 0 in EAX.
 #
-FUNCTION_BEGIN(context_save)
+FUNCTION_BEGIN(setjmp)
 	movl 0(%esp), %eax  # the caller's return %eip
 	movl 4(%esp), %edx  # address of the context variable to save context to
 
@@ -52,18 +52,18 @@ FUNCTION_BEGIN(context_save)
 	movl %gs:0, %eax
 	movl %eax, CONTEXT_OFFSET_TLS(%edx)	# tls -> ctx->tls
 
-	xorl %eax, %eax		# context_save returns 1
-	incl %eax
+	xorl %eax, %eax		# setjmp returns 0
 	ret
-FUNCTION_END(context_save)
+FUNCTION_END(setjmp)
 
 ## Restore saved CPU context
 #
 # Restore CPU context from context_t variable
-# pointed by the 1st argument. Returns 0 in EAX.
+# pointed by the 1st argument. Returns second argument in EAX.
 #
-FUNCTION_BEGIN(context_restore)
+FUNCTION_BEGIN(__longjmp)
 	movl 4(%esp), %eax  # address of the context variable to restore context from
+	movl 8(%esp), %ecx  # return value
 
 	# restore registers from the context structure
 	movl CONTEXT_OFFSET_SP(%eax),%esp	# ctx->sp -> %esp
@@ -79,7 +79,7 @@ FUNCTION_BEGIN(context_restore)
 	movl CONTEXT_OFFSET_TLS(%eax), %edx	# Set arg1 to TLS addr
 	movl %edx, %gs:0
 
-	xorl %eax, %eax		# context_restore returns 0
+	movl %ecx, %eax
 	ret
-FUNCTION_END(context_restore)
+FUNCTION_END(__longjmp)
 

--- a/uspace/lib/c/arch/ia64/include/libarch/fibril.h
+++ b/uspace/lib/c/arch/ia64/include/libarch/fibril.h
@@ -42,7 +42,7 @@
 #include <libarch/fibril_context.h>
 
 /*
- * context_save() and context_restore() are both leaf procedures.
+ * setjmp() and __longjmp() are both leaf procedures.
  * No need to allocate scratch area.
  */
 #define SP_DELTA  (0 + ALIGN_UP(STACK_ITEM_SIZE, STACK_ALIGNMENT))

--- a/uspace/lib/c/arch/ia64/include/libarch/fibril.h
+++ b/uspace/lib/c/arch/ia64/include/libarch/fibril.h
@@ -42,7 +42,7 @@
 #include <libarch/fibril_context.h>
 
 /*
- * setjmp() and __longjmp() are both leaf procedures.
+ * __setjmp() and __longjmp() are both leaf procedures.
  * No need to allocate scratch area.
  */
 #define SP_DELTA  (0 + ALIGN_UP(STACK_ITEM_SIZE, STACK_ALIGNMENT))

--- a/uspace/lib/c/arch/ia64/src/fibril.S
+++ b/uspace/lib/c/arch/ia64/src/fibril.S
@@ -31,7 +31,7 @@
 
 .text
 
-FUNCTION_BEGIN(context_save)
+FUNCTION_BEGIN(setjmp)
 	alloc loc0 = ar.pfs, 1, 49, 0, 0
 	mov loc1 = ar.unat ;;
 	mov loc3 = ar.rsc
@@ -177,12 +177,12 @@ FUNCTION_BEGIN(context_save)
 
 	mov ar.unat = loc1
 
-	add r8 = r0, r0, 1 	/* context_save returns 1 */
+	mov r8 = 0 	/* setjmp returns 0 */
 	br.ret.sptk.many b0
-FUNCTION_END(context_save)
+FUNCTION_END(setjmp)
 
-FUNCTION_BEGIN(context_restore)
-	alloc loc0 = ar.pfs, 1, 50, 0, 0	;;
+FUNCTION_BEGIN(__longjmp)
+	alloc loc0 = ar.pfs, 2, 51, 0, 0	;;
 
 	add loc9 = CONTEXT_OFFSET_AR_PFS, in0
 	add loc10 = CONTEXT_OFFSET_AR_UNAT_CALLER, in0
@@ -229,7 +229,8 @@ FUNCTION_BEGIN(context_restore)
 	add loc46 = CONTEXT_OFFSET_F28, in0
 	add loc47 = CONTEXT_OFFSET_F29, in0
 	add loc48 = CONTEXT_OFFSET_F30, in0
-	add loc49 = CONTEXT_OFFSET_F31, in0 ;;
+	add loc49 = CONTEXT_OFFSET_F31, in0
+	mov loc50 = in1 ;;
 
 	ld8 loc0 = [loc9]	/* load ar.pfs */
 	ld8 loc1 = [loc10]	/* load ar.unat (caller) */
@@ -334,6 +335,6 @@ FUNCTION_BEGIN(context_restore)
 
 	mov ar.unat = loc1
 
-	mov r8 = r0			/* context_restore returns 0 */
+	mov r8 = loc50			/* __longjmp returns second argument */
 	br.ret.sptk.many b0
-FUNCTION_END(context_restore)
+FUNCTION_END(__longjmp)

--- a/uspace/lib/c/arch/ia64/src/fibril.S
+++ b/uspace/lib/c/arch/ia64/src/fibril.S
@@ -31,7 +31,7 @@
 
 .text
 
-FUNCTION_BEGIN(setjmp)
+FUNCTION_BEGIN(__setjmp)
 	alloc loc0 = ar.pfs, 1, 49, 0, 0
 	mov loc1 = ar.unat ;;
 	mov loc3 = ar.rsc
@@ -177,9 +177,9 @@ FUNCTION_BEGIN(setjmp)
 
 	mov ar.unat = loc1
 
-	mov r8 = 0 	/* setjmp returns 0 */
+	mov r8 = 0 	/* __setjmp returns 0 */
 	br.ret.sptk.many b0
-FUNCTION_END(setjmp)
+FUNCTION_END(__setjmp)
 
 FUNCTION_BEGIN(__longjmp)
 	alloc loc0 = ar.pfs, 2, 51, 0, 0	;;

--- a/uspace/lib/c/arch/mips32/src/fibril.S
+++ b/uspace/lib/c/arch/mips32/src/fibril.S
@@ -34,7 +34,7 @@
 #include <abi/asmtool.h>
 #include <libarch/fibril_context.h>
 
-FUNCTION_BEGIN(setjmp)
+FUNCTION_BEGIN(__setjmp)
 	sw $s0, CONTEXT_OFFSET_S0($a0)
 	sw $s1, CONTEXT_OFFSET_S1($a0)
 	sw $s2, CONTEXT_OFFSET_S2($a0)
@@ -86,10 +86,10 @@ FUNCTION_BEGIN(setjmp)
 	sw $ra, CONTEXT_OFFSET_PC($a0)
 	sw $sp, CONTEXT_OFFSET_SP($a0)
 
-	# setjmp returns 0
+	# __setjmp returns 0
 	j $ra
 	li $v0, 0
-FUNCTION_END(setjmp)
+FUNCTION_END(__setjmp)
 
 FUNCTION_BEGIN(__longjmp)
 	lw $s0, CONTEXT_OFFSET_S0($a0)

--- a/uspace/lib/c/arch/mips32/src/fibril.S
+++ b/uspace/lib/c/arch/mips32/src/fibril.S
@@ -34,7 +34,7 @@
 #include <abi/asmtool.h>
 #include <libarch/fibril_context.h>
 
-FUNCTION_BEGIN(context_save)
+FUNCTION_BEGIN(setjmp)
 	sw $s0, CONTEXT_OFFSET_S0($a0)
 	sw $s1, CONTEXT_OFFSET_S1($a0)
 	sw $s2, CONTEXT_OFFSET_S2($a0)
@@ -86,12 +86,12 @@ FUNCTION_BEGIN(context_save)
 	sw $ra, CONTEXT_OFFSET_PC($a0)
 	sw $sp, CONTEXT_OFFSET_SP($a0)
 
-	# context_save returns 1
+	# setjmp returns 0
 	j $ra
-	li $v0, 1
-FUNCTION_END(context_save)
+	li $v0, 0
+FUNCTION_END(setjmp)
 
-FUNCTION_BEGIN(context_restore)
+FUNCTION_BEGIN(__longjmp)
 	lw $s0, CONTEXT_OFFSET_S0($a0)
 	lw $s1, CONTEXT_OFFSET_S1($a0)
 	lw $s2, CONTEXT_OFFSET_S2($a0)
@@ -146,7 +146,7 @@ FUNCTION_BEGIN(context_restore)
 	# but one instruction should not bother us
 	move $t9, $ra
 
-	# context_restore returns 0
+	# __longjmp returns second argument
 	j $ra
-	xor $v0, $v0
-FUNCTION_END(context_restore)
+	move $v0, $a1
+FUNCTION_END(__longjmp)

--- a/uspace/lib/c/arch/ppc32/src/fibril.S
+++ b/uspace/lib/c/arch/ppc32/src/fibril.S
@@ -32,7 +32,7 @@
 #include <libarch/regname.h>
 #include <libarch/fibril_context.h>
 
-FUNCTION_BEGIN(setjmp)
+FUNCTION_BEGIN(__setjmp)
 	stw sp, CONTEXT_OFFSET_SP(r3)
 	stw r2, CONTEXT_OFFSET_TLS(r3)
 	stw r13, CONTEXT_OFFSET_R13(r3)
@@ -61,10 +61,10 @@ FUNCTION_BEGIN(setjmp)
 	mfcr r4
 	stw r4, CONTEXT_OFFSET_CR(r3)
 
-	# setjmp returns 0
+	# __setjmp returns 0
 	li r3, 0
 	blr
-FUNCTION_END(setjmp)
+FUNCTION_END(__setjmp)
 
 FUNCTION_BEGIN(__longjmp)
 	lwz sp, CONTEXT_OFFSET_SP(r3)

--- a/uspace/lib/c/arch/ppc32/src/fibril.S
+++ b/uspace/lib/c/arch/ppc32/src/fibril.S
@@ -96,6 +96,6 @@ FUNCTION_BEGIN(__longjmp)
 	mtlr r5
 
 	# __longjmp returns second argument
-	li r3, r4
+	mr r3, r4
 	blr
 FUNCTION_END(__longjmp)

--- a/uspace/lib/c/arch/ppc32/src/fibril.S
+++ b/uspace/lib/c/arch/ppc32/src/fibril.S
@@ -32,7 +32,7 @@
 #include <libarch/regname.h>
 #include <libarch/fibril_context.h>
 
-FUNCTION_BEGIN(context_save)
+FUNCTION_BEGIN(setjmp)
 	stw sp, CONTEXT_OFFSET_SP(r3)
 	stw r2, CONTEXT_OFFSET_TLS(r3)
 	stw r13, CONTEXT_OFFSET_R13(r3)
@@ -61,12 +61,12 @@ FUNCTION_BEGIN(context_save)
 	mfcr r4
 	stw r4, CONTEXT_OFFSET_CR(r3)
 
-	# context_save returns 1
-	li r3, 1
+	# setjmp returns 0
+	li r3, 0
 	blr
-FUNCTION_END(context_save)
+FUNCTION_END(setjmp)
 
-FUNCTION_BEGIN(context_restore)
+FUNCTION_BEGIN(__longjmp)
 	lwz sp, CONTEXT_OFFSET_SP(r3)
 	lwz r2, CONTEXT_OFFSET_TLS(r3)
 	lwz r13, CONTEXT_OFFSET_R13(r3)
@@ -89,13 +89,13 @@ FUNCTION_BEGIN(context_restore)
 	lwz r30, CONTEXT_OFFSET_R30(r3)
 	lwz r31, CONTEXT_OFFSET_R31(r3)
 
-	lwz r4, CONTEXT_OFFSET_CR(r3)
-	mtcr r4
+	lwz r5, CONTEXT_OFFSET_CR(r3)
+	mtcr r5
 
-	lwz r4, CONTEXT_OFFSET_PC(r3)
-	mtlr r4
+	lwz r5, CONTEXT_OFFSET_PC(r3)
+	mtlr r5
 
-	# context_restore returns 0
-	li r3, 0
+	# __longjmp returns second argument
+	li r3, r4
 	blr
-FUNCTION_END(context_restore)
+FUNCTION_END(__longjmp)

--- a/uspace/lib/c/arch/riscv64/src/fibril.c
+++ b/uspace/lib/c/arch/riscv64/src/fibril.c
@@ -32,12 +32,12 @@
 #include <fibril.h>
 #include <stdbool.h>
 
-int context_save(context_t *ctx)
+int setjmp(context_t *ctx)
 {
-	return 1;
+	return 0;
 }
 
-void context_restore(context_t *ctx)
+void __longjmp(context_t *ctx, int ret)
 {
 	while (true);
 }

--- a/uspace/lib/c/arch/riscv64/src/fibril.c
+++ b/uspace/lib/c/arch/riscv64/src/fibril.c
@@ -32,7 +32,7 @@
 #include <fibril.h>
 #include <stdbool.h>
 
-int setjmp(context_t *ctx)
+int __setjmp(context_t *ctx)
 {
 	return 0;
 }

--- a/uspace/lib/c/arch/sparc64/src/fibril.S
+++ b/uspace/lib/c/arch/sparc64/src/fibril.S
@@ -31,7 +31,7 @@
 
 .text
 
-FUNCTION_BEGIN(setjmp)
+FUNCTION_BEGIN(__setjmp)
 	#
 	# We rely on the kernel to flush our active register windows to memory
 	# should a thread switch occur.
@@ -56,8 +56,8 @@ FUNCTION_BEGIN(setjmp)
 	stx %l7, [%o0 + CONTEXT_OFFSET_L7]
 	stx %g7, [%o0 + CONTEXT_OFFSET_TP]
 	retl
-	mov 0, %o0		! setjmp returns 0
-FUNCTION_END(setjmp)
+	mov 0, %o0		! __setjmp returns 0
+FUNCTION_END(__setjmp)
 
 FUNCTION_BEGIN(__longjmp)
 	#

--- a/uspace/lib/c/arch/sparc64/src/fibril.S
+++ b/uspace/lib/c/arch/sparc64/src/fibril.S
@@ -31,7 +31,7 @@
 
 .text
 
-FUNCTION_BEGIN(context_save)
+FUNCTION_BEGIN(setjmp)
 	#
 	# We rely on the kernel to flush our active register windows to memory
 	# should a thread switch occur.
@@ -56,10 +56,10 @@ FUNCTION_BEGIN(context_save)
 	stx %l7, [%o0 + CONTEXT_OFFSET_L7]
 	stx %g7, [%o0 + CONTEXT_OFFSET_TP]
 	retl
-	mov 1, %o0		! context_save_arch returns 1
-FUNCTION_END(context_save)
+	mov 0, %o0		! setjmp returns 0
+FUNCTION_END(setjmp)
 
-FUNCTION_BEGIN(context_restore)
+FUNCTION_BEGIN(__longjmp)
 	#
 	# Flush all active windows.
 	# This is essential, because CONTEXT_RESTORE_ARCH_CORE overwrites %sp of
@@ -88,5 +88,5 @@ FUNCTION_BEGIN(context_restore)
 	ldx [%o0 + CONTEXT_OFFSET_L7], %l7
 	ldx [%o0 + CONTEXT_OFFSET_TP], %g7
 	retl
-	xor %o0, %o0, %o0	! context_restore_arch returns 0
-FUNCTION_END(context_restore)
+	mov %o1, %o0	! __longjmp returns second argument
+FUNCTION_END(__longjmp)

--- a/uspace/lib/c/generic/context.c
+++ b/uspace/lib/c/generic/context.c
@@ -42,13 +42,13 @@
  */
 void context_swap(context_t *self, context_t *other)
 {
-	if (!setjmp(self))
+	if (!__setjmp(self))
 		__longjmp(other, 1);
 }
 
 void context_create(context_t *context, const context_create_t *arg)
 {
-	setjmp(context);
+	__setjmp(context);
 	context_set(context, FADDR(arg->fn), arg->stack_base,
 	    arg->stack_size, arg->tls);
 }

--- a/uspace/lib/c/generic/context.c
+++ b/uspace/lib/c/generic/context.c
@@ -27,6 +27,7 @@
  */
 
 #include <context.h>
+#include <setjmp.h>
 #include <libarch/tls.h>
 #include <libarch/fibril.h>
 #include <libarch/faddr.h>
@@ -41,13 +42,13 @@
  */
 void context_swap(context_t *self, context_t *other)
 {
-	if (context_save(self))
-		context_restore(other);
+	if (!setjmp(self))
+		__longjmp(other, 1);
 }
 
 void context_create(context_t *context, const context_create_t *arg)
 {
-	context_save(context);
+	setjmp(context);
 	context_set(context, FADDR(arg->fn), arg->stack_base,
 	    arg->stack_size, arg->tls);
 }

--- a/uspace/lib/c/generic/setjmp.c
+++ b/uspace/lib/c/generic/setjmp.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013 Vojtech Horky
+ * Copyright (c) 2018 CZ.NIC, z.s.p.o.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,32 +30,15 @@
 /** @addtogroup libc
  * @{
  */
-/** @file Long jump implementation.
- *
- * Implementation inspired by Jiri Zarevucky's code from
- * http://bazaar.launchpad.net/~zarevucky-jiri/helenos/stdc/revision/1544/uspace/lib/posix/setjmp.h
- */
 
 #include <setjmp.h>
 #include <context.h>
 
-// TODO: setjmp/longjmp are basically a stronger version of
-// context_save/context_restore. It would be preferable to turn
-// those two into setjmp/longjmp (all it would need is preserving the
-// return value).
-
-/**
- * Restore environment previously stored by setjmp.
- *
- * This function never returns.
- *
- * @param env Variable with the environment previously stored by call
- * to setjmp.
- * @param val Value to fake when returning from setjmp (0 is transformed to 1).
- */
-void longjmp(jmp_buf env, int val) {
-	env[0].return_value = (val == 0) ? 1 : val;
-	context_restore(&env[0].context);
+/** Standard function implementation. */
+void longjmp(jmp_buf env, int val)
+{
+	/* __longjmp defined in assembly doesn't "correct" the value. */
+	__longjmp(env, val == 0 ? 1 : val);
 }
 
 /** @}

--- a/uspace/lib/c/include/context.h
+++ b/uspace/lib/c/include/context.h
@@ -45,10 +45,5 @@ extern void context_create(context_t *context, const context_create_t *arg);
 extern uintptr_t context_get_fp(context_t *ctx);
 extern uintptr_t context_get_pc(context_t *ctx);
 
-// TODO: These should go away.
-
-extern int context_save(context_t *ctx) __attribute__((returns_twice));
-extern void context_restore(context_t *ctx) __attribute__((noreturn));
-
 #endif
 

--- a/uspace/lib/c/include/setjmp.h
+++ b/uspace/lib/c/include/setjmp.h
@@ -37,9 +37,11 @@
 
 typedef context_t jmp_buf[1];
 
-extern int setjmp(jmp_buf) __attribute__((returns_twice));
-extern void longjmp(jmp_buf, int) __attribute__((noreturn));
-extern void __longjmp(jmp_buf, int) __attribute__((noreturn));
+extern int __setjmp(jmp_buf) __attribute__((returns_twice));
+extern _Noreturn void __longjmp(jmp_buf, int);
+
+#define setjmp __setjmp
+extern _Noreturn void longjmp(jmp_buf, int);
 
 #endif
 

--- a/uspace/lib/c/include/setjmp.h
+++ b/uspace/lib/c/include/setjmp.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2008 Josef Cejka
- * Copyright (c) 2013 Vojtech Horky
+ * Copyright (c) 2018 CZ.NIC, z.s.p.o.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,45 +29,17 @@
 /** @addtogroup libc
  * @{
  */
-/** @file Long jump implementation.
- *
- * Implementation inspired by Jiri Zarevucky's code from
- * http://bazaar.launchpad.net/~zarevucky-jiri/helenos/stdc/revision/1544/uspace/lib/posix/setjmp.h
- */
 
 #ifndef LIBC_SETJMP_H_
 #define LIBC_SETJMP_H_
 
-#include <libarch/fibril.h>
+#include <libarch/fibril_context.h>
 
-struct jmp_buf_interal {
-	context_t context;
-	int return_value;
-};
-typedef struct jmp_buf_interal jmp_buf[1];
+typedef context_t jmp_buf[1];
 
-/*
- * Specified as extern to minimize number of included headers
- * because this file is used as is in libposix too.
- */
-extern int context_save(context_t *ctx) __attribute__((returns_twice));
-
-/**
- * Save current environment (registers).
- *
- * This function may return twice.
- *
- * @param env Variable where to save the environment (of type jmp_buf).
- * @return Whether the call returned after longjmp.
- * @retval 0 Environment was saved, normal execution.
- * @retval other longjmp was executed and returned here.
- */
-#define setjmp(env) \
-	((env)[0].return_value = 0, \
-	context_save(&(env)[0].context), \
-	(env)[0].return_value)
-
-extern void longjmp(jmp_buf env, int val) __attribute__((noreturn));
+extern int setjmp(jmp_buf) __attribute__((returns_twice));
+extern void longjmp(jmp_buf, int) __attribute__((noreturn));
+extern void __longjmp(jmp_buf, int) __attribute__((noreturn));
 
 #endif
 


### PR DESCRIPTION
Since they already _almost_ are identical, this just closes the tiny gap and removes an ugly hack from the standard library in the process.

The assembly changes need to be reviewed by more eyes though.