### PR TITLE
libext4: fix double free in case ext4_filesystem_open() fails.

### DIFF
--- a/uspace/lib/ext4/src/filesystem.c
+++ b/uspace/lib/ext4/src/filesystem.c
@@ -420,6 +420,7 @@ errno_t ext4_filesystem_probe(service_id_t service_id,
 errno_t ext4_filesystem_open(ext4_instance_t *inst, service_id_t service_id,
     enum cache_mode cmode, aoff64_t *size, ext4_filesystem_t **rfs)
 {
+	int fs_inited = 0;
 	ext4_filesystem_t *fs = NULL;
 	fs_node_t *root_node = NULL;
 	errno_t rc;
@@ -436,6 +437,8 @@ errno_t ext4_filesystem_open(ext4_instance_t *inst, service_id_t service_id,
 	rc = ext4_filesystem_init(fs, service_id, cmode);
 	if (rc != EOK)
 		goto error;
+
+	fs_inited = 1;
 
 	/* Read root node */
 	rc = ext4_node_get_core(&root_node, inst, EXT4_INODE_ROOT_INDEX);
@@ -462,11 +465,9 @@ error:
 	if (root_node != NULL)
 		ext4_node_put(root_node);
 
-	if (fs != NULL) {
+	if (fs_inited)
 		ext4_filesystem_fini(fs);
-		free(fs);
-	}
-
+	free(fs);
 	return rc;
 }
 


### PR DESCRIPTION
I hit an assert in free() when opening an invalid ext4 filesystem,
this was due to a bug in ext4_filesystem_open().
In case of error, it called ext4_filesystem_fini() against an
uninitialized filesystem instance.