### PR TITLE
[Work in progress] Replace the common case IPC read/write with a single function call.

### DIFF
--- a/tools/ew.py
+++ b/tools/ew.py
@@ -208,6 +208,9 @@ def qemu_run(platform, machine, processor):
 	if (not 'audio' in cfg.keys()) or cfg['audio']:
 		cmdline += qemu_audio_options()
 
+	if (is_override('nographic')):
+		cmdline += ' -nographic'
+
 	if cfg['image'] == 'image.iso':
 		cmdline += ' -boot d -cdrom image.iso'
 	elif cfg['image'] == 'image.boot':
@@ -381,6 +384,8 @@ def run():
 			overrides['noxhci'] = True
 		elif sys.argv[i] == '-notablet':
 			overrides['notablet'] = True
+		elif sys.argv[i] == '-nographic':
+			overrides['nographic'] = True
 		elif sys.argv[i] == '-qemu_path' and i < len(sys.argv) - 1:
 			expect_qemu = True
 		else:

--- a/uspace/lib/c/generic/time.c
+++ b/uspace/lib/c/generic/time.c
@@ -502,7 +502,7 @@ void tv_add(struct timeval *tv1, struct timeval *tv2)
  *         microseconds.
  *
  */
-suseconds_t tv_sub_diff(struct timeval *tv1, struct timeval *tv2)
+suseconds_t tv_sub_diff(const struct timeval *tv1, const struct timeval *tv2)
 {
 	return (tv1->tv_usec - tv2->tv_usec) +
 	    ((tv1->tv_sec - tv2->tv_sec) * USECS_PER_SEC);
@@ -530,7 +530,7 @@ void tv_sub(struct timeval *tv1, struct timeval *tv2)
  * @return False otherwise.
  *
  */
-int tv_gt(struct timeval *tv1, struct timeval *tv2)
+int tv_gt(const struct timeval *tv1, const struct timeval *tv2)
 {
 	if (tv1->tv_sec > tv2->tv_sec)
 		return true;
@@ -550,7 +550,7 @@ int tv_gt(struct timeval *tv1, struct timeval *tv2)
  * @return False otherwise.
  *
  */
-int tv_gteq(struct timeval *tv1, struct timeval *tv2)
+int tv_gteq(const struct timeval *tv1, const struct timeval *tv2)
 {
 	if (tv1->tv_sec > tv2->tv_sec)
 		return true;

--- a/uspace/lib/c/include/async.h
+++ b/uspace/lib/c/include/async.h
@@ -549,6 +549,9 @@ extern void async_call_share_in(async_call_t *, async_call_data_t *,
 extern void async_call_share_out(async_call_t *, async_call_data_t *,
     void *, unsigned int);
 
+extern void async_call_connect_to_me(async_call_t *, async_call_data_t *,
+    sysarg_t, sysarg_t, sysarg_t);
+
 // TODO: connect me to, connect to me, vfs handle, etc.
 
 #endif

--- a/uspace/lib/c/include/sys/time.h
+++ b/uspace/lib/c/include/sys/time.h
@@ -75,10 +75,10 @@ struct timezone {
 
 extern void tv_add_diff(struct timeval *, suseconds_t);
 extern void tv_add(struct timeval *, struct timeval *);
-extern suseconds_t tv_sub_diff(struct timeval *, struct timeval *);
+extern suseconds_t tv_sub_diff(const struct timeval *, const struct timeval *);
 extern void tv_sub(struct timeval *, struct timeval *);
-extern int tv_gt(struct timeval *, struct timeval *);
-extern int tv_gteq(struct timeval *, struct timeval *);
+extern int tv_gt(const struct timeval *, const struct timeval *);
+extern int tv_gteq(const struct timeval *, const struct timeval *);
 extern void gettimeofday(struct timeval *, struct timezone *);
 extern void getuptime(struct timeval *);
 


### PR DESCRIPTION
Adds three new functions, `async_read()`, `async_write()`, and `async_write_read()`, which implement and encapsulate the usual use cases of data transfer methods. Removes lots of boilerplate.
Updating users of the methods is still work in progress.