### PR TITLE
Switch completely to HelenOS-specific toolchain target.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -375,6 +375,7 @@ uspace/lib/c/arch/sparc64/_link-shlib.ld
 uspace/lib/c/arch/sparc64/_link.ld
 uspace/lib/c/test-libc
 uspace/lib/label/test-liblabel
+uspace/lib/math/test-libmath
 uspace/lib/pcut/test-libpcut-*
 uspace/lib/posix/gcc.specs
 uspace/lib/posix/include/libc

--- a/HelenOS.config
+++ b/HelenOS.config
@@ -294,10 +294,8 @@
 ## Compiler options
 
 % Compiler
-@ "gcc_cross" GNU C Compiler (cross-compiler)
+@ "gcc_cross" GNU C Compiler (HelenOS-specific cross-compiler)
 @ "clang" Clang
-@ "gcc_helenos" GNU C Compiler (experimental HelenOS-specific cross-compiler)
-@ "gcc_native" GNU C Compiler (native)
 ! COMPILER (choice)
 
 % Clang Integrated Assembler
@@ -312,7 +310,7 @@
 @ "arm32" ARM 32-bit
 @ "ia32" Intel IA-32
 @ "mips32" MIPS 32-bit
-! [PLATFORM=abs32le&(COMPILER=gcc_cross|COMPILER=gcc_helenos)] CROSS_TARGET (choice)
+! [PLATFORM=abs32le&COMPILER=gcc_cross] CROSS_TARGET (choice)
 
 
 ## Kernel configuration
@@ -424,7 +422,7 @@
 ! CONFIG_TEST (y/n)
 
 % Use link-time optimization
-! [COMPILER=gcc_cross|COMPILER=gcc_native] CONFIG_LTO (n/y)
+! [COMPILER=gcc_cross] CONFIG_LTO (n/y)
 
 % Kernel RCU algorithm
 @ "PREEMPT_PODZIMEK" Preemptible Podzimek-RCU

--- a/contrib/tools/random_check.sh
+++ b/contrib/tools/random_check.sh
@@ -49,8 +49,6 @@ while getopts n:j:x:hs option; do
 		echo "$OPTARG" | tr -d ' ' >>"$PRUNE_CONFIG_FILE"
 		;;
 	s)
-		echo "COMPILER=gcc_native" >>"$PRUNE_CONFIG_FILE"
-		echo "COMPILER=gcc_helenos" >>"$PRUNE_CONFIG_FILE"
 		;;
 	*|h)
 		echo "Usage: $0 [options]"

--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -45,21 +45,21 @@ H_ARCH_CONFIG_OUTPUT_FILENAME=3
 
 h_get_arch_config_space() {
     cat <<'EOF_CONFIG_SPACE'
-amd64:amd64-unknown-elf:image.iso
-arm32/beagleboardxm:arm-linux-gnueabi:uImage.bin
-arm32/beaglebone:arm-linux-gnueabi:uImage.bin
-arm32/gta02:arm-linux-gnueabi:uImage.bin
-arm32/integratorcp:arm-linux-gnueabi:image.boot
-arm32/raspberrypi:arm-linux-gnueabi:uImage.bin
-ia32:i686-pc-linux-gnu:image.iso
-ia64/i460GX:ia64-pc-linux-gnu:image.boot
-ia64/ski:ia64-pc-linux-gnu:image.boot
-mips32/malta-be:mips-linux-gnu:image.boot
-mips32/malta-le:mipsel-linux-gnu:image.boot
-mips32/msim:mipsel-linux-gnu:image.boot
-ppc32:ppc-linux-gnu:image.iso
-sparc64/niagara:sparc64-linux-gnu:image.iso
-sparc64/ultra:sparc64-linux-gnu:image.iso
+amd64:amd64-helenos:image.iso
+arm32/beagleboardxm:arm-helenos:uImage.bin
+arm32/beaglebone:arm-helenos:uImage.bin
+arm32/gta02:arm-helenos:uImage.bin
+arm32/integratorcp:arm-helenos:image.boot
+arm32/raspberrypi:arm-helenos:uImage.bin
+ia32:i686-helenos:image.iso
+ia64/i460GX:ia64-helenos:image.boot
+ia64/ski:ia64-helenos:image.boot
+mips32/malta-be:mips-helenos:image.boot
+mips32/malta-le:mipsel-helenos:image.boot
+mips32/msim:mipsel-helenos:image.boot
+ppc32:ppc-helenos:image.iso
+sparc64/niagara:sparc64-helenos:image.iso
+sparc64/ultra:sparc64-helenos:image.iso
 EOF_CONFIG_SPACE
 }
 

--- a/uspace/lib/posix/Makefile
+++ b/uspace/lib/posix/Makefile
@@ -119,7 +119,7 @@ export: $(EXPORT_DIR)/config.mk $(EXPORT_DIR)/config.rc
 $(EXPORT_DIR)/config.mk: export-libs export-includes
 	echo '# Generated file, do not modify.' >> $@.new
 	echo '# Do not forget to set HELENOS_EXPORT_ROOT.' >> $@.new
-	echo 'HELENOS_CROSS_PATH="$(shell dirname "$(CC)")"' >> $@.new
+	echo 'HELENOS_CROSS_PATH="$(shell dirname `which "$(CC)"`)"' >> $@.new
 	echo 'HELENOS_ARCH="$(firstword $(subst -, ,$(TARGET)))"' >> $@.new
 	echo 'HELENOS_TARGET="$(TARGET)"' >> $@.new
 	echo 'HELENOS_CPPFLAGS="$(EXPORT_CPPFLAGS)"' >> $@.new


### PR DESCRIPTION
As previously discussed, utilizing the compiler-provided headers and libraries would allow us to avoid a number of problems and reduce the amount of architecture-support code that we have to implement ourselves. With this change, the support for using Linux-targeted toolchain, or even the host toolchain itself, is removed, due to the inherent issues caused by such setup.

Additionally, the toolchain installation is a bit simplified to install all targets into a single prefix. This prefix can be added to the `PATH` so that one can simply execute e.g. `amd64-helenos-gcc` instead of needing to use the whole path.