### PR TITLE
Add missing libs to image.iso

### DIFF
--- a/boot/Makefile
+++ b/boot/Makefile
@@ -64,7 +64,6 @@ ifeq ($(CONFIG_DEVEL_FILES), y)
 	cp -r -L "$(USPACE_PATH)/lib/c/include/." "$(DIST_PATH)/inc/c/"
 	cp -r -L "$(ROOT_PATH)/abi/include/." "$(DIST_PATH)/inc/c/"
 	cp -r -L "$(USPACE_PATH)/lib/c/arch/$(UARCH)/include/." "$(DIST_PATH)/inc/c/"
-	cat "$(USPACE_PATH)/lib/c/arch/$(UARCH)/_link.ld" | sed 's/^STARTUP(.*)$$//g' > "$(DIST_PATH)/inc/_link.ld"
 endif
 
 	for app in $(RD_APPS) ; do \

--- a/boot/Makefile
+++ b/boot/Makefile
@@ -64,6 +64,9 @@ ifeq ($(CONFIG_DEVEL_FILES), y)
 	cp -r -L "$(USPACE_PATH)/lib/c/include/." "$(DIST_PATH)/inc/c/"
 	cp -r -L "$(ROOT_PATH)/abi/include/." "$(DIST_PATH)/inc/c/"
 	cp -r -L "$(USPACE_PATH)/lib/c/arch/$(UARCH)/include/." "$(DIST_PATH)/inc/c/"
+	cp -L "$(USPACE_PATH)/lib/c/crt0.o" "$(DIST_PATH)/lib/"
+	cp -L "$(USPACE_PATH)/lib/c/crt1.o" "$(DIST_PATH)/lib/"
+	cp -L "$(LIBGCC_PATH)" "$(DIST_PATH)/lib/"
 endif
 
 	for app in $(RD_APPS) ; do \


### PR DESCRIPTION
This PR adds `crt*.o` files and `libgcc.a` to the generated image when `CONFIG_DEVEL_FILES` is set so we can compile again inside HelenOS ([this bug](http://www.helenos.org/ticket/750)) (another PR for harbours will be opened shortly).

The change is rather big because it has to find `libgcc.a` which is somewhere in `$CROSS_PREFIX`.

@le-jzr does it make sense to do it like this? Thanks!