### PR TITLE
mips32: clobber memory on sycall

### DIFF
--- a/uspace/lib/c/arch/arm32/src/syscall.c
+++ b/uspace/lib/c/arch/arm32/src/syscall.c
@@ -69,6 +69,12 @@ sysarg_t __syscall(const sysarg_t p1, const sysarg_t p2, const sysarg_t p3,
 	      "r" (__arm_reg_r4),
 	      "r" (__arm_reg_r5),
 	      "r" (__arm_reg_r6)
+	    :
+	      /*
+	       * Clobber memory too as some arguments might be
+	       * actually pointers.
+	       */
+	      "memory"
 	);
 
 	return __arm_reg_r0;

--- a/uspace/lib/c/arch/mips32/src/syscall.c
+++ b/uspace/lib/c/arch/mips32/src/syscall.c
@@ -56,11 +56,17 @@ sysarg_t __syscall(const sysarg_t p1, const sysarg_t p2, const sysarg_t p3,
 	      "r" (__mips_reg_t0),
 	      "r" (__mips_reg_t1),
 	      "r" (__mips_reg_v0)
+	    :
 	      /*
 	       * We are a function call, although C
 	       * does not know it.
 	       */
-	    : "%ra"
+	      "%ra",
+	      /*
+	       * Clobber memory too as some arguments might be
+	       * actually pointers.
+	       */
+	      "memory"
 	);
 
 	return __mips_reg_v0;

--- a/uspace/lib/c/arch/ppc32/src/syscall.c
+++ b/uspace/lib/c/arch/ppc32/src/syscall.c
@@ -57,6 +57,12 @@ sysarg_t __syscall(const sysarg_t p1, const sysarg_t p2, const sysarg_t p3,
 	      "r" (__ppc32_reg_r7),
 	      "r" (__ppc32_reg_r8),
 	      "r" (__ppc32_reg_r9)
+	    :
+	      /*
+	       * Clobber memory too as some arguments might be
+	       * actually pointers.
+	       */
+	      "memory"
 	);
 
 	return __ppc32_reg_r3;


### PR DESCRIPTION
As the syscall may touch arbitrary memory, we need to prevent the compiler to cache some values in registers.

Actual problem was demonstrated on Kalisto during school assignments (thanks Adam Frey) but HelenOS uses basically the same code, thus the issue applies here too.

Can someone better versed with other architectures check that this does not apply to them as well?
