### PR TITLE
ar9271: Set cable state according to connectedness

### DIFF
--- a/uspace/drv/nic/ar9271/ar9271.c
+++ b/uspace/drv/nic/ar9271/ar9271.c
@@ -165,7 +165,17 @@ static errno_t ar9271_get_device_info(ddf_fun_t *dev, nic_device_info_t *info)
  */
 static errno_t ar9271_get_cable_state(ddf_fun_t *fun, nic_cable_state_t *state)
 {
-	*state = NIC_CS_PLUGGED;
+	nic_t *nic_data = nic_get_from_ddf_fun(fun);
+	if (!nic_data)
+		return ENOENT;
+	ar9271_t *ar9271 = nic_get_specific(nic_data);
+	if (!ar9271)
+		return ENOENT;
+
+	if (ieee80211_is_connected(ar9271->ieee80211_dev))
+		*state = NIC_CS_PLUGGED;
+	else
+		*state = NIC_CS_UNPLUGGED;
 
 	return EOK;
 }


### PR DESCRIPTION
This commit might fix Trac ticket #628. I don't have the hw and don't know how to test this in QEMU (the device seems unsupported as of QEMU 2.12).