### PR TITLE
Fix function reference counting

### DIFF
--- a/uspace/lib/drv/generic/driver.c
+++ b/uspace/lib/drv/generic/driver.c
@@ -732,9 +732,8 @@ ddf_fun_t *ddf_fun_create(ddf_dev_t *dev, fun_type_t ftype, const char *name)
 	if (fun == NULL)
 		return NULL;
 
-	/* Add one reference that will be dropped by ddf_fun_destroy() */
 	fun->dev = dev;
-	fun_add_ref(fun);
+	dev_add_ref(fun->dev);
 
 	fun->bound = false;
 	fun->ftype = ftype;
@@ -742,7 +741,7 @@ ddf_fun_t *ddf_fun_create(ddf_dev_t *dev, fun_type_t ftype, const char *name)
 	if (name != NULL) {
 		fun->name = str_dup(name);
 		if (fun->name == NULL) {
-			delete_function(fun);
+			fun_del_ref(fun);	/* fun is destroyed */
 			return NULL;
 		}
 	}


### PR DESCRIPTION
After commit 498ced1, a function is created with an implicit reference.
Adding an extra reference for creation thus adds a reference that will
never be dropped and the function will be leaked.

This commit removes the extra reference.