### PR TITLE
Noreclaimers

### DIFF
--- a/kernel/generic/include/cap/cap.h
+++ b/kernel/generic/include/cap/cap.h
@@ -63,9 +63,7 @@ struct call;
 struct irq;
 struct phone;
 
-struct kobject;
 typedef struct kobject_ops {
-	bool (*reclaim)(struct kobject *);
 	void (*destroy)(void *);
 } kobject_ops_t;
 

--- a/kernel/generic/include/ipc/ipc.h
+++ b/kernel/generic/include/ipc/ipc.h
@@ -176,7 +176,7 @@ typedef struct call {
 
 extern slab_cache_t *phone_cache;
 
-extern answerbox_t *ipc_phone_0;
+extern answerbox_t *ipc_box_0;
 
 extern void ipc_init(void);
 

--- a/kernel/generic/include/ipc/ipc.h
+++ b/kernel/generic/include/ipc/ipc.h
@@ -81,6 +81,11 @@ typedef struct answerbox {
 
 	waitq_t wq;
 
+	/**
+	 * Number of answers the answerbox is expecting to eventually arrive.
+	 */
+	atomic_t active_calls;
+
 	/** Phones connected to this answerbox. */
 	list_t connected_phones;
 	/** Received calls. */

--- a/kernel/generic/include/ipc/ipcrsc.h
+++ b/kernel/generic/include/ipc/ipcrsc.h
@@ -40,7 +40,6 @@
 #include <cap/cap.h>
 
 extern errno_t phone_alloc(task_t *, bool, cap_handle_t *, kobject_t **);
-extern bool phone_connect(cap_handle_t, answerbox_t *);
 extern void phone_dealloc(cap_handle_t);
 
 #endif

--- a/kernel/generic/include/ipc/ipcrsc.h
+++ b/kernel/generic/include/ipc/ipcrsc.h
@@ -39,7 +39,7 @@
 #include <ipc/ipc.h>
 #include <cap/cap.h>
 
-extern errno_t phone_alloc(task_t *, cap_handle_t *);
+extern errno_t phone_alloc(task_t *, bool, cap_handle_t *, kobject_t **);
 extern bool phone_connect(cap_handle_t, answerbox_t *);
 extern void phone_dealloc(cap_handle_t);
 

--- a/kernel/generic/src/ipc/ipc.c
+++ b/kernel/generic/src/ipc/ipc.c
@@ -350,7 +350,10 @@ static void _ipc_call_actions_internal(phone_t *phone, call_t *call,
 		call->forget = true;
 	} else {
 		atomic_inc(&phone->active_calls);
-		atomic_inc(&caller->answerbox.active_calls);
+		if (call->callerbox)
+			atomic_inc(&call->callerbox->active_calls);
+		else
+			atomic_inc(&caller->answerbox.active_calls);
 		kobject_add_ref(phone->kobject);
 		call->sender = caller;
 		call->active = true;

--- a/kernel/generic/src/ipc/ipc.c
+++ b/kernel/generic/src/ipc/ipc.c
@@ -349,6 +349,7 @@ static void _ipc_call_actions_internal(phone_t *phone, call_t *call,
 		call->forget = true;
 	} else {
 		atomic_inc(&phone->active_calls);
+		kobject_add_ref(phone->kobject);
 		call->sender = caller;
 		call->active = true;
 		spinlock_lock(&caller->active_calls_lock);
@@ -562,6 +563,7 @@ restart:
 		    call_t, ab_link);
 		list_remove(&request->ab_link);
 		atomic_dec(&request->caller_phone->active_calls);
+		kobject_put(request->caller_phone->kobject);
 	} else if (!list_empty(&box->calls)) {
 		/* Count received call */
 		call_cnt++;
@@ -706,6 +708,7 @@ static void ipc_forget_call(call_t *call)
 	spinlock_unlock(&TASK->active_calls_lock);
 
 	atomic_dec(&call->caller_phone->active_calls);
+	kobject_put(call->caller_phone->kobject);
 
 	SYSIPC_OP(request_forget, call);
 

--- a/kernel/generic/src/ipc/ipc.c
+++ b/kernel/generic/src/ipc/ipc.c
@@ -439,8 +439,8 @@ errno_t ipc_call(phone_t *phone, call_t *call)
 
 /** Disconnect phone from answerbox.
  *
- * This call leaves the phone in the HUNGUP state. The change to 'free' is done
- * lazily later.
+ * This call leaves the phone in the hung-up state. The phone is destroyed when
+ * its last active call is answered and there are no references to it.
  *
  * @param phone Phone structure to be hung up.
  *
@@ -754,11 +754,6 @@ static bool phone_cap_wait_cb(cap_t *cap, void *arg)
 	bool *restart = (bool *) arg;
 
 	mutex_lock(&phone->lock);
-	if ((phone->state == IPC_PHONE_HUNGUP) &&
-	    (atomic_get(&phone->active_calls) == 0)) {
-		phone->state = IPC_PHONE_FREE;
-		phone->callee = NULL;
-	}
 
 	/*
 	 * We might have had some IPC_PHONE_CONNECTING phones at the beginning

--- a/kernel/generic/src/ipc/ipc.c
+++ b/kernel/generic/src/ipc/ipc.c
@@ -922,7 +922,7 @@ static bool print_task_phone_cb(cap_t *cap, void *arg)
 			printf("slammed by %p", phone->callee);
 			break;
 		case IPC_PHONE_HUNGUP:
-			printf("hung up by %p", phone->callee);
+			printf("hung up to %p", phone->callee);
 			break;
 		default:
 			break;

--- a/kernel/generic/src/ipc/ipc.c
+++ b/kernel/generic/src/ipc/ipc.c
@@ -62,8 +62,8 @@
 
 static void ipc_forget_call(call_t *);
 
-/** Open channel that is assigned automatically to new tasks */
-answerbox_t *ipc_phone_0 = NULL;
+/** Answerbox that new tasks are automatically connected to */
+answerbox_t *ipc_box_0 = NULL;
 
 static slab_cache_t *call_cache;
 static slab_cache_t *answerbox_cache;

--- a/kernel/generic/src/ipc/ipc.c
+++ b/kernel/generic/src/ipc/ipc.c
@@ -160,13 +160,13 @@ void ipc_answerbox_init(answerbox_t *box, task_t *task)
  */
 bool ipc_phone_connect(phone_t *phone, answerbox_t *box)
 {
-	bool active;
+	bool connected;
 
 	mutex_lock(&phone->lock);
 	irq_spinlock_lock(&box->lock, true);
 
-	active = box->active;
-	if (active) {
+	connected = box->active && (phone->state == IPC_PHONE_CONNECTING);
+	if (connected) {
 		phone->state = IPC_PHONE_CONNECTED;
 		phone->callee = box;
 		/* Pass phone->kobject reference to box->connected_phones */
@@ -176,12 +176,12 @@ bool ipc_phone_connect(phone_t *phone, answerbox_t *box)
 	irq_spinlock_unlock(&box->lock, true);
 	mutex_unlock(&phone->lock);
 
-	if (!active) {
+	if (!connected) {
 		/* We still have phone->kobject's reference; drop it */
 		kobject_put(phone->kobject);
 	}
 
-	return active;
+	return connected;
 }
 
 /** Initialize a phone structure.

--- a/kernel/generic/src/ipc/ipc.c
+++ b/kernel/generic/src/ipc/ipc.c
@@ -959,6 +959,9 @@ void ipc_print_task(task_id_t taskid)
 	irq_spinlock_lock(&task->lock, true);
 	irq_spinlock_lock(&task->answerbox.lock, false);
 
+	printf("Active calls: %" PRIun "\n",
+	    atomic_get(&task->answerbox.active_calls));
+
 #ifdef __32_BITS__
 	printf("[call id ] [method] [arg1] [arg2] [arg3] [arg4] [arg5]"
 	    " [flags] [sender\n");

--- a/kernel/generic/src/ipc/ipcrsc.c
+++ b/kernel/generic/src/ipc/ipcrsc.c
@@ -218,7 +218,14 @@ bool phone_connect(cap_handle_t handle, answerbox_t *box)
 	if (!phone_obj)
 		return false;
 
-	assert(phone_obj->phone->state == IPC_PHONE_CONNECTING);
+	if (phone_obj->phone->state != IPC_PHONE_CONNECTING) {
+		/*
+		 * This looks like another phone. The one we were expecting
+		 * under this handle must be in the IPC_PHONE_CONNECTING state.
+		 */
+		kobject_put(phone_obj);
+		return false;
+	}
 
 	/* Hand over phone_obj reference to the answerbox */
 	return ipc_phone_connect(phone_obj->phone, box);

--- a/kernel/generic/src/ipc/ipcrsc.c
+++ b/kernel/generic/src/ipc/ipcrsc.c
@@ -199,7 +199,6 @@ void phone_dealloc(cap_handle_t handle)
 	if (!kobj)
 		return;
 
-	assert(kobj->phone);
 	assert(kobj->phone->state == IPC_PHONE_CONNECTING);
 
 	kobject_put(kobj);

--- a/kernel/generic/src/ipc/ipcrsc.c
+++ b/kernel/generic/src/ipc/ipcrsc.c
@@ -215,15 +215,6 @@ bool phone_connect(cap_handle_t handle, answerbox_t *box)
 	if (!phone_obj)
 		return false;
 
-	if (phone_obj->phone->state != IPC_PHONE_CONNECTING) {
-		/*
-		 * This looks like another phone. The one we were expecting
-		 * under this handle must be in the IPC_PHONE_CONNECTING state.
-		 */
-		kobject_put(phone_obj);
-		return false;
-	}
-
 	/* Hand over phone_obj reference to the answerbox */
 	return ipc_phone_connect(phone_obj->phone, box);
 }

--- a/kernel/generic/src/ipc/ipcrsc.c
+++ b/kernel/generic/src/ipc/ipcrsc.c
@@ -136,19 +136,6 @@
 #include <cap/cap.h>
 #include <mm/slab.h>
 
-static bool phone_reclaim(kobject_t *kobj)
-{
-	bool gc = false;
-
-	mutex_lock(&kobj->phone->lock);
-	if (kobj->phone->state == IPC_PHONE_HUNGUP &&
-	    atomic_get(&kobj->phone->active_calls) == 0)
-		gc = true;
-	mutex_unlock(&kobj->phone->lock);
-
-	return gc;
-}
-
 static void phone_destroy(void *arg)
 {
 	phone_t *phone = (phone_t *) arg;
@@ -156,7 +143,6 @@ static void phone_destroy(void *arg)
 }
 
 static kobject_ops_t phone_kobject_ops = {
-	.reclaim = phone_reclaim,
 	.destroy = phone_destroy
 };
 

--- a/kernel/generic/src/ipc/ipcrsc.c
+++ b/kernel/generic/src/ipc/ipcrsc.c
@@ -208,21 +208,5 @@ void phone_dealloc(cap_handle_t handle)
 	cap_free(TASK, handle);
 }
 
-/** Connect phone to a given answerbox.
- *
- * @param handle  Capability handle of the phone to be connected.
- * @param box     Answerbox to which to connect the phone.
- * @return        True if the phone was connected, false otherwise.
- */
-bool phone_connect(cap_handle_t handle, answerbox_t *box)
-{
-	kobject_t *phone_obj = kobject_get(TASK, handle, KOBJECT_TYPE_PHONE);
-	if (!phone_obj)
-		return false;
-
-	/* Hand over phone_obj reference to the answerbox */
-	return ipc_phone_connect(phone_obj->phone, box);
-}
-
 /** @}
  */

--- a/kernel/generic/src/ipc/ipcrsc.c
+++ b/kernel/generic/src/ipc/ipcrsc.c
@@ -199,8 +199,6 @@ void phone_dealloc(cap_handle_t handle)
 	if (!kobj)
 		return;
 
-	assert(kobj->phone->state == IPC_PHONE_CONNECTING);
-
 	kobject_put(kobj);
 	cap_free(TASK, handle);
 }

--- a/kernel/generic/src/ipc/kbox.c
+++ b/kernel/generic/src/ipc/kbox.c
@@ -252,7 +252,7 @@ errno_t ipc_connect_kbox(task_id_t taskid, cap_handle_t *out_phone)
 
 	/* Allocate a new phone. */
 	cap_handle_t phone_handle;
-	errno_t rc = phone_alloc(TASK, &phone_handle);
+	errno_t rc = phone_alloc(TASK, true, &phone_handle, NULL);
 	if (rc != EOK) {
 		mutex_unlock(&task->kb.cleanup_lock);
 		return rc;

--- a/kernel/generic/src/ipc/ops/conctmeto.c
+++ b/kernel/generic/src/ipc/ops/conctmeto.c
@@ -51,9 +51,17 @@ static errno_t request_preprocess(call_t *call, phone_t *phone)
 		return rc;
 	}
 
-	/* Set arg5 for server */
+	/* Set ARG5 for server */
 	kobject_t *phone_obj = kobject_get(TASK, phone_handle,
 	    KOBJECT_TYPE_PHONE);
+	if (!phone_obj) {
+		/*
+		 * Another thread of the same task can destroy the new
+		 * capability before we manage to get a reference from it.
+		 */
+		call->priv = -1;
+		return ENOENT;
+	}
 	/* Hand over phone_obj's reference to ARG5 */
 	IPC_SET_ARG5(call->data, (sysarg_t) phone_obj->phone);
 

--- a/kernel/generic/src/ipc/ops/concttome.c
+++ b/kernel/generic/src/ipc/ops/concttome.c
@@ -73,7 +73,7 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 	} else if (phone_handle >= 0) {
 		/*
 		 * The connection was accepted
-		 * */
+		 */
 
 		/*
 		 * We need to create another reference as the one we have now

--- a/kernel/generic/src/ipc/ops/concttome.c
+++ b/kernel/generic/src/ipc/ops/concttome.c
@@ -42,7 +42,7 @@
 static int request_process(call_t *call, answerbox_t *box)
 {
 	cap_handle_t phone_handle;
-	errno_t rc = phone_alloc(TASK, &phone_handle);
+	errno_t rc = phone_alloc(TASK, true, &phone_handle, NULL);
 	IPC_SET_ARG5(call->data, (rc == EOK) ? phone_handle : -1);
 	return 0;
 }

--- a/kernel/generic/src/ipc/ops/concttome.c
+++ b/kernel/generic/src/ipc/ops/concttome.c
@@ -42,7 +42,9 @@
 static int request_process(call_t *call, answerbox_t *box)
 {
 	cap_handle_t phone_handle;
-	errno_t rc = phone_alloc(TASK, true, &phone_handle, NULL);
+	kobject_t *phone_obj;
+	errno_t rc = phone_alloc(TASK, false, &phone_handle, &phone_obj);
+	call->priv = (sysarg_t) phone_obj;
 	IPC_SET_ARG5(call->data, (rc == EOK) ? phone_handle : -1);
 	return 0;
 }
@@ -50,9 +52,12 @@ static int request_process(call_t *call, answerbox_t *box)
 static errno_t answer_cleanup(call_t *answer, ipc_data_t *olddata)
 {
 	cap_handle_t phone_handle = (cap_handle_t) IPC_GET_ARG5(*olddata);
+	kobject_t *phone_obj = (kobject_t *) answer->priv;
 
-	if (phone_handle >= 0)
-		phone_dealloc(phone_handle);
+	if (phone_handle >= 0) {
+		kobject_put(phone_obj);
+		cap_free(TASK, phone_handle);
+	}
 
 	return EOK;
 }
@@ -60,19 +65,29 @@ static errno_t answer_cleanup(call_t *answer, ipc_data_t *olddata)
 static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 {
 	cap_handle_t phone_handle = (cap_handle_t) IPC_GET_ARG5(*olddata);
+	kobject_t *phone_obj = (kobject_t *) answer->priv;
 
 	if (IPC_GET_RETVAL(answer->data) != EOK) {
 		/* The connection was not accepted */
 		answer_cleanup(answer, olddata);
 	} else if (phone_handle >= 0) {
-		/* The connection was accepted */
-		if (phone_connect(phone_handle, &answer->sender->answerbox)) {
+		/*
+		 * The connection was accepted
+		 * */
+
+		/*
+		 * We need to create another reference as the one we have now
+		 * will be consumed by ipc_phone_connect().
+		 */
+		kobject_add_ref(phone_obj);
+
+		if (ipc_phone_connect(phone_obj->phone,
+		    &answer->sender->answerbox)) {
+			/* Pass the reference to the capability */
+			cap_publish(TASK, phone_handle, phone_obj);
 			/* Set 'phone hash' as ARG5 of response */
-			kobject_t *phone_obj = kobject_get(TASK, phone_handle,
-			    KOBJECT_TYPE_PHONE);
 			IPC_SET_ARG5(answer->data,
 			    (sysarg_t) phone_obj->phone);
-			kobject_put(phone_obj);
 		} else {
 			/* The answerbox is shutting down. */
 			IPC_SET_RETVAL(answer->data, ENOENT);

--- a/kernel/generic/src/ipc/sysipc.c
+++ b/kernel/generic/src/ipc/sysipc.c
@@ -723,12 +723,13 @@ sys_errno_t sys_ipc_answer_slow(sysarg_t chandle, ipc_data_t *data)
  */
 sys_errno_t sys_ipc_hangup(sysarg_t handle)
 {
-	kobject_t *kobj = kobject_get(TASK, handle, KOBJECT_TYPE_PHONE);
+	kobject_t *kobj = cap_unpublish(TASK, handle, KOBJECT_TYPE_PHONE);
 	if (!kobj)
 		return ENOENT;
 
 	errno_t rc = ipc_phone_hangup(kobj->phone);
 	kobject_put(kobj);
+	cap_free(TASK, handle);
 	return rc;
 }
 

--- a/kernel/generic/src/main/kinit.c
+++ b/kernel/generic/src/main/kinit.c
@@ -264,11 +264,11 @@ void kinit(void *arg)
 				    PERM_PERM | PERM_MEM_MANAGER |
 				    PERM_IO_MANAGER | PERM_IRQ_REG);
 
-				if (!ipc_phone_0) {
-					ipc_phone_0 = &programs[i].task->answerbox;
+				if (!ipc_box_0) {
+					ipc_box_0 = &programs[i].task->answerbox;
 					/*
-					 * Hold the first task so that the
-					 * ipc_phone_0 remains a valid pointer
+					 * Hold the first task so that
+					 * ipc_box_0 remains a valid pointer
 					 * even if the first task exits for
 					 * whatever reason.
 					 */

--- a/kernel/generic/src/proc/task.c
+++ b/kernel/generic/src/proc/task.c
@@ -128,9 +128,9 @@ void task_done(void)
 {
 	size_t tasks_left;
 
-	if (ipc_phone_0) {
-		task_t *task_0 = ipc_phone_0->task;
-		ipc_phone_0 = NULL;
+	if (ipc_box_0) {
+		task_t *task_0 = ipc_box_0->task;
+		ipc_box_0 = NULL;
 		/*
 		 * The first task is held by kinit(), we need to release it or
 		 * it will never finish cleanup.
@@ -242,8 +242,8 @@ task_t *task_create(as_t *as, const char *name)
 	task->kb.finished = false;
 #endif
 
-	if ((ipc_phone_0) &&
-	    (container_check(ipc_phone_0->task->container, task->container))) {
+	if ((ipc_box_0) &&
+	    (container_check(ipc_box_0->task->container, task->container))) {
 		cap_handle_t phone_handle;
 		errno_t rc = phone_alloc(task, &phone_handle);
 		if (rc != EOK) {
@@ -255,7 +255,7 @@ task_t *task_create(as_t *as, const char *name)
 
 		kobject_t *phone_obj = kobject_get(task, phone_handle,
 		    KOBJECT_TYPE_PHONE);
-		(void) ipc_phone_connect(phone_obj->phone, ipc_phone_0);
+		(void) ipc_phone_connect(phone_obj->phone, ipc_box_0);
 	}
 
 	futex_task_init(task);

--- a/kernel/generic/src/proc/task.c
+++ b/kernel/generic/src/proc/task.c
@@ -245,7 +245,7 @@ task_t *task_create(as_t *as, const char *name)
 	if ((ipc_box_0) &&
 	    (container_check(ipc_box_0->task->container, task->container))) {
 		cap_handle_t phone_handle;
-		errno_t rc = phone_alloc(task, &phone_handle);
+		errno_t rc = phone_alloc(task, true, &phone_handle, NULL);
 		if (rc != EOK) {
 			task->as = NULL;
 			task_destroy_arch(task);


### PR DESCRIPTION
This branch contains the removal of the so-called capability reclaiming which simplifies capability allocation in that it is no longer necessary to go through the existing capabilities in an attempt to reclaim some unused one. In the course of these changes, I slightly refactored the ipc_cleanup() mechanism and provided a race-free implementation of connect_me_to and connect_to_me. In the new scheme, the new phone is first connected and only then is its capability published (made visible to userspace). Thus it cannot be fiddled with from userspace in the meantime and pathological ipc_cleanup() scenarios such as connected phones that are only reachable from the answerbox they are connected to (but not from their own task) cannot occur.