### PR TITLE
Change the way page flags work.

### DIFF
--- a/kernel/arch/abs32le/include/arch/mm/page.h
+++ b/kernel/arch/abs32le/include/arch/mm/page.h
@@ -91,9 +91,9 @@
 #define GET_PTL1_FLAGS_ARCH(ptl0, i) \
 	get_pt_flags((pte_t *) (ptl0), (size_t) (i))
 #define GET_PTL2_FLAGS_ARCH(ptl1, i) \
-	PAGE_PRESENT
+	PAGE_NEXT_LEVEL_PT
 #define GET_PTL3_FLAGS_ARCH(ptl2, i) \
-	PAGE_PRESENT
+	PAGE_NEXT_LEVEL_PT
 #define GET_FRAME_FLAGS_ARCH(ptl3, i) \
 	get_pt_flags((pte_t *) (ptl3), (size_t) (i))
 
@@ -120,9 +120,12 @@
 	((p)->present != 0)
 #define PTE_GET_FRAME_ARCH(p) \
 	((p)->frame_address << FRAME_WIDTH)
+#define PTE_READABLE_ARCH(p) \
+	1
 #define PTE_WRITABLE_ARCH(p) \
 	((p)->writeable != 0)
-#define PTE_EXECUTABLE_ARCH(p)  1
+#define PTE_EXECUTABLE_ARCH(p) \
+	1
 
 #include <mm/mm.h>
 #include <arch/interrupt.h>
