### PR TITLE
Add Ccheck to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ env:
     - H_ARCH=ppc32
     - H_ARCH=sparc64/niagara
     - H_ARCH=sparc64/ultra
+    - H_CCHECK=true
 before_install:
  - ./tools/travis.sh install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ env:
   global:
     - CROSS_PREFIX=/usr/local/cross-static/
   matrix:
+    - H_CCHECK=true
     - H_ARCH=amd64
     - H_ARCH=arm32/beagleboardxm
     - H_ARCH=arm32/beaglebone
@@ -54,7 +55,6 @@ env:
     - H_ARCH=ppc32
     - H_ARCH=sparc64/niagara
     - H_ARCH=sparc64/ultra
-    - H_CCHECK=true
 before_install:
  - ./tools/travis.sh install
 script:

--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -81,6 +81,16 @@ if [ -z "$TRAVIS" ]; then
     exit 5
 fi
 
+# C style check
+if [ -n "$H_CCHECK" ]; then
+    echo "Will try to run C style check."
+    echo
+    rm -rf tools/sycek
+    make ccheck || exit 1
+    echo "C style check passed."
+    exit 0
+fi
+
 # Check HelenOS configuration was set-up
 if [ -z "$H_ARCH" ]; then
     echo "\$H_ARCH env not set. Are you running me inside Travis?" >&2
@@ -96,7 +106,9 @@ fi
 
 
 # Custom CROSS_PREFIX
-export CROSS_PREFIX=/usr/local/cross-static/
+if [ ."$CROSS_PREFIX" == . ]; then
+	export CROSS_PREFIX=/usr/local/cross-static/
+fi
 
 # Default Harbours repository
 if [ -z "$H_HARBOURS_REPOSITORY" ]; then
@@ -113,6 +125,10 @@ if [ "$1" = "help" ]; then
     echo
     echo "export H_HARBOURS=true"
     echo "export H_HARBOUR_LIST=\"$H_DEFAULT_HARBOURS_LIST\""
+    echo
+    echo "or"
+    echo
+    echo "export H_CCHECK=true"
     echo
     exit 0
 


### PR DESCRIPTION
This adds a ccheck job to Travis CI. The job will currently only fail if ccheck cannot parse a source file. This can happen either if the file has broken syntax, one of the few specific style issues mentioned in ccheck''s README.md or if it tries to use a macro to extend the C syntax in a way other than those explicitly supported.