### PR TITLE
Add notification queue to the async framework.

### DIFF
--- a/uspace/lib/c/generic/fibril.c
+++ b/uspace/lib/c/generic/fibril.c
@@ -115,8 +115,6 @@ fibril_t *fibril_setup(void)
 
 	fibril->waits_for = NULL;
 
-	fibril->switches = 0;
-
 	/*
 	 * We are called before __tcb_set(), so we need to use
 	 * futex_down/up() instead of futex_lock/unlock() that
@@ -205,7 +203,6 @@ int fibril_switch(fibril_switch_type_t stype)
 		// Nothing.
 		break;
 	case FIBRIL_TO_MANAGER:
-		srcf->switches++;
 		/*
 		 * Don't put the current fibril into any list, it should
 		 * already be somewhere, or it will be lost.

--- a/uspace/lib/c/include/async.h
+++ b/uspace/lib/c/include/async.h
@@ -491,6 +491,8 @@ extern void async_remote_state_release_exchange(async_exch_t *);
 extern void *async_as_area_create(void *, size_t, unsigned int, async_sess_t *,
     sysarg_t, sysarg_t, sysarg_t);
 
+errno_t async_spawn_notification_handler(void);
+
 #endif
 
 /** @}

--- a/uspace/lib/c/include/fibril.h
+++ b/uspace/lib/c/include/fibril.h
@@ -71,8 +71,6 @@ typedef struct fibril {
 	int flags;
 
 	fibril_owner_info_t *waits_for;
-
-	unsigned int switches;
 } fibril_t;
 
 /** Fibril-local variable specifier */


### PR DESCRIPTION
Instead of running notification handlers in the same fibril that received it,
forcing us to allocate a new fibril when the handler blocks, we instead queue
the notifications, and allow an arbitrary but fixed number of dedicated fibrils
handle them.

Although a service can increase the number of handler fibrils to reduce latency,
there are now no dynamic allocations due to received notifications.
When the same notification is received again while the older instance is still
in queue, the new notification overwrites the old and increments a counter
of received notifications.

The counter is currently unused, because passing it to the handler would
require extensive changes to user code, but it should be straightforward
to make use of it should the need arise.