### PR TITLE
Fix device reference counting

### DIFF
--- a/uspace/lib/drv/generic/driver.c
+++ b/uspace/lib/drv/generic/driver.c
@@ -144,8 +144,6 @@ static void driver_dev_add(ipc_call_t *icall)
 		return;
 	}
 
-	/* Add one reference that will be dropped by driver_dev_remove() */
-	dev_add_ref(dev);
 	dev->handle = dev_handle;
 	dev->name = dev_name;
 


### PR DESCRIPTION
After commit 498ced1, a device is created with an implicit reference.
Adding an extra reference for creation thus adds a reference that will
never be dropped and the device will be leaked.

This commit removes the extra reference.