### PR TITLE
compositor: ignore "mouse button pressed" events when resizing/moving…

### DIFF
--- a/uspace/srv/hid/compositor/compositor.c
+++ b/uspace/srv/hid/compositor/compositor.c
@@ -1700,7 +1700,7 @@ static errno_t comp_mouse_button(input_t *input, int bnum, int bpress)
 	desktop_rect_t dmg_rect1, dmg_rect2, dmg_rect3, dmg_rect4;
 #endif
 
-	if (bpress) {
+	if (bpress && !pointer->pressed) {
 		pointer->btn_pos = pointer->pos;
 		pointer->btn_num = bnum;
 		pointer->pressed = true;


### PR DESCRIPTION
… a window

If you are moving a window on top of another and you click the
mouse's right button, the compositor brings the background window on top.
This interferes with the window moving operation, leaves
a weird empty rectangle on the screen and confuses the user.

This patch fixes the bug by forcing the compositor to ignore
"mouse button pressed" events until the pointer is released.