### PR TITLE
Some improvements to x86 kernel loading

### DIFF
--- a/kernel/arch/amd64/_link.ld.in
+++ b/kernel/arch/amd64/_link.ld.in
@@ -41,7 +41,11 @@ SECTIONS {
 		unmapped_end = .;
 	} :unmapped
 
-	.mapped (PA2KA(BOOT_OFFSET) + SIZEOF(.unmapped)) : AT (BOOT_OFFSET + SIZEOF(.unmapped)) {
+	.unmapped_bss : {
+		*(.bootstack);
+	} :unmapped
+
+	.mapped (PA2KA(BOOT_OFFSET) + SIZEOF(.unmapped) + SIZEOF(.unmapped_bss)) : AT (BOOT_OFFSET + SIZEOF(.unmapped) + SIZEOF(.unmapped_bss)) {
 		ktext_start = .;
 		*(.text .text.*);
 		ktext_end = .;

--- a/kernel/arch/amd64/_link.ld.in
+++ b/kernel/arch/amd64/_link.ld.in
@@ -13,18 +13,35 @@
 
 ENTRY(multiboot_image_start)
 
+PHDRS {
+	ap_boot PT_LOAD ;
+	unmapped PT_LOAD ;
+	mapped PT_LOAD ;
+}
+
 SECTIONS {
 	kernel_load_address = PA2KA(BOOT_OFFSET);
 
-	.unmapped (BOOT_OFFSET + SIZEOF_HEADERS): AT (BOOT_OFFSET + SIZEOF_HEADERS) {
+	.ap_bootstrap (AP_BOOT_OFFSET): AT (AP_BOOT_OFFSET) {
+		ap_bootstrap_start = .;
+
+		/* Must be first. */
+		*(.multiboot);
+
+		*(K_AP_TEXT_START);
+		*(K_AP_DATA_START);
+		ap_bootstrap_end = .;
+	} :ap_boot
+
+	.unmapped (BOOT_OFFSET): AT (BOOT_OFFSET) {
 		unmapped_start = .;
 		*(K_TEXT_START);
 		*(K_DATA_START);
 		*(K_INI_PTLS);
 		unmapped_end = .;
-	}
+	} :unmapped
 
-	.mapped (PA2KA(BOOT_OFFSET) + SIZEOF_HEADERS + SIZEOF(.unmapped)) : AT (BOOT_OFFSET + SIZEOF_HEADERS + SIZEOF(.unmapped)) {
+	.mapped (PA2KA(BOOT_OFFSET) + SIZEOF(.unmapped)) : AT (BOOT_OFFSET + SIZEOF(.unmapped)) {
 		ktext_start = .;
 		*(.text .text.*);
 		ktext_end = .;
@@ -42,7 +59,7 @@ SECTIONS {
 		*(symtab.*);    /* Symbol table, must be LAST symbol!*/
 
 		kdata_end = .;
-	}
+	} :mapped
 
 #ifdef CONFIG_LINE_DEBUG
 	.comment 0 : { *(.comment); }
@@ -62,8 +79,6 @@ SECTIONS {
 	}
 
 #ifdef CONFIG_SMP
-	ap_boot = unmapped_ap_boot - BOOT_OFFSET + AP_BOOT_OFFSET;
-	ap_gdtr = unmapped_ap_gdtr - BOOT_OFFSET + AP_BOOT_OFFSET;
 	protected_ap_gdtr = PA2KA(ap_gdtr);
 #endif /* CONFIG_SMP */
 

--- a/kernel/arch/amd64/_link.ld.in
+++ b/kernel/arch/amd64/_link.ld.in
@@ -11,6 +11,8 @@
 #include <arch/boot/boot.h>
 #include <arch/mm/page.h>
 
+ENTRY(multiboot_image_start)
+
 SECTIONS {
 	kernel_load_address = PA2KA(BOOT_OFFSET);
 

--- a/kernel/arch/amd64/_link.ld.in
+++ b/kernel/arch/amd64/_link.ld.in
@@ -22,46 +22,55 @@ PHDRS {
 SECTIONS {
 	kernel_load_address = PA2KA(BOOT_OFFSET);
 
-	.ap_bootstrap (AP_BOOT_OFFSET): AT (AP_BOOT_OFFSET) {
-		ap_bootstrap_start = .;
+	. = AP_BOOT_OFFSET + SIZEOF_HEADERS;
 
-		/* Must be first. */
-		*(.multiboot);
+	/* Must be first. */
+	.multiboot : { *(.multiboot); } :ap_boot
 
+	ap_bootstrap_start = .;
+
+	.ap_bootstrap : {
 		*(K_AP_TEXT_START);
 		*(K_AP_DATA_START);
-		ap_bootstrap_end = .;
 	} :ap_boot
 
-	.unmapped (BOOT_OFFSET): AT (BOOT_OFFSET) {
-		unmapped_start = .;
+	ap_bootstrap_end = .;
+
+	. = BOOT_OFFSET + (ap_bootstrap_end & (PAGE_SIZE-1));
+	unmapped_start = .;
+
+	.unmapped : {
 		*(K_TEXT_START);
 		*(K_DATA_START);
 		*(K_INI_PTLS);
-		unmapped_end = .;
 	} :unmapped
+
+	unmapped_file_end = .;
 
 	.unmapped_bss : {
 		*(.bootstack);
+		*(K_BSS_START);
 	} :unmapped
 
-	.mapped (PA2KA(BOOT_OFFSET) + SIZEOF(.unmapped) + SIZEOF(.unmapped_bss)) : AT (BOOT_OFFSET + SIZEOF(.unmapped) + SIZEOF(.unmapped_bss)) {
+	unmapped_end = .;
+	mapped_load_start = ALIGN(PAGE_SIZE) + (unmapped_file_end & (PAGE_SIZE-1));
+
+	.mapped (PA2KA(mapped_load_start)): AT (mapped_load_start) {
 		ktext_start = .;
 		*(.text .text.*);
 		ktext_end = .;
 
 		kdata_start = .;
-		*(.data);              /* initialized data */
-		*(.rodata .rodata.*);  /* string literals */
-		*(COMMON);      /* global variables */
+		*(.data);               /* initialized data */
+		*(.rodata .rodata.*);   /* string literals */
+		*(COMMON);              /* global variables */
 
 		/* bss can't be omitted from the ELF image. */
-		*(.bss);        /* uninitialized static variables */
+		*(.bss);                /* uninitialized static variables */
 
 		. = ALIGN(8);
 		symbol_table = .;
-		*(symtab.*);    /* Symbol table, must be LAST symbol!*/
-
+		*(symtab.*);            /* Symbol table, must be LAST symbol! */
 		kdata_end = .;
 	} :mapped
 

--- a/kernel/arch/amd64/include/arch/boot/boot.h
+++ b/kernel/arch/amd64/include/arch/boot/boot.h
@@ -41,7 +41,8 @@
 
 #ifndef __ASSEMBLER__
 
-extern uint8_t unmapped_end[];
+extern uint8_t ap_bootstrap_start[];
+extern uint8_t ap_bootstrap_end[];
 
 #endif /* __ASSEMBLER__ */
 

--- a/kernel/arch/amd64/src/amd64.c
+++ b/kernel/arch/amd64/src/amd64.c
@@ -91,12 +91,6 @@ void amd64_pre_main(uint32_t signature, void *info)
 	/* Parse multiboot information obtained from the bootloader. */
 	multiboot_info_parse(signature, (multiboot_info_t *) info);
 	multiboot2_info_parse(signature, (multiboot2_info_t *) info);
-
-#ifdef CONFIG_SMP
-	size_t unmapped_size = (uintptr_t) unmapped_end - BOOT_OFFSET;
-	/* Copy AP bootstrap routines below 1 MB. */
-	memcpy((void *) AP_BOOT_OFFSET, (void *) BOOT_OFFSET, unmapped_size);
-#endif
 }
 
 void amd64_pre_mm_init(void)

--- a/kernel/arch/amd64/src/asm.S
+++ b/kernel/arch/amd64/src/asm.S
@@ -33,6 +33,13 @@
 #include <arch/kseg_struct.h>
 #include <arch/cpu.h>
 #include <arch/smp/apic.h>
+#include <arch/boot/boot.h>
+
+.section .bootstack, "a", @nobits
+.align 16
+SYMBOL(bootstack_bottom)
+.skip BOOT_STACK_SIZE
+SYMBOL(bootstack_top)
 
 .text
 

--- a/kernel/arch/amd64/src/boot/multiboot.S
+++ b/kernel/arch/amd64/src/boot/multiboot.S
@@ -45,6 +45,30 @@
 
 #define START_STACK  (BOOT_OFFSET - BOOT_STACK_SIZE)
 
+.section .multiboot, "a"
+
+.align 4
+multiboot_header:
+	.long MULTIBOOT_HEADER_MAGIC
+#ifdef CONFIG_FB
+	.long MULTIBOOT_HEADER_FLAGS
+	.long -(MULTIBOOT_HEADER_MAGIC + MULTIBOOT_HEADER_FLAGS)  /* checksum */
+#else
+	.long MULTIBOOT_HEADER_FLAGS_NOFB
+	.long -(MULTIBOOT_HEADER_MAGIC + MULTIBOOT_HEADER_FLAGS_NOFB)  /* checksum */
+#endif
+	.long 0
+	.long 0
+	.long 0
+	.long 0
+	.long 0
+#ifdef CONFIG_FB
+	.long 0
+	.long CONFIG_BFB_WIDTH
+	.long CONFIG_BFB_HEIGHT
+	.long CONFIG_BFB_BPP
+#endif
+
 .section K_TEXT_START, "ax"
 
 .code32
@@ -68,28 +92,6 @@
 	pm_status \msg
 #endif
 .endm
-
-.align 4
-multiboot_header:
-	.long MULTIBOOT_HEADER_MAGIC
-#ifdef CONFIG_FB
-	.long MULTIBOOT_HEADER_FLAGS
-	.long -(MULTIBOOT_HEADER_MAGIC + MULTIBOOT_HEADER_FLAGS)  /* checksum */
-#else
-	.long MULTIBOOT_HEADER_FLAGS_NOFB
-	.long -(MULTIBOOT_HEADER_MAGIC + MULTIBOOT_HEADER_FLAGS_NOFB)  /* checksum */
-#endif
-	.long 0
-	.long 0
-	.long 0
-	.long 0
-	.long 0
-#ifdef CONFIG_FB
-	.long 0
-	.long CONFIG_BFB_WIDTH
-	.long CONFIG_BFB_HEIGHT
-	.long CONFIG_BFB_BPP
-#endif
 
 SYMBOL(multiboot_image_start)
 	cli

--- a/kernel/arch/amd64/src/boot/multiboot.S
+++ b/kernel/arch/amd64/src/boot/multiboot.S
@@ -79,11 +79,11 @@ multiboot_header:
 	.long MULTIBOOT_HEADER_FLAGS_NOFB
 	.long -(MULTIBOOT_HEADER_MAGIC + MULTIBOOT_HEADER_FLAGS_NOFB)  /* checksum */
 #endif
-	.long multiboot_header
-	.long unmapped_start
 	.long 0
 	.long 0
-	.long multiboot_image_start
+	.long 0
+	.long 0
+	.long 0
 #ifdef CONFIG_FB
 	.long 0
 	.long CONFIG_BFB_WIDTH

--- a/kernel/arch/amd64/src/boot/multiboot.S
+++ b/kernel/arch/amd64/src/boot/multiboot.S
@@ -43,8 +43,6 @@
 //       Currently we only enable EGA statically, which forces us to rebuild
 //       the image to get very early debug output.
 
-#define START_STACK  (BOOT_OFFSET - BOOT_STACK_SIZE)
-
 .section .multiboot, "a"
 
 .align 4
@@ -98,7 +96,7 @@ SYMBOL(multiboot_image_start)
 	cld
 
 	/* Initialize stack pointer */
-	movl $START_STACK, %esp
+	movl $bootstack_top, %esp
 
 	/*
 	 * Initialize Global Descriptor Table and
@@ -435,7 +433,7 @@ start64:
 	 * Long mode.
 	 */
 
-	movq $(PA2KA(START_STACK)), %rsp
+	movq $(PA2KA(bootstack_top)), %rsp
 
 	/* Create the first stack frame */
 	pushq $0

--- a/kernel/arch/amd64/src/boot/multiboot2.S
+++ b/kernel/arch/amd64/src/boot/multiboot2.S
@@ -59,27 +59,6 @@ multiboot2_header_start:
 #endif
 	tag_info_req_end:
 
-	/* Address tag */
-	.align 8
-	tag_address_start:
-		.word MULTIBOOT2_TAG_ADDRESS
-		.word MULTIBOOT2_FLAGS_REQUIRED
-		.long tag_address_end - tag_address_start
-		.long multiboot2_header_start
-		.long unmapped_start
-		.long 0
-		.long 0
-	tag_address_end:
-
-	/* Entry address tag */
-	.align 8
-	tag_entry_address_start:
-		.word MULTIBOOT2_TAG_ENTRY_ADDRESS
-		.word MULTIBOOT2_FLAGS_REQUIRED
-		.long tag_entry_address_end - tag_entry_address_start
-		.long multiboot_image_start
-	tag_entry_address_end:
-
 	/* Flags tag */
 	.align 8
 	tag_flags_start:

--- a/kernel/arch/amd64/src/boot/multiboot2.S
+++ b/kernel/arch/amd64/src/boot/multiboot2.S
@@ -34,9 +34,7 @@
 #include <arch/cpu.h>
 #include <genarch/multiboot/multiboot2.h>
 
-.section K_TEXT_START, "ax"
-
-.code32
+.section .multiboot, "a"
 
 .align 8
 multiboot2_header_start:

--- a/kernel/arch/amd64/src/smp/ap.S
+++ b/kernel/arch/amd64/src/smp/ap.S
@@ -40,7 +40,7 @@
 #include <arch/cpuid.h>
 #include <arch/context_struct.h>
 
-.section K_TEXT_START, "ax"
+.section K_AP_TEXT_START, "ax"
 
 #ifdef CONFIG_SMP
 
@@ -49,7 +49,8 @@
 # IPI requirements.
 
 .align 4096
-SYMBOL(unmapped_ap_boot)
+
+SYMBOL(ap_boot)
 .code16
 	cli
 	xorw %ax, %ax
@@ -60,7 +61,7 @@ SYMBOL(unmapped_ap_boot)
 	movl %cr0, %eax
 	orl $CR0_PE, %eax
 	movl %eax, %cr0     # switch to protected mode
-	jmpl $GDT_SELECTOR(KTEXT32_DES), $jump_to_kernel - BOOT_OFFSET + AP_BOOT_OFFSET
+	jmpl $GDT_SELECTOR(KTEXT32_DES), $jump_to_kernel
 
 jump_to_kernel:
 .code32
@@ -93,7 +94,7 @@ jump_to_kernel:
 	movl %eax, %cr0
 
 	# At this point we are in compatibility mode
-	jmpl $GDT_SELECTOR(KTEXT_DES), $start64 - BOOT_OFFSET + AP_BOOT_OFFSET
+	jmpl $GDT_SELECTOR(KTEXT_DES), $start64
 
 .code64
 start64:
@@ -108,11 +109,11 @@ start64:
 
 #endif /* CONFIG_SMP */
 
-.section K_DATA_START, "aw", @progbits
+.section K_AP_DATA_START, "aw", @progbits
 
 #ifdef CONFIG_SMP
 
-SYMBOL(unmapped_ap_gdtr)
+SYMBOL(ap_gdtr)
 	.word 0
 	.long 0
 

--- a/kernel/arch/ia32/_link.ld.in
+++ b/kernel/arch/ia32/_link.ld.in
@@ -13,17 +13,34 @@
 
 ENTRY(multiboot_image_start)
 
+PHDRS {
+	ap_boot PT_LOAD ;
+	unmapped PT_LOAD ;
+	mapped PT_LOAD ;
+}
+
 SECTIONS {
 	kernel_load_address = PA2KA(BOOT_OFFSET);
 
-	.unmapped (BOOT_OFFSET + SIZEOF_HEADERS): AT (BOOT_OFFSET + SIZEOF_HEADERS) {
+	.ap_bootstrap (AP_BOOT_OFFSET): AT (AP_BOOT_OFFSET) {
+		ap_bootstrap_start = .;
+
+		/* Must be first. */
+		*(.multiboot);
+
+		*(K_AP_TEXT_START);
+		*(K_AP_DATA_START);
+		ap_bootstrap_end = .;
+	} :ap_boot
+
+	.unmapped (BOOT_OFFSET): AT (BOOT_OFFSET) {
 		unmapped_start = .;
 		*(K_TEXT_START);
 		*(K_DATA_START);
 		unmapped_end = .;
-	}
+	} :unmapped
 
-	.mapped (PA2KA(BOOT_OFFSET) + SIZEOF_HEADERS + SIZEOF(.unmapped)): AT (BOOT_OFFSET + SIZEOF_HEADERS + SIZEOF(.unmapped)) {
+	.mapped (PA2KA(BOOT_OFFSET) + SIZEOF(.unmapped)): AT (BOOT_OFFSET + SIZEOF(.unmapped)) {
 		ktext_start = .;
 		*(.text .text.*);
 		ktext_end = .;
@@ -40,7 +57,7 @@ SECTIONS {
 		symbol_table = .;
 		*(symtab.*);            /* Symbol table, must be LAST symbol! */
 		kdata_end = .;
-	}
+	} :mapped
 
 #ifdef CONFIG_LINE_DEBUG
 	.comment 0 : { *(.comment); }
@@ -60,11 +77,7 @@ SECTIONS {
 	}
 
 #ifdef CONFIG_SMP
-
-	ap_boot = unmapped_ap_boot - BOOT_OFFSET + AP_BOOT_OFFSET;
-	ap_gdtr = unmapped_ap_gdtr - BOOT_OFFSET + AP_BOOT_OFFSET;
 	protected_ap_gdtr = PA2KA(ap_gdtr);
-
 #endif /* CONFIG_SMP */
 
 }

--- a/kernel/arch/ia32/_link.ld.in
+++ b/kernel/arch/ia32/_link.ld.in
@@ -40,7 +40,11 @@ SECTIONS {
 		unmapped_end = .;
 	} :unmapped
 
-	.mapped (PA2KA(BOOT_OFFSET) + SIZEOF(.unmapped)): AT (BOOT_OFFSET + SIZEOF(.unmapped)) {
+	.unmapped_bss : {
+		*(.bootstack);
+	} :unmapped
+
+	.mapped (PA2KA(BOOT_OFFSET) + SIZEOF(.unmapped) + SIZEOF(.unmapped_bss)): AT (BOOT_OFFSET + SIZEOF(.unmapped) + SIZEOF(.unmapped_bss)) {
 		ktext_start = .;
 		*(.text .text.*);
 		ktext_end = .;

--- a/kernel/arch/ia32/_link.ld.in
+++ b/kernel/arch/ia32/_link.ld.in
@@ -22,29 +22,39 @@ PHDRS {
 SECTIONS {
 	kernel_load_address = PA2KA(BOOT_OFFSET);
 
-	.ap_bootstrap (AP_BOOT_OFFSET): AT (AP_BOOT_OFFSET) {
-		ap_bootstrap_start = .;
+	. = AP_BOOT_OFFSET + SIZEOF_HEADERS;
 
-		/* Must be first. */
-		*(.multiboot);
+	/* Must be first. */
+	.multiboot : { *(.multiboot); } :ap_boot
 
+	ap_bootstrap_start = .;
+
+	.ap_bootstrap : {
 		*(K_AP_TEXT_START);
 		*(K_AP_DATA_START);
-		ap_bootstrap_end = .;
 	} :ap_boot
 
-	.unmapped (BOOT_OFFSET): AT (BOOT_OFFSET) {
-		unmapped_start = .;
+	ap_bootstrap_end = .;
+
+	. = BOOT_OFFSET + (ap_bootstrap_end & (PAGE_SIZE-1));
+	unmapped_start = .;
+
+	.unmapped : {
 		*(K_TEXT_START);
 		*(K_DATA_START);
-		unmapped_end = .;
 	} :unmapped
+
+	unmapped_file_end = .;
 
 	.unmapped_bss : {
 		*(.bootstack);
+		*(K_BSS_START);
 	} :unmapped
 
-	.mapped (PA2KA(BOOT_OFFSET) + SIZEOF(.unmapped) + SIZEOF(.unmapped_bss)): AT (BOOT_OFFSET + SIZEOF(.unmapped) + SIZEOF(.unmapped_bss)) {
+	unmapped_end = .;
+	mapped_load_start = ALIGN(PAGE_SIZE) + (unmapped_file_end & (PAGE_SIZE-1));
+
+	.mapped (PA2KA(mapped_load_start)): AT (mapped_load_start) {
 		ktext_start = .;
 		*(.text .text.*);
 		ktext_end = .;

--- a/kernel/arch/ia32/_link.ld.in
+++ b/kernel/arch/ia32/_link.ld.in
@@ -11,6 +11,8 @@
 #include <arch/boot/boot.h>
 #include <arch/mm/page.h>
 
+ENTRY(multiboot_image_start)
+
 SECTIONS {
 	kernel_load_address = PA2KA(BOOT_OFFSET);
 

--- a/kernel/arch/ia32/include/arch/boot/boot.h
+++ b/kernel/arch/ia32/include/arch/boot/boot.h
@@ -43,7 +43,8 @@
 
 #ifdef CONFIG_SMP
 
-extern uint8_t unmapped_end[];
+extern uint8_t ap_bootstrap_start[];
+extern uint8_t ap_bootstrap_end[];
 
 #endif /* CONFIG_SMP */
 

--- a/kernel/arch/ia32/src/asm.S
+++ b/kernel/arch/ia32/src/asm.S
@@ -36,6 +36,13 @@
 #include <arch/mm/page.h>
 #include <arch/istate_struct.h>
 #include <arch/smp/apic.h>
+#include <arch/boot/boot.h>
+
+.section .bootstack, "a", @nobits
+.align 16
+SYMBOL(bootstack_bottom)
+.skip BOOT_STACK_SIZE
+SYMBOL(bootstack_top)
 
 .text
 

--- a/kernel/arch/ia32/src/boot/multiboot.S
+++ b/kernel/arch/ia32/src/boot/multiboot.S
@@ -45,23 +45,7 @@
 
 #define START_STACK  (BOOT_OFFSET - BOOT_STACK_SIZE)
 
-.section K_TEXT_START, "ax"
-
-.code32
-
-.macro pm_status msg
-#if defined(CONFIG_EGA) && !defined(CONFIG_FB)
-	pushl %esi
-	movl \msg, %esi
-	call pm_early_puts
-	popl %esi
-#endif
-.endm
-
-.macro pm2_status msg
-	pushl \msg
-	call early_puts
-.endm
+.section .multiboot, "a"
 
 .align 4
 multiboot_header:
@@ -84,6 +68,24 @@ multiboot_header:
 	.long CONFIG_BFB_HEIGHT
 	.long CONFIG_BFB_BPP
 #endif
+
+.section K_TEXT_START, "ax"
+
+.code32
+
+.macro pm_status msg
+#if defined(CONFIG_EGA) && !defined(CONFIG_FB)
+	pushl %esi
+	movl \msg, %esi
+	call pm_early_puts
+	popl %esi
+#endif
+.endm
+
+.macro pm2_status msg
+	pushl \msg
+	call early_puts
+.endm
 
 SYMBOL(multiboot_image_start)
 	cli

--- a/kernel/arch/ia32/src/boot/multiboot.S
+++ b/kernel/arch/ia32/src/boot/multiboot.S
@@ -43,8 +43,6 @@
 //       Currently we only enable EGA statically, which forces us to rebuild
 //       the image to get very early debug output.
 
-#define START_STACK  (BOOT_OFFSET - BOOT_STACK_SIZE)
-
 .section .multiboot, "a"
 
 .align 4
@@ -92,7 +90,7 @@ SYMBOL(multiboot_image_start)
 	cld
 
 	/* Initialize stack pointer */
-	movl $START_STACK, %esp
+	movl $bootstack_top, %esp
 
 	/*
 	 * Initialize Global Descriptor Table and
@@ -146,6 +144,7 @@ SYMBOL(multiboot_image_start)
 		call map_kernel_non_pse
 
 	stack_init:
+	movl $PA2KA(bootstack_top), %esp
 
 	/* Create the first stack frame */
 	pushl $0
@@ -299,6 +298,8 @@ calc_kernel_end:
 	movl $KA2PA(kdata_end), %edi
 	movl %edi, kernel_end
 	ret
+
+// TODO: remove this cruft
 
 /** Find free 2M (+4k for alignment) region where to store page tables */
 find_mem_for_pt:

--- a/kernel/arch/ia32/src/boot/multiboot.S
+++ b/kernel/arch/ia32/src/boot/multiboot.S
@@ -596,7 +596,7 @@ early_puts:
 
 	ret
 
-.section K_DATA_START, "aw", @progbits
+.section K_BSS_START, "aw", @nobits
 
 .align 4096
 page_directory:
@@ -605,10 +605,6 @@ page_directory:
 SYMBOL(bootstrap_idtr)
 	.word 0
 	.long 0
-
-SYMBOL(bootstrap_gdtr)
-	.word GDT_SELECTOR(GDT_ITEMS)
-	.long KA2PA(gdt)
 
 SYMBOL(multiboot_eax)
 	.long 0
@@ -622,6 +618,12 @@ kernel_end:
 	.long 0
 free_area:
 	.long 0
+
+.section K_DATA_START, "aw", @progbits
+
+SYMBOL(bootstrap_gdtr)
+	.word GDT_SELECTOR(GDT_ITEMS)
+	.long KA2PA(gdt)
 
 status_prot:
 	.asciz "[prot] "

--- a/kernel/arch/ia32/src/boot/multiboot.S
+++ b/kernel/arch/ia32/src/boot/multiboot.S
@@ -219,154 +219,59 @@ FUNCTION_BEGIN(map_kernel_non_pse)
 	andl $~CR4_PAE, %ecx  /* PAE off */
 	movl %ecx, %cr4
 
-	call calc_kernel_end
-	call find_mem_for_pt
+	/* Allocate space for page tables */
+	// TODO: we shouldn't need to put this allocation in ballocs,
+	//       since it's static.
+	movl $KA2PA(ballocs), %edi
+	movl $page_tables, 0(%edi)
+	movl $(2 * 1024 * 1024), 4(%edi)
 
-	mov kernel_end, %esi
-	mov free_area, %ecx
+	/* Fill page tables */
+	xorl %ecx, %ecx
+	xorl %ebx, %ebx
+	mov $page_tables, %esi
 
-	cmpl %esi, %ecx
-	jbe use_kernel_end
+	floop_pt:
+		movl $(PTE_RW | PTE_P), %eax
+		orl %ebx, %eax
+		movl %eax, (%esi, %ecx, 4)
+		addl $PAGE_SIZE, %ebx
 
-		mov %ecx, %esi
+		incl %ecx
+		cmpl $(512 * 1024), %ecx
 
-		/* Align address down to 4k */
-		andl $(~(PAGE_SIZE - 1)), %esi
+		jl floop_pt
 
-	use_kernel_end:
+	/* Fill page directory */
+	movl $(page_directory + 0), %esi
+	movl $(page_directory + 2048), %edi
+	xorl %ecx, %ecx
+	movl $page_tables, %ebx
 
-		/* Align address to 4k */
-		addl $(PAGE_SIZE - 1), %esi
-		andl $(~(PAGE_SIZE - 1)), %esi
+	floop:
+		movl $(PDE_RW | PDE_P), %eax
+		orl %ebx, %eax
 
-		/* Allocate space for page tables */
-		movl %esi, pt_loc
-		movl $KA2PA(ballocs), %edi
+		/* Mapping 0x00000000 + %ecx * 4M => 0x00000000 + %ecx * 4M */
+		movl %eax, (%esi, %ecx, 4)
 
-		movl %esi, (%edi)
-		addl $4, %edi
-		movl $(2 * 1024 * 1024), (%edi)
+		/* Mapping 0x80000000 + %ecx * 4M => 0x00000000 + %ecx * 4M */
+		movl %eax, (%edi, %ecx, 4)
+		addl $PAGE_SIZE, %ebx
 
-		/* Fill page tables */
-		xorl %ecx, %ecx
-		xorl %ebx, %ebx
+		incl %ecx
+		cmpl $512, %ecx
 
-		floop_pt:
-			movl $(PTE_RW | PTE_P), %eax
-			orl %ebx, %eax
-			movl %eax, (%esi, %ecx, 4)
-			addl $PAGE_SIZE, %ebx
+		jl floop
 
-			incl %ecx
-			cmpl $(512 * 1024), %ecx
+	movl %esi, %cr3
 
-			jl floop_pt
+	movl %cr0, %ebx
+	orl $CR0_PG, %ebx  /* paging on */
+	movl %ebx, %cr0
 
-		/* Fill page directory */
-		movl $(page_directory + 0), %esi
-		movl $(page_directory + 2048), %edi
-		xorl %ecx, %ecx
-		movl pt_loc, %ebx
-
-		floop:
-			movl $(PDE_RW | PDE_P), %eax
-			orl %ebx, %eax
-
-			/* Mapping 0x00000000 + %ecx * 4M => 0x00000000 + %ecx * 4M */
-			movl %eax, (%esi, %ecx, 4)
-
-			/* Mapping 0x80000000 + %ecx * 4M => 0x00000000 + %ecx * 4M */
-			movl %eax, (%edi, %ecx, 4)
-			addl $PAGE_SIZE, %ebx
-
-			incl %ecx
-			cmpl $512, %ecx
-
-			jl floop
-
-		movl %esi, %cr3
-
-		movl %cr0, %ebx
-		orl $CR0_PG, %ebx  /* paging on */
-		movl %ebx, %cr0
-
-		ret
-FUNCTION_END(map_kernel_non_pse)
-
-/** Calculate unmapped address of the end of the kernel. */
-calc_kernel_end:
-	movl $KA2PA(kdata_end), %edi
-	movl %edi, kernel_end
 	ret
-
-// TODO: remove this cruft
-
-/** Find free 2M (+4k for alignment) region where to store page tables */
-find_mem_for_pt:
-	/* Check if multiboot info is present */
-	cmpl $MULTIBOOT_LOADER_MAGIC, multiboot_eax
-	je check_multiboot_map
-
-		ret
-
-	check_multiboot_map:
-
-		/* Copy address of the multiboot info to ebx */
-		movl multiboot_ebx, %ebx
-
-		/* Check if memory map flag is present */
-		movl (%ebx), %edx
-		andl $MULTIBOOT_INFO_FLAGS_MMAP, %edx
-		jnz use_multiboot_map
-
-			ret
-
-	use_multiboot_map:
-
-		/* Copy address of the memory map to edx */
-		movl MULTIBOOT_INFO_OFFSET_MMAP_ADDR(%ebx), %edx
-		movl %edx, %ecx
-
-		addl MULTIBOOT_INFO_OFFSET_MMAP_LENGTH(%ebx), %ecx
-
-		/* Find a free region at least 2M in size */
-		check_memmap_loop:
-
-			/* Is this a free region? */
-			cmpl $MEMMAP_MEMORY_AVAILABLE, MULTIBOOT_MEMMAP_OFFSET_MM_INFO + E820MEMMAP_OFFSET_TYPE(%edx)
-			jnz next_region
-
-			/* Check size */
-			cmpl $0, MULTIBOOT_MEMMAP_OFFSET_MM_INFO + E820MEMMAP_OFFSET_SIZE + 4(%edx)
-			jnz next_region
-			cmpl $(2 * 1024 * 1024 + PAGE_SIZE), MULTIBOOT_MEMMAP_OFFSET_MM_INFO + E820MEMMAP_OFFSET_SIZE(%edx)
-			jbe next_region
-
-			cmpl $0, MULTIBOOT_MEMMAP_OFFSET_MM_INFO + E820MEMMAP_OFFSET_BASE_ADDRESS + 4(%edx)
-			jz found_region
-
-		next_region:
-
-			cmp %ecx, %edx
-			jbe next_region_do
-
-				ret
-
-		next_region_do:
-
-			addl MULTIBOOT_MEMMAP_OFFSET_SIZE(%edx), %edx
-			addl $MULTIBOOT_MEMMAP_SIZE_SIZE, %edx
-			jmp check_memmap_loop
-
-		found_region:
-
-			/* Use end of the found region */
-			mov MULTIBOOT_MEMMAP_OFFSET_MM_INFO + E820MEMMAP_OFFSET_BASE_ADDRESS(%edx), %ecx
-			add MULTIBOOT_MEMMAP_OFFSET_MM_INFO + E820MEMMAP_OFFSET_SIZE(%edx), %ecx
-			sub $(2 * 1024 * 1024), %ecx
-			mov %ecx, free_area
-
-			ret
+FUNCTION_END(map_kernel_non_pse)
 
 /** Print string to EGA display (in light green).
  *
@@ -599,6 +504,10 @@ early_puts:
 .section K_BSS_START, "aw", @nobits
 
 .align 4096
+page_tables:
+	.space 2*1024*1024;
+
+.align 4096
 page_directory:
 	.space 4096, 0
 
@@ -610,13 +519,6 @@ SYMBOL(multiboot_eax)
 	.long 0
 
 SYMBOL(multiboot_ebx)
-	.long 0
-
-pt_loc:
-	.long 0
-kernel_end:
-	.long 0
-free_area:
 	.long 0
 
 .section K_DATA_START, "aw", @progbits

--- a/kernel/arch/ia32/src/boot/multiboot.S
+++ b/kernel/arch/ia32/src/boot/multiboot.S
@@ -73,11 +73,11 @@ multiboot_header:
 	.long MULTIBOOT_HEADER_FLAGS_NOFB
 	.long -(MULTIBOOT_HEADER_MAGIC + MULTIBOOT_HEADER_FLAGS_NOFB)  /* checksum */
 #endif
-	.long multiboot_header
-	.long unmapped_start
 	.long 0
 	.long 0
-	.long multiboot_image_start
+	.long 0
+	.long 0
+	.long 0
 #ifdef CONFIG_FB
 	.long 0
 	.long CONFIG_BFB_WIDTH

--- a/kernel/arch/ia32/src/boot/multiboot2.S
+++ b/kernel/arch/ia32/src/boot/multiboot2.S
@@ -57,27 +57,6 @@ multiboot2_header_start:
 #endif
 	tag_info_req_end:
 
-	/* Address tag */
-	.align 8
-	tag_address_start:
-		.word MULTIBOOT2_TAG_ADDRESS
-		.word MULTIBOOT2_FLAGS_REQUIRED
-		.long tag_address_end - tag_address_start
-		.long multiboot2_header_start
-		.long unmapped_start
-		.long 0
-		.long 0
-	tag_address_end:
-
-	/* Entry address tag */
-	.align 8
-	tag_entry_address_start:
-		.word MULTIBOOT2_TAG_ENTRY_ADDRESS
-		.word MULTIBOOT2_FLAGS_REQUIRED
-		.long tag_entry_address_end - tag_entry_address_start
-		.long multiboot_image_start
-	tag_entry_address_end:
-
 	/* Flags tag */
 	.align 8
 	tag_flags_start:

--- a/kernel/arch/ia32/src/boot/multiboot2.S
+++ b/kernel/arch/ia32/src/boot/multiboot2.S
@@ -32,9 +32,7 @@
 #include <arch/cpuid.h>
 #include <genarch/multiboot/multiboot2.h>
 
-.section K_TEXT_START, "ax"
-
-.code32
+.section .multiboot, "a"
 
 .align 8
 multiboot2_header_start:

--- a/kernel/arch/ia32/src/ia32.c
+++ b/kernel/arch/ia32/src/ia32.c
@@ -91,12 +91,6 @@ void ia32_pre_main(uint32_t signature, void *info)
 	/* Parse multiboot information obtained from the bootloader. */
 	multiboot_info_parse(signature, (multiboot_info_t *) info);
 	multiboot2_info_parse(signature, (multiboot2_info_t *) info);
-
-#ifdef CONFIG_SMP
-	size_t unmapped_size = (uintptr_t) unmapped_end - BOOT_OFFSET;
-	/* Copy AP bootstrap routines below 1 MB. */
-	memcpy((void *) AP_BOOT_OFFSET, (void *) BOOT_OFFSET, unmapped_size);
-#endif
 }
 
 void ia32_pre_mm_init(void)

--- a/kernel/arch/ia32/src/mm/frame.c
+++ b/kernel/arch/ia32/src/mm/frame.c
@@ -151,11 +151,9 @@ void frame_low_arch_init(void)
 		minconf = 1;
 
 #ifdef CONFIG_SMP
-		size_t unmapped_size =
-		    (uintptr_t) unmapped_end - BOOT_OFFSET;
-
-		minconf = max(minconf,
-		    ADDR2PFN(AP_BOOT_OFFSET + unmapped_size));
+		// FIXME: What is the purpose of minconf? Can we remove it?
+		uintptr_t ap_end = ALIGN_UP((uintptr_t) ap_bootstrap_end, FRAME_SIZE);
+		minconf = max(minconf, ADDR2PFN(ap_end));
 #endif
 
 		init_e820_memory(minconf, true);
@@ -164,9 +162,13 @@ void frame_low_arch_init(void)
 		frame_mark_unavailable(0, 1);
 
 #ifdef CONFIG_SMP
+		// TODO: should go away implicitly with section table
+
 		/* Reserve AP real mode bootstrap memory */
+		size_t ap_size =
+		    ALIGN_UP(ap_bootstrap_end - ap_bootstrap_start, FRAME_SIZE);
 		frame_mark_unavailable(AP_BOOT_OFFSET >> FRAME_WIDTH,
-		    unmapped_size >> FRAME_WIDTH);
+		    ap_size >> FRAME_WIDTH);
 #endif
 	}
 }

--- a/kernel/arch/ia32/src/smp/ap.S
+++ b/kernel/arch/ia32/src/smp/ap.S
@@ -39,7 +39,7 @@
 #include <arch/cpu.h>
 #include <arch/context_struct.h>
 
-.section K_TEXT_START, "ax"
+.section K_AP_TEXT_START, "ax"
 
 #ifdef CONFIG_SMP
 
@@ -53,7 +53,7 @@ KDATA=16
  */
 
 .align 4096
-SYMBOL(unmapped_ap_boot)
+SYMBOL(ap_boot)
 .code16
 	cli
 	xorw %ax, %ax
@@ -66,7 +66,7 @@ SYMBOL(unmapped_ap_boot)
 	movl %cr0, %eax
 	orl $CR0_PE, %eax
 	movl %eax, %cr0
-	jmpl $KTEXT, $jump_to_kernel - BOOT_OFFSET + AP_BOOT_OFFSET
+	jmpl $KTEXT, $jump_to_kernel
 
 jump_to_kernel:
 .code32
@@ -95,11 +95,11 @@ jump_to_kernel:
 #endif /* CONFIG_SMP */
 
 
-.section K_DATA_START, "aw", @progbits
+.section K_AP_DATA_START, "aw", @progbits
 
 #ifdef CONFIG_SMP
 
-SYMBOL(unmapped_ap_gdtr)
+SYMBOL(ap_gdtr)
 	.word 0
 	.long 0
 

--- a/kernel/genarch/include/genarch/multiboot/multiboot.h
+++ b/kernel/genarch/include/genarch/multiboot/multiboot.h
@@ -39,8 +39,8 @@
 #include <genarch/multiboot/multiboot_info_struct.h>
 
 #define MULTIBOOT_HEADER_MAGIC       0x1badb002
-#define MULTIBOOT_HEADER_FLAGS       0x00010007
-#define MULTIBOOT_HEADER_FLAGS_NOFB  0x00010003
+#define MULTIBOOT_HEADER_FLAGS       0x00000007
+#define MULTIBOOT_HEADER_FLAGS_NOFB  0x00000003
 
 #define MULTIBOOT_LOADER_MAGIC  0x2badb002
 


### PR DESCRIPTION
We want the kernel to be loaded according to its ELF headers.
This allows much greater flexibility in the kernel image layout and contents.

Additionally, some ad-hoc allocation code is removed in favor of static allocations.