### PR TITLE
scheduler: fix compile error in kcpulb() when KCPULB_VERBOSE is defined.

### DIFF
--- a/kernel/generic/src/proc/scheduler.c
+++ b/kernel/generic/src/proc/scheduler.c
@@ -658,7 +658,7 @@ not_satisfied:
 #ifdef KCPULB_VERBOSE
 				log(LF_OTHER, LVL_DEBUG,
 				    "kcpulb%u: TID %" PRIu64 " -> cpu%u, "
-				    "nrdy=%ld, avg=%ld", CPU->id, t->tid,
+				    "nrdy=%ld, avg=%ld", CPU->id, thread->tid,
 				    CPU->id, atomic_load(&CPU->nrdy),
 				    atomic_load(&nrdy) / config.cpu_active);
 #endif


### PR DESCRIPTION
"t" has been renamed to "thread"