### PR TITLE
Fix devman function reference counting

### DIFF
--- a/uspace/srv/devman/devtree.c
+++ b/uspace/srv/devman/devtree.c
@@ -143,8 +143,11 @@ bool create_root_nodes(dev_tree_t *tree)
 		return false;
 	}
 
-	fun_add_ref(fun);
-	insert_fun_node(tree, fun, str_dup(""), NULL);
+	if (!insert_fun_node(tree, fun, str_dup(""), NULL)) {
+		fun_del_ref(fun);	/* fun is destroyed */
+		fibril_rwlock_write_unlock(&tree->rwlock);
+		return false;
+	}
 
 	match_id_t *id = create_match_id();
 	id->id = str_dup("root");

--- a/uspace/srv/devman/drv_conn.c
+++ b/uspace/srv/devman/drv_conn.c
@@ -283,8 +283,10 @@ static void devman_add_function(ipc_call_t *call)
 	}
 
 	fun_node_t *fun = create_fun_node();
-	/* One reference for creation, one for us */
-	fun_add_ref(fun);
+	/*
+	 * Hold a temporary reference while we work with fun. The reference from
+	 * create_fun_node() moves to the device tree.
+	 */
 	fun_add_ref(fun);
 	fun->ftype = ftype;
 
@@ -299,7 +301,7 @@ static void devman_add_function(ipc_call_t *call)
 		dev_del_ref(pdev);
 		fun_busy_unlock(fun);
 		fun_del_ref(fun);
-		delete_fun_node(fun);
+		fun_del_ref(fun);	/* fun is destroyed */
 		async_answer_0(call, ENOMEM);
 		return;
 	}


### PR DESCRIPTION
After commit 498ced18a4, create_fun_node() returns a fun pointer with an
implicit reference. Adding an extra reference for creation thus adds a
reference that will never be dropped and the function object will be
leaked.

This commit fixes the reference counting issue and also adds the missing
check to the call to insert_fun_node().