@@ -153,7 +156,7 @@ NO_TRACE static inline unsigned int get_pt_flags(pte_t *pt, size_t i)
 
 	return (
 	    ((unsigned int) (!p->page_cache_disable) << PAGE_CACHEABLE_SHIFT) |
-	    ((unsigned int) (!p->present) << PAGE_PRESENT_SHIFT) |
+	    ((unsigned int) (!p->present) << PAGE_NOT_PRESENT_SHIFT) |
 	    ((unsigned int) p->uaccessible << PAGE_USER_SHIFT) |
 	    (1 << PAGE_READ_SHIFT) |
 	    ((unsigned int) p->writeable << PAGE_WRITE_SHIFT) |
@@ -171,7 +174,7 @@ NO_TRACE static inline void set_pt_flags(pte_t *pt, size_t i, int flags)
 	p->page_cache_disable = !(flags & PAGE_CACHEABLE);
 	p->present = !(flags & PAGE_NOT_PRESENT);
 	p->uaccessible = (flags & PAGE_USER) != 0;
-	p->writeable = (flags & PAGE_WRITE) != 0;
+	p->writeable = (flags & _PAGE_WRITE) != 0;
 	p->global = (flags & PAGE_GLOBAL) != 0;
 
 	/*

--- a/kernel/arch/amd64/src/mm/page.c
+++ b/kernel/arch/amd64/src/mm/page.c
@@ -54,8 +54,8 @@ void page_arch_init(void)
 	}
 
 	uintptr_t cur;
-	unsigned int identity_flags =
-	    PAGE_GLOBAL | PAGE_CACHEABLE | PAGE_EXEC | PAGE_WRITE | PAGE_READ;
+	unsigned int identity_flags = PAGE_READ_WRITE_EXECUTE |
+	    PAGE_CACHEABLE | PAGE_KERNEL | PAGE_GLOBAL;
 
 	page_mapping_operations = &pt_mapping_operations;
 

--- a/kernel/arch/amd64/src/vreg.c
+++ b/kernel/arch/amd64/src/vreg.c
@@ -66,7 +66,7 @@ void vreg_init(void)
 		panic("Cannot allocate VREG frame.");
 
 	page = (uint64_t *) km_map(frame, PAGE_SIZE,
-	    PAGE_READ | PAGE_WRITE | PAGE_USER | PAGE_CACHEABLE);
+	    PAGE_READ_WRITE | PAGE_USER | PAGE_CACHEABLE);
 
 	write_msr(AMD_MSR_FS, (uintptr_t) page);
 

--- a/kernel/arch/arm32/include/arch/mm/page.h
+++ b/kernel/arch/arm32/include/arch/mm/page.h
@@ -107,9 +107,9 @@
 #define GET_PTL1_FLAGS_ARCH(ptl0, i) \
         get_pt_level0_flags((pte_t *) (ptl0), (size_t) (i))
 #define GET_PTL2_FLAGS_ARCH(ptl1, i) \
-        PAGE_PRESENT
+        PAGE_NEXT_LEVEL_PT
 #define GET_PTL3_FLAGS_ARCH(ptl2, i) \
-        PAGE_PRESENT
+        PAGE_NEXT_LEVEL_PT
 #define GET_FRAME_FLAGS_ARCH(ptl3, i) \
         get_pt_level1_flags((pte_t *) (ptl3), (size_t) (i))
 

--- a/kernel/arch/arm32/src/mach/beagleboardxm/beagleboardxm.c
+++ b/kernel/arch/arm32/src/mach/beagleboardxm/beagleboardxm.c
@@ -100,7 +100,7 @@ static void bbxm_init(void)
 	/* Initialize interrupt controller */
 	beagleboard.irc_addr =
 	    (void *) km_map(AMDM37x_IRC_BASE_ADDRESS, AMDM37x_IRC_SIZE,
-	    PAGE_NOT_CACHEABLE);
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 	assert(beagleboard.irc_addr);
 	omap_irc_init(beagleboard.irc_addr);
 

--- a/kernel/arch/arm32/src/mach/beaglebone/beaglebone.c
+++ b/kernel/arch/arm32/src/mach/beaglebone/beaglebone.c
@@ -86,16 +86,20 @@ struct arm_machine_ops bbone_machine_ops = {
 static void bbone_init(void)
 {
 	bbone.irc_addr = (void *) km_map(AM335x_IRC_BASE_ADDRESS,
-	    AM335x_IRC_SIZE, PAGE_NOT_CACHEABLE);
+	    AM335x_IRC_SIZE,
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 
 	bbone.cm_per_addr = (void *) km_map(AM335x_CM_PER_BASE_ADDRESS,
-	    AM335x_CM_PER_SIZE, PAGE_NOT_CACHEABLE);
+	    AM335x_CM_PER_SIZE,
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 
 	bbone.cm_dpll_addr = (void *) km_map(AM335x_CM_DPLL_BASE_ADDRESS,
-	    AM335x_CM_DPLL_SIZE, PAGE_NOT_CACHEABLE);
+	    AM335x_CM_DPLL_SIZE,
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 
 	bbone.ctrl_module = (void *) km_map(AM335x_CTRL_MODULE_BASE_ADDRESS,
-	    AM335x_CTRL_MODULE_SIZE, PAGE_NOT_CACHEABLE);
+	    AM335x_CTRL_MODULE_SIZE,
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 
 	assert(bbone.irc_addr != NULL);
 	assert(bbone.cm_per_addr != NULL);

--- a/kernel/arch/arm32/src/mach/gta02/gta02.c
+++ b/kernel/arch/arm32/src/mach/gta02/gta02.c
@@ -102,9 +102,9 @@ static void gta02_init(void)
 	s3c24xx_irqc_regs_t *irqc_regs;
 
 	gta02_timer = (void *) km_map(S3C24XX_TIMER_ADDRESS, PAGE_SIZE,
-	    PAGE_NOT_CACHEABLE);
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 	irqc_regs = (void *) km_map(S3C24XX_IRQC_ADDRESS, PAGE_SIZE,
-	    PAGE_NOT_CACHEABLE);
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 
 	/* Initialize interrupt controller. */
 	s3c24xx_irqc_init(&gta02_irqc, irqc_regs);

--- a/kernel/arch/arm32/src/mach/integratorcp/integratorcp.c
+++ b/kernel/arch/arm32/src/mach/integratorcp/integratorcp.c
@@ -134,13 +134,14 @@ static inline void icp_irqc_unmask(uint32_t irq)
 void icp_init(void)
 {
 	icp.hw_map.uart = km_map(ICP_UART, PAGE_SIZE,
-	    PAGE_WRITE | PAGE_NOT_CACHEABLE);
-	icp.hw_map.kbd_ctrl = km_map(ICP_KBD, PAGE_SIZE, PAGE_NOT_CACHEABLE);
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
+	icp.hw_map.kbd_ctrl = km_map(ICP_KBD, PAGE_SIZE,
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 	icp.hw_map.kbd_stat = icp.hw_map.kbd_ctrl + ICP_KBD_STAT;
 	icp.hw_map.kbd_data = icp.hw_map.kbd_ctrl + ICP_KBD_DATA;
 	icp.hw_map.kbd_intstat = icp.hw_map.kbd_ctrl + ICP_KBD_INTR_STAT;
 	icp.hw_map.rtc = km_map(ICP_RTC, PAGE_SIZE,
-	    PAGE_WRITE | PAGE_NOT_CACHEABLE);
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 	icp.hw_map.rtc1_load = icp.hw_map.rtc + ICP_RTC1_LOAD_OFFSET;
 	icp.hw_map.rtc1_read = icp.hw_map.rtc + ICP_RTC1_READ_OFFSET;
 	icp.hw_map.rtc1_ctl = icp.hw_map.rtc + ICP_RTC1_CTL_OFFSET;
@@ -149,14 +150,14 @@ void icp_init(void)
 	icp.hw_map.rtc1_intrstat = icp.hw_map.rtc + ICP_RTC1_INTRSTAT_OFFSET;
 
 	icp.hw_map.irqc = km_map(ICP_IRQC, PAGE_SIZE,
-	    PAGE_WRITE | PAGE_NOT_CACHEABLE);
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 	icp.hw_map.irqc_mask = icp.hw_map.irqc + ICP_IRQC_MASK_OFFSET;
 	icp.hw_map.irqc_unmask = icp.hw_map.irqc + ICP_IRQC_UNMASK_OFFSET;
 	icp.hw_map.cmcr = km_map(ICP_CMCR, PAGE_SIZE,
-	    PAGE_WRITE | PAGE_NOT_CACHEABLE);
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 	icp.hw_map.sdramcr = icp.hw_map.cmcr + ICP_SDRAMCR_OFFSET;
 	icp.hw_map.vga = km_map(ICP_VGA, PAGE_SIZE,
-	    PAGE_WRITE | PAGE_NOT_CACHEABLE);
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 
 	hw_map_init_called = true;
 }

--- a/kernel/arch/arm32/src/mach/raspberrypi/raspberrypi.c
+++ b/kernel/arch/arm32/src/mach/raspberrypi/raspberrypi.c
@@ -101,14 +101,14 @@ static void raspberrypi_init(void)
 {
 	/* Initialize interrupt controller */
 	raspi.irc = (void *) km_map(BCM2835_IRC_ADDR, sizeof(bcm2835_irc_t),
-				    PAGE_NOT_CACHEABLE);
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 	assert(raspi.irc);
 	bcm2835_irc_init(raspi.irc);
 
 	/* Initialize system timer */
 	raspi.timer = (void *) km_map(BCM2835_TIMER_ADDR,
-				      sizeof(bcm2835_timer_t),
-				      PAGE_NOT_CACHEABLE);
+	      sizeof(bcm2835_timer_t),
+	      PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 }
 
 static void raspberrypi_timer_irq_start(void)

--- a/kernel/arch/arm32/src/mm/page.c
+++ b/kernel/arch/arm32/src/mm/page.c
@@ -51,7 +51,7 @@
  */
 void page_arch_init(void)
 {
-	int flags = PAGE_CACHEABLE | PAGE_EXEC;
+	int flags = PAGE_READ_WRITE_EXECUTE | PAGE_KERNEL | PAGE_CACHEABLE;
 	page_mapping_operations = &pt_mapping_operations;
 
 	page_table_lock(AS_KERNEL, true);

--- a/kernel/arch/arm32/src/ras.c
+++ b/kernel/arch/arm32/src/ras.c
@@ -56,7 +56,7 @@ void ras_init(void)
 		frame = frame_alloc(1, FRAME_LOWMEM, 0);
 
 	ras_page = (uintptr_t *) km_map(frame,
-	    PAGE_SIZE, PAGE_READ | PAGE_WRITE | PAGE_USER | PAGE_CACHEABLE);
+	    PAGE_SIZE, PAGE_READ_WRITE | PAGE_USER | PAGE_CACHEABLE);
 
 	memsetb(ras_page, PAGE_SIZE, 0);
 	ras_page[RAS_START] = 0;

--- a/kernel/arch/ia32/src/mm/page.c
+++ b/kernel/arch/ia32/src/mm/page.c
@@ -69,7 +69,7 @@ void page_arch_init(void)
 	page_table_lock(AS_KERNEL, true);
 	for (cur = 0; cur < min(config.identity_size, config.physmem_end);
 	    cur += FRAME_SIZE) {
-		flags = PAGE_GLOBAL | PAGE_CACHEABLE | PAGE_WRITE | PAGE_READ;
+		flags = PAGE_READ_WRITE | PAGE_KERNEL | PAGE_GLOBAL | PAGE_CACHEABLE;
 		page_mapping_insert(AS_KERNEL, PA2KA(cur), cur, flags);
 	}
 	page_table_unlock(AS_KERNEL, true);

--- a/kernel/arch/ia32/src/smp/smp.c
+++ b/kernel/arch/ia32/src/smp/smp.c
@@ -74,10 +74,12 @@ void smp_init(void)
 	}
 
 	if (config.cpu_count > 1) {
-		l_apic = (uint32_t *) km_map((uintptr_t) l_apic, PAGE_SIZE,
-		    PAGE_WRITE | PAGE_NOT_CACHEABLE);
-		io_apic = (uint32_t *) km_map((uintptr_t) io_apic, PAGE_SIZE,
-		    PAGE_WRITE | PAGE_NOT_CACHEABLE);
+		l_apic = (uint32_t *) km_map((uintptr_t) l_apic,
+		    PAGE_SIZE,
+		    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
+		io_apic = (uint32_t *) km_map((uintptr_t) io_apic,
+		    PAGE_SIZE,
+		    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 	}
 }
 

--- a/kernel/arch/ia32/src/vreg.c
+++ b/kernel/arch/ia32/src/vreg.c
@@ -67,7 +67,7 @@ void vreg_init(void)
 		panic("Cannot allocate VREG frame.");
 
 	page = (uint32_t *) km_map(frame, PAGE_SIZE,
-	    PAGE_READ | PAGE_WRITE | PAGE_USER | PAGE_CACHEABLE);
+	    PAGE_READ_WRITE | PAGE_USER | PAGE_CACHEABLE);
 
 	gdt_setbase(&gdt_p[VREG_DES], (uintptr_t) page);
 	gdt_setlimit(&gdt_p[VREG_DES], sizeof(uint32_t));

--- a/kernel/arch/ia64/src/ia64.c
+++ b/kernel/arch/ia64/src/ia64.c
@@ -105,7 +105,7 @@ void ia64_pre_mm_init(void)
 static void iosapic_init(void)
 {
 	uintptr_t IOSAPIC = km_map(iosapic_base, PAGE_SIZE,
-	    PAGE_WRITE | PAGE_NOT_CACHEABLE);
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 	int i;
 
 	int myid, myeid;
@@ -134,7 +134,7 @@ void ia64_post_mm_init(void)
 	if (config.cpu_active == 1) {
 		/* Map the page with legacy I/O. */
 		legacyio_virt_base = km_map(LEGACYIO_PHYS_BASE, LEGACYIO_SIZE,
-		    PAGE_WRITE | PAGE_NOT_CACHEABLE);
+		    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 
 		iosapic_init();
 		irq_init(INR_COUNT, INR_COUNT);

--- a/kernel/arch/ia64/src/mm/page.c
+++ b/kernel/arch/ia64/src/mm/page.c
@@ -245,8 +245,8 @@ vhpt_set_record(vhpt_entry_t *v, uintptr_t page, asid_t asid, uintptr_t frame,
 	v->present.a = false;  /* not accessed */
 	v->present.d = false;  /* not dirty */
 	v->present.pl = (flags & PAGE_USER) ? PL_USER : PL_KERNEL;
-	v->present.ar = (flags & PAGE_WRITE) ? AR_WRITE : AR_READ;
-	v->present.ar |= (flags & PAGE_EXEC) ? AR_EXECUTE : 0;
+	v->present.ar = (flags & _PAGE_WRITE) ? AR_WRITE : AR_READ;
+	v->present.ar |= (flags & _PAGE_EXEC) ? AR_EXECUTE : 0;
 	v->present.ppn = frame >> PPN_SHIFT;
 	v->present.ed = false;  /* exception not deffered */
 	v->present.ps = PAGE_WIDTH;

--- a/kernel/arch/ppc32/include/arch/mm/page.h
+++ b/kernel/arch/ppc32/include/arch/mm/page.h
@@ -110,10 +110,10 @@
 	get_pt_flags((pte_t *) (ptl0), (size_t) (i))
 
 #define GET_PTL2_FLAGS_ARCH(ptl1, i) \
-	PAGE_PRESENT
+	PAGE_NEXT_LEVEL_PT
 
 #define GET_PTL3_FLAGS_ARCH(ptl2, i) \
-	PAGE_PRESENT
+	PAGE_NEXT_LEVEL_PT
 
 #define GET_FRAME_FLAGS_ARCH(ptl3, i) \
 	get_pt_flags((pte_t *) (ptl3), (size_t) (i))
@@ -142,6 +142,7 @@
 #define PTE_VALID_ARCH(pte)       ((pte)->valid != 0)
 #define PTE_PRESENT_ARCH(pte)     ((pte)->present != 0)
 #define PTE_GET_FRAME_ARCH(pte)   ((pte)->pfn << 12)
+#define PTE_READABLE_ARCH(pte)    1
 #define PTE_WRITABLE_ARCH(pte)    1
 #define PTE_EXECUTABLE_ARCH(pte)  1
 
@@ -166,7 +167,7 @@ NO_TRACE static inline unsigned int get_pt_flags(pte_t *pt, size_t i)
 	pte_t *entry = &pt[i];
 
 	return (((!entry->page_cache_disable) << PAGE_CACHEABLE_SHIFT) |
-	    ((!entry->present) << PAGE_PRESENT_SHIFT) |
+	    ((!entry->present) << PAGE_NOT_PRESENT_SHIFT) |
 	    (1 << PAGE_USER_SHIFT) |
 	    (1 << PAGE_READ_SHIFT) |
 	    (1 << PAGE_WRITE_SHIFT) |

--- a/kernel/arch/ppc32/src/drivers/pic.c
+++ b/kernel/arch/ppc32/src/drivers/pic.c
@@ -41,7 +41,8 @@ static volatile uint32_t *pic = NULL;
 
 void pic_init(uintptr_t base, size_t size, cir_t *cir, void **cir_arg)
 {
-	pic = (uint32_t *) km_map(base, size, PAGE_WRITE | PAGE_NOT_CACHEABLE);
+	pic = (uint32_t *) km_map(base, size,
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 	*cir = pic_ack_interrupt;
 	*cir_arg = NULL;
 }

--- a/kernel/arch/ppc32/src/ppc32.c
+++ b/kernel/arch/ppc32/src/ppc32.c
@@ -241,7 +241,7 @@ static bool macio_register(ofw_tree_node_t *node, void *arg)
 		size_t size = 2 * PAGE_SIZE;
 
 		cuda_t *cuda = (cuda_t *) (km_map(aligned_addr, offset + size,
-		    PAGE_WRITE | PAGE_NOT_CACHEABLE) + offset);
+		    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE) + offset);
 
 		/* Initialize I/O controller */
 		cuda_instance_t *cuda_instance =

--- a/kernel/arch/riscv64/include/arch/mm/page.h
+++ b/kernel/arch/riscv64/include/arch/mm/page.h
@@ -81,7 +81,7 @@
 #define PTL3_INDEX_ARCH(vaddr)  (((vaddr) >> 12) & 0x1ff)
 
 /* Flags mask for non-leaf page table entries */
-#define NON_LEAF_MASK  (~(PAGE_READ | PAGE_WRITE | PAGE_EXEC))
+#define NON_LEAF_MASK  (~(_PAGE_READ | _PAGE_WRITE | _PAGE_EXEC))
 
 /* Get PTE address accessors for each level. */
 #define GET_PTL1_ADDRESS_ARCH(ptl0, i) \
@@ -155,6 +155,7 @@
 #define PTE_VALID_ARCH(pte)       ((pte)->valid != 0)
 #define PTE_PRESENT_ARCH(pte)     ((pte)->valid != 0)
 #define PTE_GET_FRAME_ARCH(pte)   ((uintptr_t) (pte)->pfn << 12)
+#define PTE_READABLE_ARCH(pte)    ((pte)->readable != 0)
 #define PTE_WRITABLE_ARCH(pte)    ((pte)->writable != 0)
 #define PTE_EXECUTABLE_ARCH(pte)  ((pte)->executable != 0)
 
@@ -182,7 +183,7 @@ NO_TRACE static inline unsigned int get_pt_flags(pte_t *pt, size_t i)
 {
 	pte_t *entry = &pt[i];
 
-	return (((!entry->valid) << PAGE_PRESENT_SHIFT) |
+	return (((!entry->valid) << PAGE_NOT_PRESENT_SHIFT) |
 	    (entry->user << PAGE_USER_SHIFT) |
 	    (entry->readable << PAGE_READ_SHIFT) |
 	    (entry->writable << PAGE_WRITE_SHIFT) |
@@ -195,9 +196,9 @@ NO_TRACE static inline void set_pt_flags(pte_t *pt, size_t i, int flags)
 	pte_t *entry = &pt[i];
 
 	entry->valid = !(flags & PAGE_NOT_PRESENT);
-	entry->readable = (flags & PAGE_READ) != 0;
-	entry->writable = (flags & PAGE_WRITE) != 0;
-	entry->executable = (flags & PAGE_EXEC) != 0;
+	entry->readable = (flags & _PAGE_READ) != 0;
+	entry->writable = (flags & _PAGE_WRITE) != 0;
+	entry->executable = (flags & _PAGE_EXEC) != 0;
 	entry->user = (flags & PAGE_USER) != 0;
 	entry->global = (flags & PAGE_GLOBAL) != 0;
 	entry->accessed = 1;

--- a/kernel/arch/riscv64/src/mm/page.c
+++ b/kernel/arch/riscv64/src/mm/page.c
@@ -62,7 +62,7 @@ void page_arch_init(void)
 		    cur < min(config.identity_size, config.physmem_end);
 		    cur += FRAME_SIZE)
 			page_mapping_insert(AS_KERNEL, PA2KA(cur), cur,
-			    PAGE_GLOBAL | PAGE_CACHEABLE | PAGE_EXEC | PAGE_WRITE | PAGE_READ);
+			    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_GLOBAL | PAGE_CACHEABLE);
 
 		page_table_unlock(AS_KERNEL, true);
 

--- a/kernel/arch/sparc64/src/drivers/kbd.c
+++ b/kernel/arch/sparc64/src/drivers/kbd.c
@@ -118,7 +118,7 @@ static bool kbd_ns16550_init(ofw_tree_node_t *node)
 	size_t offset = pa - aligned_addr;
 
 	ioport8_t *ns16550 = (ioport8_t *) (km_map(aligned_addr, offset + size,
-	    PAGE_WRITE | PAGE_NOT_CACHEABLE) + offset);
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE) + offset);
 
 	ns16550_instance_t *ns16550_instance = ns16550_init(ns16550, 0, inr, cir,
 	    cir_arg, NULL);

--- a/kernel/arch/sparc64/src/drivers/pci.c
+++ b/kernel/arch/sparc64/src/drivers/pci.c
@@ -109,7 +109,7 @@ pci_t *pci_sabre_init(ofw_tree_node_t *node)
 	pci->model = PCI_SABRE;
 	pci->op = &pci_sabre_ops;
 	pci->reg = (uint64_t *) km_map(paddr, reg[SABRE_INTERNAL_REG].size,
-	    PAGE_WRITE | PAGE_NOT_CACHEABLE);
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 
 	return pci;
 }
@@ -151,7 +151,7 @@ pci_t *pci_psycho_init(ofw_tree_node_t *node)
 	pci->model = PCI_PSYCHO;
 	pci->op = &pci_psycho_ops;
 	pci->reg = (uint64_t *) km_map(paddr, reg[PSYCHO_INTERNAL_REG].size,
-	    PAGE_WRITE | PAGE_NOT_CACHEABLE);
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 
 	return pci;
 }

--- a/kernel/genarch/include/genarch/drivers/amdm37x/gpt.h
+++ b/kernel/genarch/include/genarch/drivers/amdm37x/gpt.h
@@ -207,13 +207,15 @@ static inline void amdm37x_gpt_timer_ticks_init(
 	/* Set 32768 Hz clock as source */
 	// TODO find a nicer way to setup 32kHz clock source for timer1
 	// reg 0x48004C40 is CM_CLKSEL_WKUP see page 485 of the manual
-	ioport32_t *clksel = (void*) km_map(0x48004C40, 4, PAGE_NOT_CACHEABLE);
+	ioport32_t *clksel = (void*) km_map(0x48004C40, 4,
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 	*clksel &= ~1;
 	km_unmap((uintptr_t)clksel, 4);
 
 	assert(timer);
 	/* Map control register */
-	timer->regs = (void*) km_map(ioregs, iosize, PAGE_NOT_CACHEABLE);
+	timer->regs = (void*) km_map(ioregs, iosize,
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 
 	/* Reset the timer */
 	timer->regs->tiocp_cfg |= AMDM37x_GPT_TIOCP_CFG_SOFTRESET_FLAG;

--- a/kernel/genarch/include/genarch/mm/page_pt.h
+++ b/kernel/genarch/include/genarch/mm/page_pt.h
@@ -135,7 +135,7 @@
 #define PTE_VALID(p)       PTE_VALID_ARCH((p))
 #define PTE_PRESENT(p)     PTE_PRESENT_ARCH((p))
 #define PTE_GET_FRAME(p)   PTE_GET_FRAME_ARCH((p))
-#define PTE_READABLE(p)    1
+#define PTE_READABLE(p)    PTE_READABLE_ARCH((p))
 #define PTE_WRITABLE(p)    PTE_WRITABLE_ARCH((p))
 #define PTE_EXECUTABLE(p)  PTE_EXECUTABLE_ARCH((p))
 

--- a/kernel/genarch/src/acpi/acpi.c
+++ b/kernel/genarch/src/acpi/acpi.c
@@ -103,11 +103,13 @@ static struct acpi_sdt_header *map_sdt(struct acpi_sdt_header *psdt)
 
 	/* Start with mapping the header only. */
 	vhdr = (struct acpi_sdt_header *) km_map((uintptr_t) psdt,
-	    sizeof(struct acpi_sdt_header), PAGE_READ | PAGE_NOT_CACHEABLE);
+	    sizeof(struct acpi_sdt_header),
+	    PAGE_READ_ONLY | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 
 	/* Now we can map the entire structure. */
 	vsdt = (struct acpi_sdt_header *) km_map((uintptr_t) psdt,
-	    vhdr->length, PAGE_WRITE | PAGE_NOT_CACHEABLE);
+	    vhdr->length,
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 
 	// TODO: do not leak vtmp
 

--- a/kernel/genarch/src/drivers/am335x/timer.c
+++ b/kernel/genarch/src/drivers/am335x/timer.c
@@ -99,7 +99,8 @@ am335x_timer_init(am335x_timer_t *timer, am335x_timer_id_t id, unsigned hz,
 	base_addr = regs_map[id].base;
 	size = regs_map[id].size;
 
-	timer->regs = (void *) km_map(base_addr, size, PAGE_NOT_CACHEABLE);
+	timer->regs = (void *) km_map(base_addr, size,
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 	assert(timer->regs != NULL);
 
 	timer->id = id;

--- a/kernel/genarch/src/drivers/bcm2835/mbox.c
+++ b/kernel/genarch/src/drivers/bcm2835/mbox.c
@@ -90,7 +90,7 @@ bool bcm2835_fb_init(fb_properties_t *prop)
         MBOX_BUFF_ALLOC(fb_desc, bcm2835_fb_desc_t);
 
 	fb_mbox = (void *) km_map(BCM2835_MBOX0_ADDR, sizeof(bcm2835_mbox_t),
-				  PAGE_NOT_CACHEABLE);
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 
 	fb_desc->width = 640;
 	fb_desc->height = 480;

--- a/kernel/genarch/src/drivers/ega/ega.c
+++ b/kernel/genarch/src/drivers/ega/ega.c
@@ -600,7 +600,7 @@ outdev_t *ega_init(ioport8_t *base, uintptr_t addr)
 
 	instance->base = base;
 	instance->addr = (uint8_t *) km_map(addr, EGA_VRAM_SIZE,
-	    PAGE_WRITE | PAGE_NOT_CACHEABLE);
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 	if (!instance->addr) {
 		LOG("Unable to EGA video memory.");
 		free(instance);

--- a/kernel/genarch/src/drivers/omap/uart.c
+++ b/kernel/genarch/src/drivers/omap/uart.c
@@ -86,7 +86,8 @@ bool omap_uart_init(
     omap_uart_t *uart, inr_t interrupt, uintptr_t addr, size_t size)
 {
 	assert(uart);
-	uart->regs = (void *)km_map(addr, size, PAGE_NOT_CACHEABLE);
+	uart->regs = (void *)km_map(addr, size,
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 
 	assert(uart->regs);
 

--- a/kernel/genarch/src/drivers/pl011/pl011.c
+++ b/kernel/genarch/src/drivers/pl011/pl011.c
@@ -99,7 +99,7 @@ bool pl011_uart_init(pl011_uart_t *uart, inr_t interrupt, uintptr_t addr)
 {
 	assert(uart);
 	uart->regs = (void*)km_map(addr, sizeof(pl011_uart_regs_t),
-				   PAGE_NOT_CACHEABLE);
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 	assert(uart->regs);
 
 	/* Disable UART */

--- a/kernel/genarch/src/drivers/s3c24xx/uart.c
+++ b/kernel/genarch/src/drivers/s3c24xx/uart.c
@@ -116,7 +116,7 @@ outdev_t *s3c24xx_uart_init(uintptr_t paddr, inr_t inr)
 	uart_dev->data = uart;
 
 	uart->io = (s3c24xx_uart_io_t *) km_map(paddr, PAGE_SIZE,
-	    PAGE_WRITE | PAGE_NOT_CACHEABLE);
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 	uart->indev = NULL;
 
 	/* Initialize IRQ structure. */

--- a/kernel/genarch/src/fb/fb.c
+++ b/kernel/genarch/src/fb/fb.c
@@ -609,7 +609,7 @@ outdev_t *fb_init(fb_properties_t *props)
 	size_t glyphsize = FONT_GLYPHS * instance->glyphbytes;
 
 	instance->addr = (uint8_t *) km_map((uintptr_t) props->addr, fbsize,
-	    PAGE_WRITE | PAGE_NOT_CACHEABLE);
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 	if (!instance->addr) {
 		LOG("Unable to map framebuffer.");
 		free(instance);

--- a/kernel/genarch/src/mm/page_ht.c
+++ b/kernel/genarch/src/mm/page_ht.c
@@ -60,7 +60,7 @@ static void ht_remove_callback(ht_link_t *);
 static void ht_mapping_insert(as_t *, uintptr_t, uintptr_t, unsigned int);
 static void ht_mapping_remove(as_t *, uintptr_t);
 static bool ht_mapping_find(as_t *, uintptr_t, bool, pte_t *);
-static void ht_mapping_update(as_t *, uintptr_t, bool, pte_t *);
+static void ht_mapping_update(as_t *, uintptr_t, bool, const pte_t *);
 static void ht_mapping_make_global(uintptr_t, size_t);
 
 slab_cache_t *pte_cache = NULL;
@@ -167,8 +167,8 @@ void ht_mapping_insert(as_t *as, uintptr_t page, uintptr_t frame,
 		assert(pte != NULL);
 
 		pte->g = (flags & PAGE_GLOBAL) != 0;
-		pte->x = (flags & PAGE_EXEC) != 0;
-		pte->w = (flags & PAGE_WRITE) != 0;
+		pte->x = (flags & _PAGE_EXEC) != 0;
+		pte->w = (flags & _PAGE_WRITE) != 0;
 		pte->k = !(flags & PAGE_USER);
 		pte->c = (flags & PAGE_CACHEABLE) != 0;
 		pte->p = !(flags & PAGE_NOT_PRESENT);
@@ -267,7 +267,7 @@ bool ht_mapping_find(as_t *as, uintptr_t page, bool nolock, pte_t *pte)
  * @param nolock   True if the page tables need not be locked.
  * @param pte      New PTE.
  */
-void ht_mapping_update(as_t *as, uintptr_t page, bool nolock, pte_t *pte)
+void ht_mapping_update(as_t *as, uintptr_t page, bool nolock, const pte_t *pte)
 {
 	irq_spinlock_lock(&page_ht_lock, true);
 

--- a/kernel/genarch/src/mm/page_pt.c
+++ b/kernel/genarch/src/mm/page_pt.c
@@ -54,7 +54,7 @@
 static void pt_mapping_insert(as_t *, uintptr_t, uintptr_t, unsigned int);
 static void pt_mapping_remove(as_t *, uintptr_t);
 static bool pt_mapping_find(as_t *, uintptr_t, bool, pte_t *pte);
-static void pt_mapping_update(as_t *, uintptr_t, bool, pte_t *pte);
+static void pt_mapping_update(as_t *, uintptr_t, bool, const pte_t *pte);
 static void pt_mapping_make_global(uintptr_t, size_t);
 
 page_mapping_operations_t pt_mapping_operations = {
@@ -89,8 +89,7 @@ void pt_mapping_insert(as_t *as, uintptr_t page, uintptr_t frame,
 		memsetb(newpt, PTL1_SIZE, 0);
 		SET_PTL1_ADDRESS(ptl0, PTL0_INDEX(page), KA2PA(newpt));
 		SET_PTL1_FLAGS(ptl0, PTL0_INDEX(page),
-		    PAGE_NOT_PRESENT | PAGE_USER | PAGE_EXEC | PAGE_CACHEABLE |
-		    PAGE_WRITE);
+		    PAGE_NOT_PRESENT | PAGE_NEXT_LEVEL_PT);
 		/*
 		 * Make sure that a concurrent hardware page table walk or
 		 * pt_mapping_find() will see the new PTL1 only after it is
@@ -108,8 +107,7 @@ void pt_mapping_insert(as_t *as, uintptr_t page, uintptr_t frame,
 		memsetb(newpt, PTL2_SIZE, 0);
 		SET_PTL2_ADDRESS(ptl1, PTL1_INDEX(page), KA2PA(newpt));
 		SET_PTL2_FLAGS(ptl1, PTL1_INDEX(page),
-		    PAGE_NOT_PRESENT | PAGE_USER | PAGE_EXEC | PAGE_CACHEABLE |
-		    PAGE_WRITE);
+		    PAGE_NOT_PRESENT | PAGE_NEXT_LEVEL_PT);
 		/*
 		 * Make the new PTL2 visible only after it is fully initialized.
 		 */
@@ -125,8 +123,7 @@ void pt_mapping_insert(as_t *as, uintptr_t page, uintptr_t frame,
 		memsetb(newpt, PTL2_SIZE, 0);
 		SET_PTL3_ADDRESS(ptl2, PTL2_INDEX(page), KA2PA(newpt));
 		SET_PTL3_FLAGS(ptl2, PTL2_INDEX(page),
-		    PAGE_NOT_PRESENT | PAGE_USER | PAGE_EXEC | PAGE_CACHEABLE |
-		    PAGE_WRITE);
+		    PAGE_NOT_PRESENT | PAGE_NEXT_LEVEL_PT);
 		/*
 		 * Make the new PTL3 visible only after it is fully initialized.
 		 */
@@ -352,7 +349,7 @@ bool pt_mapping_find(as_t *as, uintptr_t page, bool nolock, pte_t *pte)
  * @param nolock   True if the page tables need not be locked.
  * @param[in] pte  New PTE.
  */
-void pt_mapping_update(as_t *as, uintptr_t page, bool nolock, pte_t *pte)
+void pt_mapping_update(as_t *as, uintptr_t page, bool nolock, const pte_t *pte)
 {
 	pte_t *t = pt_mapping_find_internal(as, page, nolock);
 	if (!t)
@@ -430,8 +427,7 @@ void pt_mapping_make_global(uintptr_t base, size_t size)
 		memsetb((void *) l1, FRAMES2SIZE(frames), 0);
 		SET_PTL1_ADDRESS(ptl0, PTL0_INDEX(addr), KA2PA(l1));
 		SET_PTL1_FLAGS(ptl0, PTL0_INDEX(addr),
-		    PAGE_PRESENT | PAGE_USER | PAGE_CACHEABLE |
-		    PAGE_EXEC | PAGE_WRITE | PAGE_READ);
+		    PAGE_NEXT_LEVEL_PT);
 	}
 }
 

--- a/kernel/generic/include/mm/mm.h
+++ b/kernel/generic/include/mm/mm.h
@@ -35,31 +35,116 @@
 #ifndef KERN_MM_H_
 #define KERN_MM_H_
 
-#define PAGE_CACHEABLE_SHIFT		0
-#define PAGE_NOT_CACHEABLE_SHIFT	PAGE_CACHEABLE_SHIFT
-#define PAGE_PRESENT_SHIFT		1
-#define PAGE_NOT_PRESENT_SHIFT		PAGE_PRESENT_SHIFT
-#define PAGE_USER_SHIFT			2
-#define PAGE_KERNEL_SHIFT		PAGE_USER_SHIFT
+#include <assert.h>
+#include <stdbool.h>
+
+#define PAGE_NOT_CACHEABLE_SHIFT	0
+#define PAGE_CACHEABLE_SHIFT		1
+#define PAGE_NOT_PRESENT_SHIFT		2
 #define PAGE_READ_SHIFT			3
 #define PAGE_WRITE_SHIFT		4
 #define PAGE_EXEC_SHIFT			5
 #define PAGE_GLOBAL_SHIFT		6
+#define PAGE_USER_SHIFT			7
+#define PAGE_KERNEL_SHIFT		8
 
-#define PAGE_NOT_CACHEABLE		(0 << PAGE_CACHEABLE_SHIFT)
+/* Cacheability.
+ * Platform-independent code should always use PAGE_CACHEABLE for normal memory,
+ * and PAGE_NOT_CACHEABLE for I/O memory.
+ * In particular, setting PAGE_NOT_CACHEABLE on normal memory does not prevent
+ * caching on all platforms. You have been warned.
+ * Exactly one must be present for leaf pages.
+ * None may be present for non-leaf entries.
+ */
+
+#define PAGE_NOT_CACHEABLE		(1 << PAGE_NOT_CACHEABLE_SHIFT)
 #define PAGE_CACHEABLE			(1 << PAGE_CACHEABLE_SHIFT)
 
-#define PAGE_PRESENT			(0 << PAGE_PRESENT_SHIFT)
-#define PAGE_NOT_PRESENT		(1 << PAGE_PRESENT_SHIFT)
 
-#define PAGE_USER			(1 << PAGE_USER_SHIFT)
-#define PAGE_KERNEL			(0 << PAGE_USER_SHIFT)
+/* Discriminant, exactly one of the following seven must be set for
+ * the flags to be valid. Furthermore, the first two are only legal
+ * for setting individual page table entries. Setting an entry
+ * to PAGE_NOT_PRESENT renders the entry eligible for removal.
+ * In an earlier iteration of this interface, page could be not
+ * present but valid, preventing removal. This has been changed, and
+ * if future iterations allow kernel to hide data (e.g. swap identifiers)
+ * in page tables, it should be achieved by adding a separate discriminant.
+ */
+#define PAGE_NOT_PRESENT          (1 << PAGE_NOT_PRESENT_SHIFT)
 
-#define PAGE_READ			(1 << PAGE_READ_SHIFT)
-#define PAGE_WRITE			(1 << PAGE_WRITE_SHIFT)
-#define PAGE_EXEC			(1 << PAGE_EXEC_SHIFT)
+// TODO: This will be a separate flag.
+#define PAGE_NEXT_LEVEL_PT        (_PAGE_READ | _PAGE_WRITE | _PAGE_EXEC | PAGE_USER | PAGE_CACHEABLE)
 
-#define PAGE_GLOBAL			(1 << PAGE_GLOBAL_SHIFT)
+#define PAGE_READ_ONLY            (_PAGE_READ)
+#define PAGE_READ_EXECUTE         (_PAGE_READ | _PAGE_EXEC)
+#define PAGE_READ_WRITE           (_PAGE_READ | _PAGE_WRITE)
+#define PAGE_READ_WRITE_EXECUTE   (_PAGE_READ | _PAGE_WRITE | _PAGE_EXEC)
+#define PAGE_EXECUTE_ONLY         (_PAGE_EXEC)
+
+/* Individual permissions.
+ * Only used when the flags are tested or translated from other
+ * format. In constant flags, use one of the combinations above.
+ */
+#define _PAGE_READ                (1 << PAGE_READ_SHIFT)
+#define _PAGE_WRITE               (1 << PAGE_WRITE_SHIFT)
+#define _PAGE_EXEC                (1 << PAGE_EXEC_SHIFT)
+
+/* Global page. Can be combined with anything except PAGE_NOT_PRESENT.
+ * PAGE_GLOBAL on non-leaf entry means all the leaf entries under it are global,
+ * even if they don't have the PAGE_GLOBAL flag themselves.
+ */
+#define PAGE_GLOBAL               (1 << PAGE_GLOBAL_SHIFT)
+
+/* Protection.
+ * PAGE_USER for memory accessible to userspace programs, PAGE_KERNEL for
+ * memory accessible only to the kernel. Note that on some platforms,
+ * PAGE_USER pages are accessible to kernel, while on others, they are not.
+ * For non-leaf entries, PAGE_USER means that all of the lower-level pages
+ * are PAGE_USER, likewise with PAGE_KERNEL. Exactly one of these two must be
+ * used for leaf entries, but it may be omitted for non-leaf entries.
+ */
+#define PAGE_USER                 (1 << PAGE_USER_SHIFT)
+#define PAGE_KERNEL               (1 << PAGE_KERNEL_SHIFT)
+
+
+
+static inline bool PAGE_FLAGS_VALID(unsigned flags) {
+	// TODO
+
+	/* Empty entry supports no flags. */
+	if (flags & PAGE_NOT_PRESENT)
+		return flags == PAGE_NOT_PRESENT;
+
+	/* PAGE_USER and PAGE_KERNEL are mutually exclusive. */
+	if ((flags & PAGE_USER) && (flags & PAGE_KERNEL))
+		return false;
+
+	/* Check allowed flags for non-leaf entry. */
+	if (flags & PAGE_NEXT_LEVEL_PT)
+		return flags == (flags & (PAGE_NEXT_LEVEL_PT | PAGE_GLOBAL | PAGE_USER | PAGE_KERNEL));
+
+	/* Leaf entries only. */
+
+	/* Check that at least one permission is set. */
+	if (!(flags & (_PAGE_READ | _PAGE_WRITE | _PAGE_EXEC)))
+		return false;
+
+	/* Check that write implies read. */
+	if ((flags & _PAGE_WRITE) && !(flags & _PAGE_READ))
+		return false;
+
+	/* One of PAGE_USER and PAGE_KERNEL must be used. */
+	if (!(flags & (PAGE_USER | PAGE_KERNEL)))
+		return false;
+
+	/* One of PAGE_CACHEABLE and PAGE_NOT_CACHEABLE must be used. */
+	if ((flags & PAGE_CACHEABLE) && (flags & PAGE_NOT_CACHEABLE))
+		return false;
+	if (!(flags & (PAGE_CACHEABLE | PAGE_NOT_CACHEABLE)))
+		return false;
+
+	return true;
+}
 
 #endif
 

--- a/kernel/generic/include/mm/page.h
+++ b/kernel/generic/include/mm/page.h
@@ -48,7 +48,7 @@ typedef struct {
 	void (*mapping_insert)(as_t *, uintptr_t, uintptr_t, unsigned int);
 	void (*mapping_remove)(as_t *, uintptr_t);
 	bool (*mapping_find)(as_t *, uintptr_t, bool, pte_t *);
-	void (*mapping_update)(as_t *, uintptr_t, bool, pte_t *);
+	void (*mapping_update)(as_t *, uintptr_t, bool, const pte_t *);
 	void (*mapping_make_global)(uintptr_t, size_t);
 } page_mapping_operations_t;
 

--- a/kernel/generic/src/console/cmd.c
+++ b/kernel/generic/src/console/cmd.c
@@ -726,8 +726,9 @@ static int cmd_pio_read_8(cmd_arg_t *argv)
 		ptr = (void *) argv[0].intval;
 	else
 #endif
-		ptr = (uint8_t *) km_map(argv[0].intval, sizeof(uint8_t),
-		    PAGE_NOT_CACHEABLE);
+		ptr = (uint8_t *) km_map(
+		    argv[0].intval, sizeof(uint8_t),
+		    PAGE_READ_ONLY | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 
 	const uint8_t val = pio_read_8(ptr);
 	printf("read %" PRIxn ": %" PRIx8 "\n", argv[0].intval, val);
@@ -756,8 +757,9 @@ static int cmd_pio_read_16(cmd_arg_t *argv)
 		ptr = (void *) argv[0].intval;
 	else
 #endif
-		ptr = (uint16_t *) km_map(argv[0].intval, sizeof(uint16_t),
-		    PAGE_NOT_CACHEABLE);
+		ptr = (uint16_t *) km_map(
+		    argv[0].intval, sizeof(uint16_t),
+		    PAGE_READ_ONLY | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 
 	const uint16_t val = pio_read_16(ptr);
 	printf("read %" PRIxn ": %" PRIx16 "\n", argv[0].intval, val);
@@ -786,8 +788,9 @@ static int cmd_pio_read_32(cmd_arg_t *argv)
 		ptr = (void *) argv[0].intval;
 	else
 #endif
-		ptr = (uint32_t *) km_map(argv[0].intval, sizeof(uint32_t),
-		    PAGE_NOT_CACHEABLE);
+		ptr = (uint32_t *) km_map(
+		    argv[0].intval, sizeof(uint32_t),
+		    PAGE_READ_ONLY | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 
 	const uint32_t val = pio_read_32(ptr);
 	printf("read %" PRIxn ": %" PRIx32 "\n", argv[0].intval, val);
@@ -817,7 +820,7 @@ static int cmd_pio_write_8(cmd_arg_t *argv)
 	else
 #endif
 		ptr = (uint8_t *) km_map(argv[0].intval, sizeof(uint8_t),
-		    PAGE_NOT_CACHEABLE);
+		    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 
 	printf("write %" PRIxn ": %" PRIx8 "\n", argv[0].intval,
 	    (uint8_t) argv[1].intval);
@@ -848,7 +851,7 @@ static int cmd_pio_write_16(cmd_arg_t *argv)
 	else
 #endif
 		ptr = (uint16_t *) km_map(argv[0].intval, sizeof(uint16_t),
-		    PAGE_NOT_CACHEABLE);
+		    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 
 	printf("write %" PRIxn ": %" PRIx16 "\n", argv[0].intval,
 	    (uint16_t) argv[1].intval);
@@ -879,7 +882,7 @@ static int cmd_pio_write_32(cmd_arg_t *argv)
 	else
 #endif
 		ptr = (uint32_t *) km_map(argv[0].intval, sizeof(uint32_t),
-		    PAGE_NOT_CACHEABLE);
+		    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 
 	printf("write %" PRIxn ": %" PRIx32 "\n", argv[0].intval,
 	    (uint32_t) argv[1].intval);

--- a/kernel/generic/src/ipc/irq.c
+++ b/kernel/generic/src/ipc/irq.c
@@ -92,7 +92,7 @@ static errno_t ranges_map_and_apply(irq_pio_range_t *ranges, size_t rangecount,
 			continue;
 #endif
 		ranges[i].base = km_map(pbase[i], ranges[i].size,
-		    PAGE_READ | PAGE_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
+		    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_NOT_CACHEABLE);
 		if (!ranges[i].base) {
 			ranges_unmap(ranges, i);
 			free(pbase);

--- a/kernel/generic/src/main/kinit.c
+++ b/kernel/generic/src/main/kinit.c
@@ -249,7 +249,7 @@ void kinit(void *arg)
 		 */
 		uintptr_t page = km_map(init.tasks[i].paddr,
 		    init.tasks[i].size,
-		    PAGE_READ | PAGE_WRITE | PAGE_CACHEABLE);
+		    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_CACHEABLE);
 		assert(page);
 
 		errno_t rc = program_create_from_image((void *) page, namebuf,

--- a/kernel/generic/src/mm/as.c
+++ b/kernel/generic/src/mm/as.c
@@ -1216,19 +1216,21 @@ NO_TRACE bool as_area_check_access(as_area_t *area, pf_access_t access)
  */
 NO_TRACE static unsigned int area_flags_to_page_flags(unsigned int aflags)
 {
-	unsigned int flags = PAGE_USER | PAGE_PRESENT;
+	unsigned int flags = PAGE_USER;
 
 	if (aflags & AS_AREA_READ)
-		flags |= PAGE_READ;
+		flags |= _PAGE_READ;
 
 	if (aflags & AS_AREA_WRITE)
-		flags |= PAGE_WRITE;
+		flags |= _PAGE_WRITE;
 
 	if (aflags & AS_AREA_EXEC)
-		flags |= PAGE_EXEC;
+		flags |= _PAGE_EXEC;
 
 	if (aflags & AS_AREA_CACHEABLE)
 		flags |= PAGE_CACHEABLE;
+	else
+		flags |= PAGE_NOT_CACHEABLE;
 
 	return flags;
 }

--- a/kernel/generic/src/mm/km.c
+++ b/kernel/generic/src/mm/km.c
@@ -256,7 +256,7 @@ uintptr_t km_temporary_page_get(uintptr_t *framep, frame_flags_t flags)
 	frame = frame_alloc(1, FRAME_HIGHMEM | FRAME_ATOMIC | flags, 0);
 	if (frame) {
 		page = km_map(frame, PAGE_SIZE,
-		    PAGE_READ | PAGE_WRITE | PAGE_CACHEABLE);
+		    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_CACHEABLE);
 		if (!page) {
 			frame_free(frame, 1);
 			goto lowmem;

--- a/kernel/test/mm/mapping1.c
+++ b/kernel/test/mm/mapping1.c
@@ -43,12 +43,12 @@ const char *test_mapping1(void)
 	uintptr_t frame = frame_alloc(1, FRAME_NONE, 0);
 
 	uintptr_t page0 = km_map(frame, FRAME_SIZE,
-	    PAGE_READ | PAGE_WRITE | PAGE_CACHEABLE);
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_CACHEABLE);
 	TPRINTF("Virtual address %p mapped to physical address %p.\n",
 	    (void *) page0, (void *) frame);
 
 	uintptr_t page1 = km_map(frame, FRAME_SIZE,
-	    PAGE_READ | PAGE_WRITE | PAGE_CACHEABLE);
+	    PAGE_READ_WRITE | PAGE_KERNEL | PAGE_CACHEABLE);
 	TPRINTF("Virtual address %p mapped to physical address %p.\n",
 	    (void *) page1, (void *) frame);
 


### PR DESCRIPTION
This is the first part of a larger overhaul of the generic paging interface.

Page flags in `generic/mm/page.h` are expanded to include a "discriminant" -- a single enum-like flag that determines the contents of the page table entry. This is currently one of "not present", "next level page table", "leaf page". Leaf pages further have a separate discriminant for each legal combination of read-write-execute permissions.

In addition to discriminant, there are two mutually-exclusive pairs of flags: "cacheable"/"not-cacheable", and "kernel"/"user". Leaf pages must have one flag from each pair. Non-leaf entries may not have cacheability flag (the meaning of cacheability on non-leaf entries may not be consistent between platforms, and the generic code doesn't know the appropriate flags anyway). Non-leaf entries may have one of "kernel"/"user" flags, but are not required to. The flag is defined to mean that everything in the subtree is kernel-only or user-only, respectively. The motivation for this feature is that some platforms can disable kernel access to user pages, which is useful as a safety and/or debugging precaution.
