### PR TITLE
Fix devman device reference counting

### DIFF
--- a/uspace/srv/devman/devtree.c
+++ b/uspace/srv/devman/devtree.c
@@ -161,7 +161,6 @@ bool create_root_nodes(dev_tree_t *tree)
 		return false;
 	}
 
-	dev_add_ref(dev);
 	insert_dev_node(tree, dev, fun);
 
 	fibril_rwlock_write_unlock(&tree->rwlock);

--- a/uspace/srv/devman/fun.c
+++ b/uspace/srv/devman/fun.c
@@ -316,7 +316,6 @@ errno_t fun_online(fun_node_t *fun)
 		}
 
 		insert_dev_node(&device_tree, dev, fun);
-		dev_add_ref(dev);
 	}
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "devman_add_function(fun=\"%s\")", fun->pathname);


### PR DESCRIPTION
After commit 498ced1, create_dev_node() returns a dev pointer with an
implicit reference. Adding an extra reference for creation thus adds a
reference that will never be dropped and the device object will be
leaked.

This commit removes the extra reference.