### PR TITLE
Rename THE/the_t to CURRENT/current_t

### DIFF
--- a/kernel/arch/abs32le/include/arch/asm.h
+++ b/kernel/arch/abs32le/include/arch/asm.h
@@ -191,7 +191,7 @@ NO_TRACE static inline uintptr_t get_stack_base(void)
 {
 	/*
 	 * On real hardware this returns the address of the bottom
-	 * of the current CPU stack. The the_t structure is stored
+	 * of the current CPU stack. The current_t structure is stored
 	 * on the bottom of stack and this is used to identify the
 	 * current CPU, current task, current thread and current
 	 * address space.

--- a/kernel/generic/include/arch.h
+++ b/kernel/generic/include/arch.h
@@ -39,12 +39,11 @@
 #include <config.h>
 
 /*
- * THE is not an abbreviation, but the English definite article written in
- * capital letters. It means the current pointer to something, e.g. thread,
- * processor or address space. Kind reader of this comment shall appreciate
- * the wit of constructs like THE->thread and similar.
+ * The context pointer. The current_t structure holds pointers to various parts
+ * of the current execution context, like running task, thread, address space,
+ * etc.
  */
-#define THE  ((the_t * )(get_stack_base()))
+#define CURRENT  ((current_t * )(get_stack_base()))
 
 #define MAGIC                UINT32_C(0xfacefeed)
 
@@ -52,7 +51,7 @@
 
 #define DEFAULT_CONTAINER  0
 #define CONTAINER \
-	((THE->task) ? (THE->task->container) : (DEFAULT_CONTAINER))
+	((CURRENT->task) ? (CURRENT->task->container) : (DEFAULT_CONTAINER))
 
 /* Fwd decl. to avoid include hell. */
 struct thread;
@@ -75,7 +74,7 @@ typedef struct {
 	struct cpu *cpu;       /**< Executing cpu. */
 	struct as *as;         /**< Current address space. */
 	uint32_t magic;        /**< Magic value */
-} the_t;
+} current_t;
 
 typedef struct {
 	void (*pre_mm_init)(void);
@@ -95,8 +94,8 @@ extern arch_ops_t *arch_ops;
 
 #define ARCH_OP(op)	ARCH_STRUCT_OP(arch_ops, op)
 
-extern void the_initialize(the_t *);
-extern void the_copy(the_t *, the_t *);
+extern void current_initialize(current_t *);
+extern void current_copy(current_t *, current_t *);
 
 extern void calibrate_delay_loop(void);
 

--- a/kernel/generic/include/arch.h
+++ b/kernel/generic/include/arch.h
@@ -39,9 +39,8 @@
 #include <config.h>
 
 /*
- * The context pointer. The current_t structure holds pointers to various parts
- * of the current execution context, like running task, thread, address space,
- * etc.
+ * The current_t structure holds pointers to various parts of the current
+ * execution state, like running task, thread, address space, etc.
  */
 #define CURRENT  ((current_t * )(get_stack_base()))
 

--- a/kernel/generic/include/cpu.h
+++ b/kernel/generic/include/cpu.h
@@ -44,7 +44,7 @@
 #include <adt/list.h>
 #include <arch.h>
 
-#define CPU                  THE->cpu
+#define CPU                  CURRENT->cpu
 
 /** CPU structure.
  *

--- a/kernel/generic/include/mm/as.h
+++ b/kernel/generic/include/mm/as.h
@@ -49,7 +49,7 @@
 #include <arch.h>
 #include <lib/refcount.h>
 
-#define AS                   THE->as
+#define AS                   CURRENT->as
 
 /**
  * Defined to be true if user address space and kernel address space shadow each

--- a/kernel/generic/include/preemption.h
+++ b/kernel/generic/include/preemption.h
@@ -40,13 +40,13 @@
 #include <barrier.h>
 
 #define PREEMPTION_INC         (1 << 0)
-#define PREEMPTION_DISABLED    (PREEMPTION_INC <= THE->preemption)
+#define PREEMPTION_DISABLED    (PREEMPTION_INC <= CURRENT->preemption)
 #define PREEMPTION_ENABLED     (!PREEMPTION_DISABLED)
 
 /** Increment preemption disabled counter. */
 #define preemption_disable() \
 	do { \
-		THE->preemption += PREEMPTION_INC; \
+		CURRENT->preemption += PREEMPTION_INC; \
 		compiler_barrier(); \
 	} while (0)
 
@@ -55,7 +55,7 @@
 	do { \
 		assert(PREEMPTION_DISABLED); \
 		compiler_barrier(); \
-		THE->preemption -= PREEMPTION_INC; \
+		CURRENT->preemption -= PREEMPTION_INC; \
 	} while (0)
 
 #endif

--- a/kernel/generic/include/proc/task.h
+++ b/kernel/generic/include/proc/task.h
@@ -62,7 +62,7 @@
 #include <arch.h>
 #include <cap/cap.h>
 
-#define TASK                 THE->task
+#define TASK                 CURRENT->task
 
 struct thread;
 struct cap;

--- a/kernel/generic/include/proc/thread.h
+++ b/kernel/generic/include/proc/thread.h
@@ -51,7 +51,7 @@
 #include <abi/sysinfo.h>
 #include <arch.h>
 
-#define THREAD              THE->thread
+#define THREAD              CURRENT->thread
 
 #define THREAD_NAME_BUFLEN  20
 

--- a/kernel/generic/include/synch/rcu.h
+++ b/kernel/generic/include/synch/rcu.h
@@ -131,7 +131,7 @@ void _rcu_preempted_unlock(void);
  */
 static inline void rcu_read_lock(void)
 {
-	THE->rcu_nesting += RCU_CNT_INC;
+	CURRENT->rcu_nesting += RCU_CNT_INC;
 	compiler_barrier();
 }
 
@@ -139,9 +139,9 @@ static inline void rcu_read_lock(void)
 static inline void rcu_read_unlock(void)
 {
 	compiler_barrier();
-	THE->rcu_nesting -= RCU_CNT_INC;
+	CURRENT->rcu_nesting -= RCU_CNT_INC;
 
-	if (RCU_WAS_PREEMPTED == THE->rcu_nesting) {
+	if (RCU_WAS_PREEMPTED == CURRENT->rcu_nesting) {
 		_rcu_preempted_unlock();
 	}
 }

--- a/kernel/generic/include/time/timeout.h
+++ b/kernel/generic/include/time/timeout.h
@@ -44,7 +44,7 @@ typedef void (*timeout_handler_t)(void *arg);
 typedef struct {
 	IRQ_SPINLOCK_DECLARE(lock);
 
-	/** Link to the list of active timeouts on THE->cpu */
+	/** Link to the list of active timeouts on CURRENT->cpu */
 	link_t link;
 	/** Timeout will be activated in this amount of clock() ticks. */
 	uint64_t ticks;

--- a/kernel/generic/src/debug/panic.c
+++ b/kernel/generic/src/debug/panic.c
@@ -93,17 +93,17 @@ void panic_common(panic_category_t cat, istate_t *istate, int access,
 
 	printf("\n");
 
-	printf("THE=%p: ", THE);
-	if (THE != NULL) {
+	printf("CURRENT=%p: ", CURRENT);
+	if (CURRENT != NULL) {
 		printf("pe=%" PRIuPTR " thread=%p task=%p cpu=%p as=%p"
-		    " magic=%#" PRIx32 "\n", THE->preemption,
-		    THE->thread, THE->task, THE->cpu, THE->as, THE->magic);
+		    " magic=%#" PRIx32 "\n", CURRENT->preemption,
+		    CURRENT->thread, CURRENT->task, CURRENT->cpu, CURRENT->as, CURRENT->magic);
 
-		if (THE->thread != NULL)
-			printf("thread=\"%s\"\n", THE->thread->name);
+		if (CURRENT->thread != NULL)
+			printf("thread=\"%s\"\n", CURRENT->thread->name);
 
-		if (THE->task != NULL)
-			printf("task=\"%s\"\n", THE->task->name);
+		if (CURRENT->task != NULL)
+			printf("task=\"%s\"\n", CURRENT->task->name);
 	} else
 		printf("invalid\n");
 

--- a/kernel/generic/src/main/main.c
+++ b/kernel/generic/src/main/main.c
@@ -212,7 +212,7 @@ NO_TRACE void main_bsp(void)
 void main_bsp_separated_stack(void)
 {
 	/* Keep this the first thing. */
-	the_initialize(THE);
+	current_initialize(CURRENT);
 
 	version_print();
 
@@ -341,9 +341,9 @@ void main_ap(void)
 	config.cpu_active++;
 
 	/*
-	 * The THE structure is well defined because ctx.sp is used as stack.
+	 * The CURRENT structure is well defined because ctx.sp is used as stack.
 	 */
-	the_initialize(THE);
+	current_initialize(CURRENT);
 
 	ARCH_OP(pre_mm_init);
 	frame_init();
@@ -355,7 +355,7 @@ void main_ap(void)
 	calibrate_delay_loop();
 	ARCH_OP(post_cpu_init);
 
-	the_copy(THE, (the_t *) CPU->stack);
+	current_copy(CURRENT, (current_t *) CPU->stack);
 
 	/*
 	 * If we woke kmp up before we left the kernel stack, we could

--- a/kernel/generic/src/proc/scheduler.c
+++ b/kernel/generic/src/proc/scheduler.c
@@ -362,12 +362,12 @@ void scheduler(void)
 	}
 
 	/*
-	 * Through the 'THE' structure, we keep track of THREAD, TASK, CPU, AS
-	 * and preemption counter. At this point THE could be coming either
+	 * Through the 'CURRENT' structure, we keep track of THREAD, TASK, CPU, AS
+	 * and preemption counter. At this point CURRENT could be coming either
 	 * from THREAD's or CPU's stack.
 	 *
 	 */
-	the_copy(THE, (the_t *) CPU->stack);
+	current_copy(CURRENT, (current_t *) CPU->stack);
 
 	/*
 	 * We may not keep the old stack.
@@ -547,7 +547,7 @@ void scheduler_separated_stack(void)
 	 * Copy the knowledge of CPU, TASK, THREAD and preemption counter to
 	 * thread's stack.
 	 */
-	the_copy(THE, (the_t *) THREAD->kstack);
+	current_copy(CURRENT, (current_t *) THREAD->kstack);
 
 	context_restore(&THREAD->saved_context);
 

--- a/kernel/generic/src/proc/the.c
+++ b/kernel/generic/src/proc/the.c
@@ -32,10 +32,10 @@
 
 /**
  * @file
- * @brief THE structure functions.
+ * @brief CURRENT structure functions.
  *
- * This file contains functions to manage the THE structure.
- * The THE structure exists at the base address of every kernel
+ * This file contains functions to manage the CURRENT structure.
+ * The CURRENT structure exists at the base address of every kernel
  * stack and carries information about current settings
  * (e.g. current CPU, current thread, task and address space
  * and current preemption counter).
@@ -44,14 +44,14 @@
 #include <arch.h>
 #include <assert.h>
 
-/** Initialize THE structure
+/** Initialize CURRENT structure
  *
- * Initialize THE structure passed as argument.
+ * Initialize CURRENT structure passed as argument.
  *
- * @param the THE structure to be initialized.
+ * @param the CURRENT structure to be initialized.
  *
  */
-void the_initialize(the_t *the)
+void current_initialize(current_t *the)
 {
 	the->preemption = 0;
 	the->cpu = NULL;
@@ -64,15 +64,15 @@ void the_initialize(the_t *the)
 #endif
 }
 
-/** Copy THE structure
+/** Copy CURRENT structure
  *
- * Copy the source THE structure to the destination THE structure.
+ * Copy the source CURRENT structure to the destination CURRENT structure.
  *
- * @param src The source THE structure.
- * @param dst The destination THE structure.
+ * @param src The source CURRENT structure.
+ * @param dst The destination CURRENT structure.
  *
  */
-NO_TRACE void the_copy(the_t *src, the_t *dst)
+NO_TRACE void current_copy(current_t *src, current_t *dst)
 {
 	assert(src->magic == MAGIC);
 	*dst = *src;

--- a/kernel/generic/src/proc/thread.c
+++ b/kernel/generic/src/proc/thread.c
@@ -355,7 +355,7 @@ thread_t *thread_create(void (*func)(void *), void *arg, task_t *task,
 	context_set(&thread->saved_context, FADDR(cushion),
 	    (uintptr_t) thread->kstack, STACK_SIZE);
 
-	the_initialize((the_t *) thread->kstack);
+	current_initialize((current_t *) thread->kstack);
 
 	ipl_t ipl = interrupts_disable();
 	thread->saved_context.ipl = interrupts_read();


### PR DESCRIPTION
Because the word "THE" occurs several times in every licence
header, searching for occurences of "THE" macro is more difficult
than necessary.

While I appreciate the wit of it, using a nonconflicting word
for it is more practical.