### PR TITLE
Fix as_t reference counting

### DIFF
--- a/kernel/generic/src/mm/as.c
+++ b/kernel/generic/src/mm/as.c
@@ -136,12 +136,6 @@ void as_init(void)
 	AS_KERNEL = as_create(FLAG_AS_KERNEL);
 	if (!AS_KERNEL)
 		panic("Cannot create kernel address space.");
-
-	/*
-	 * Make sure the kernel address space
-	 * reference count never drops to zero.
-	 */
-	as_hold(AS_KERNEL);
 }
 
 /** Create address space.

--- a/kernel/generic/src/proc/task.c
+++ b/kernel/generic/src/proc/task.c
@@ -251,11 +251,6 @@ task_t *task_create(as_t *as, const char *name)
 
 	futex_task_init(task);
 
-	/*
-	 * Get a reference to the address space.
-	 */
-	as_hold(task->as);
-
 	irq_spinlock_lock(&tasks_lock, true);
 
 	task->taskid = ++task_counter;


### PR DESCRIPTION
Commit 78de83de52a9115dc77b09bb7029403dad8c2fb0 changed the way how
reference counting works for newly created objects, but didn't remove
the explicit bumping of reference count for address spaces, which had
been necessary before that. Because of that, as_t structures were never
deallocated.