### PR TITLE
Remove async "fast" and "slow" functions from public interface

### DIFF
--- a/uspace/lib/c/generic/async/client.c
+++ b/uspace/lib/c/generic/async/client.c
@@ -248,7 +248,7 @@ void async_reply_received(ipc_call_t *data)
  * @return Hash of the sent message or 0 on error.
  *
  */
-aid_t async_send_fast(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1,
+static aid_t async_send_fast(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1,
     sysarg_t arg2, sysarg_t arg3, sysarg_t arg4, ipc_call_t *dataptr)
 {
 	if (exch == NULL)
@@ -288,7 +288,7 @@ aid_t async_send_fast(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1,
  * @return Hash of the sent message or 0 on error.
  *
  */
-aid_t async_send_slow(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1,
+static aid_t async_send_slow(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1,
     sysarg_t arg2, sysarg_t arg3, sysarg_t arg4, sysarg_t arg5,
     ipc_call_t *dataptr)
 {
@@ -309,6 +309,43 @@ aid_t async_send_slow(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1,
 	}
 
 	return (aid_t) msg;
+}
+
+aid_t async_send_0(async_exch_t *exch, sysarg_t imethod, ipc_call_t *dataptr)
+{
+	return async_send_fast(exch, imethod, 0, 0, 0, 0, dataptr);
+}
+
+aid_t async_send_1(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1,
+    ipc_call_t *dataptr)
+{
+	return async_send_fast(exch, imethod, arg1, 0, 0, 0, dataptr);
+}
+
+aid_t async_send_2(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1,
+    sysarg_t arg2, ipc_call_t *dataptr)
+{
+	return async_send_fast(exch, imethod, arg1, arg2, 0, 0, dataptr);
+}
+
+aid_t async_send_3(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1,
+    sysarg_t arg2, sysarg_t arg3, ipc_call_t *dataptr)
+{
+	return async_send_fast(exch, imethod, arg1, arg2, arg3, 0, dataptr);
+}
+
+aid_t async_send_4(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1,
+    sysarg_t arg2, sysarg_t arg3, sysarg_t arg4, ipc_call_t *dataptr)
+{
+	return async_send_fast(exch, imethod, arg1, arg2, arg3, arg4, dataptr);
+}
+
+aid_t async_send_5(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1,
+    sysarg_t arg2, sysarg_t arg3, sysarg_t arg4, sysarg_t arg5,
+    ipc_call_t *dataptr)
+{
+	return async_send_slow(exch, imethod, arg1, arg2, arg3, arg4, arg5,
+	    dataptr);
 }
 
 /** Wait for a message sent by the async framework.
@@ -433,9 +470,9 @@ void async_forget(aid_t amsgid)
  * @return Return code of the reply or an error code.
  *
  */
-errno_t async_req_fast(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1,
-    sysarg_t arg2, sysarg_t arg3, sysarg_t arg4, sysarg_t *r1, sysarg_t *r2,
-    sysarg_t *r3, sysarg_t *r4, sysarg_t *r5)
+static errno_t async_req_fast(async_exch_t *exch, sysarg_t imethod,
+    sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t arg4,
+    sysarg_t *r1, sysarg_t *r2, sysarg_t *r3, sysarg_t *r4, sysarg_t *r5)
 {
 	if (exch == NULL)
 		return ENOENT;
@@ -485,9 +522,9 @@ errno_t async_req_fast(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1,
  * @return Return code of the reply or an error code.
  *
  */
-errno_t async_req_slow(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1,
-    sysarg_t arg2, sysarg_t arg3, sysarg_t arg4, sysarg_t arg5, sysarg_t *r1,
-    sysarg_t *r2, sysarg_t *r3, sysarg_t *r4, sysarg_t *r5)
+static errno_t async_req_slow(async_exch_t *exch, sysarg_t imethod,
+    sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t arg4, sysarg_t arg5,
+    sysarg_t *r1, sysarg_t *r2, sysarg_t *r3, sysarg_t *r4, sysarg_t *r5)
 {
 	if (exch == NULL)
 		return ENOENT;
@@ -515,6 +552,186 @@ errno_t async_req_slow(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1,
 		*r5 = IPC_GET_ARG5(result);
 
 	return rc;
+}
+
+errno_t async_req_0_0(async_exch_t *exch, sysarg_t imethod)
+{
+	return async_req_fast(exch, imethod, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL);
+}
+
+errno_t async_req_0_1(async_exch_t *exch, sysarg_t imethod, sysarg_t *r1)
+{
+	return async_req_fast(exch, imethod, 0, 0, 0, 0, r1, NULL, NULL, NULL, NULL);
+}
+
+errno_t async_req_0_2(async_exch_t *exch, sysarg_t imethod, sysarg_t *r1, sysarg_t *r2)
+{
+	return async_req_fast(exch, imethod, 0, 0, 0, 0, r1, r2, NULL, NULL, NULL);
+}
+
+errno_t async_req_0_3(async_exch_t *exch, sysarg_t imethod, sysarg_t *r1, sysarg_t *r2, sysarg_t *r3)
+{
+	return async_req_fast(exch, imethod, 0, 0, 0, 0, r1, r2, r3, NULL, NULL);
+}
+
+errno_t async_req_0_4(async_exch_t *exch, sysarg_t imethod, sysarg_t *r1, sysarg_t *r2, sysarg_t *r3, sysarg_t *r4)
+{
+	return async_req_fast(exch, imethod, 0, 0, 0, 0, r1, r2, r3, r4, NULL);
+}
+
+errno_t async_req_0_5(async_exch_t *exch, sysarg_t imethod, sysarg_t *r1, sysarg_t *r2, sysarg_t *r3, sysarg_t *r4, sysarg_t *r5)
+{
+	return async_req_fast(exch, imethod, 0, 0, 0, 0, r1, r2, r3, r4, r5);
+}
+
+errno_t async_req_1_0(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1)
+{
+	return async_req_fast(exch, imethod, arg1, 0, 0, 0, NULL, NULL, NULL, NULL, NULL);
+}
+
+errno_t async_req_1_1(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t *r1)
+{
+	return async_req_fast(exch, imethod, arg1, 0, 0, 0, r1, NULL, NULL, NULL, NULL);
+}
+
+errno_t async_req_1_2(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t *r1, sysarg_t *r2)
+{
+	return async_req_fast(exch, imethod, arg1, 0, 0, 0, r1, r2, NULL, NULL, NULL);
+}
+
+errno_t async_req_1_3(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t *r1, sysarg_t *r2, sysarg_t *r3)
+{
+	return async_req_fast(exch, imethod, arg1, 0, 0, 0, r1, r2, r3, NULL, NULL);
+}
+
+errno_t async_req_1_4(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t *r1, sysarg_t *r2, sysarg_t *r3, sysarg_t *r4)
+{
+	return async_req_fast(exch, imethod, arg1, 0, 0, 0, r1, r2, r3, r4, NULL);
+}
+
+errno_t async_req_1_5(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t *r1, sysarg_t *r2, sysarg_t *r3, sysarg_t *r4, sysarg_t *r5)
+{
+	return async_req_fast(exch, imethod, arg1, 0, 0, 0, r1, r2, r3, r4, r5);
+}
+
+errno_t async_req_2_0(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t arg2)
+{
+	return async_req_fast(exch, imethod, arg1, arg2, 0, 0, NULL, NULL, NULL, NULL, NULL);
+}
+
+errno_t async_req_2_1(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t *r1)
+{
+	return async_req_fast(exch, imethod, arg1, arg2, 0, 0, r1, NULL, NULL, NULL, NULL);
+}
+
+errno_t async_req_2_2(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t *r1, sysarg_t *r2)
+{
+	return async_req_fast(exch, imethod, arg1, arg2, 0, 0, r1, r2, NULL, NULL, NULL);
+}
+
+errno_t async_req_2_3(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t *r1, sysarg_t *r2, sysarg_t *r3)
+{
+	return async_req_fast(exch, imethod, arg1, arg2, 0, 0, r1, r2, r3, NULL, NULL);
+}
+
+errno_t async_req_2_4(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t *r1, sysarg_t *r2, sysarg_t *r3, sysarg_t *r4)
+{
+	return async_req_fast(exch, imethod, arg1, arg2, 0, 0, r1, r2, r3, r4, NULL);
+}
+
+errno_t async_req_2_5(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t *r1, sysarg_t *r2, sysarg_t *r3, sysarg_t *r4, sysarg_t *r5)
+{
+	return async_req_fast(exch, imethod, arg1, arg2, 0, 0, r1, r2, r3, r4, r5);
+}
+
+errno_t async_req_3_0(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t arg3)
+{
+	return async_req_fast(exch, imethod, arg1, arg2, arg3, 0, NULL, NULL, NULL, NULL, NULL);
+}
+
+errno_t async_req_3_1(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t *r1)
+{
+	return async_req_fast(exch, imethod, arg1, arg2, arg3, 0, r1, NULL, NULL, NULL, NULL);
+}
+
+errno_t async_req_3_2(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t *r1, sysarg_t *r2)
+{
+	return async_req_fast(exch, imethod, arg1, arg2, arg3, 0, r1, r2, NULL, NULL, NULL);
+}
+
+errno_t async_req_3_3(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t *r1, sysarg_t *r2, sysarg_t *r3)
+{
+	return async_req_fast(exch, imethod, arg1, arg2, arg3, 0, r1, r2, r3, NULL, NULL);
+}
+
+errno_t async_req_3_4(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t *r1, sysarg_t *r2, sysarg_t *r3, sysarg_t *r4)
+{
+	return async_req_fast(exch, imethod, arg1, arg2, arg3, 0, r1, r2, r3, r4, NULL);
+}
+
+errno_t async_req_3_5(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t *r1, sysarg_t *r2, sysarg_t *r3, sysarg_t *r4, sysarg_t *r5)
+{
+	return async_req_fast(exch, imethod, arg1, arg2, arg3, 0, r1, r2, r3, r4, r5);
+}
+
+errno_t async_req_4_0(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t arg4)
+{
+	return async_req_fast(exch, imethod, arg1, arg2, arg3, arg4, NULL, NULL, NULL, NULL, NULL);
+}
+
+errno_t async_req_4_1(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t arg4, sysarg_t *r1)
+{
+	return async_req_fast(exch, imethod, arg1, arg2, arg3, arg4, r1, NULL, NULL, NULL, NULL);
+}
+
+errno_t async_req_4_2(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t arg4, sysarg_t *r1, sysarg_t *r2)
+{
+	return async_req_fast(exch, imethod, arg1, arg2, arg3, arg4, r1, r2, NULL, NULL, NULL);
+}
+
+errno_t async_req_4_3(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t arg4, sysarg_t *r1, sysarg_t *r2, sysarg_t *r3)
+{
+	return async_req_fast(exch, imethod, arg1, arg2, arg3, arg4, r1, r2, r3, NULL, NULL);
+}
+
+errno_t async_req_4_4(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t arg4, sysarg_t *r1, sysarg_t *r2, sysarg_t *r3, sysarg_t *r4)
+{
+	return async_req_fast(exch, imethod, arg1, arg2, arg3, arg4, r1, r2, r3, r4, NULL);
+}
+
+errno_t async_req_4_5(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t arg4, sysarg_t *r1, sysarg_t *r2, sysarg_t *r3, sysarg_t *r4, sysarg_t *r5)
+{
+	return async_req_fast(exch, imethod, arg1, arg2, arg3, arg4, r1, r2, r3, r4, r5);
+}
+
+errno_t async_req_5_0(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t arg4, sysarg_t arg5)
+{
+	return async_req_slow(exch, imethod, arg1, arg2, arg3, arg4, arg5, NULL, NULL, NULL, NULL, NULL);
+}
+
+errno_t async_req_5_1(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t arg4, sysarg_t arg5, sysarg_t *r1)
+{
+	return async_req_slow(exch, imethod, arg1, arg2, arg3, arg4, arg5, r1, NULL, NULL, NULL, NULL);
+}
+
+errno_t async_req_5_2(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t arg4, sysarg_t arg5, sysarg_t *r1, sysarg_t *r2)
+{
+	return async_req_slow(exch, imethod, arg1, arg2, arg3, arg4, arg5, r1, r2, NULL, NULL, NULL);
+}
+
+errno_t async_req_5_3(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t arg4, sysarg_t arg5, sysarg_t *r1, sysarg_t *r2, sysarg_t *r3)
+{
+	return async_req_slow(exch, imethod, arg1, arg2, arg3, arg4, arg5, r1, r2, r3, NULL, NULL);
+}
+
+errno_t async_req_5_4(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t arg4, sysarg_t arg5, sysarg_t *r1, sysarg_t *r2, sysarg_t *r3, sysarg_t *r4)
+{
+	return async_req_slow(exch, imethod, arg1, arg2, arg3, arg4, arg5, r1, r2, r3, r4, NULL);
+}
+
+errno_t async_req_5_5(async_exch_t *exch, sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t arg4, sysarg_t arg5, sysarg_t *r1, sysarg_t *r2, sysarg_t *r3, sysarg_t *r4, sysarg_t *r5)
+{
+	return async_req_slow(exch, imethod, arg1, arg2, arg3, arg4, arg5, r1, r2, r3, r4, r5);
 }
 
 void async_msg_0(async_exch_t *exch, sysarg_t imethod)
@@ -925,8 +1142,8 @@ void async_exchange_end(async_exch_t *exch)
  * @return Zero on success or an error code from errno.h.
  *
  */
-errno_t async_share_in_start(async_exch_t *exch, size_t size, sysarg_t arg,
-    unsigned int *flags, void **dst)
+static errno_t async_share_in_start(async_exch_t *exch, size_t size,
+    sysarg_t arg, unsigned int *flags, void **dst)
 {
 	if (exch == NULL)
 		return ENOENT;
@@ -942,6 +1159,29 @@ errno_t async_share_in_start(async_exch_t *exch, size_t size, sysarg_t arg,
 
 	*dst = (void *) _dst;
 	return res;
+}
+
+errno_t async_share_in_start_0_0(async_exch_t *exch, size_t size, void **dst)
+{
+	return async_share_in_start(exch, size, 0, NULL, dst);
+}
+
+errno_t async_share_in_start_0_1(async_exch_t *exch, size_t size,
+    unsigned int *flags, void **dst)
+{
+	return async_share_in_start(exch, size, 0, flags, dst);
+}
+
+errno_t async_share_in_start_1_0(async_exch_t *exch, size_t size, sysarg_t arg,
+    void **dst)
+{
+	return async_share_in_start(exch, size, arg, NULL, dst);
+}
+
+errno_t async_share_in_start_1_1(async_exch_t *exch, size_t size, sysarg_t arg,
+    unsigned int *flags, void **dst)
+{
+	return async_share_in_start(exch, size, arg, flags, dst);
 }
 
 /** Wrapper for IPC_M_SHARE_OUT calls using the async framework.

--- a/uspace/lib/c/generic/async/server.c
+++ b/uspace/lib/c/generic/async/server.c
@@ -877,6 +877,11 @@ bool async_get_call_timeout(ipc_call_t *call, usec_t usecs)
 	return true;
 }
 
+bool async_get_call(ipc_call_t *call)
+{
+	return async_get_call_timeout(call, 0);
+}
+
 void *async_get_client_data(void)
 {
 	assert(fibril_connection);
@@ -1095,7 +1100,7 @@ errno_t async_answer_5(ipc_call_t *call, errno_t retval, sysarg_t arg1,
 	return ipc_answer_5(chandle, retval, arg1, arg2, arg3, arg4, arg5);
 }
 
-errno_t async_forward_fast(ipc_call_t *call, async_exch_t *exch,
+static errno_t async_forward_fast(ipc_call_t *call, async_exch_t *exch,
     sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, unsigned int mode)
 {
 	assert(call);
@@ -1111,7 +1116,7 @@ errno_t async_forward_fast(ipc_call_t *call, async_exch_t *exch,
 	    mode);
 }
 
-errno_t async_forward_slow(ipc_call_t *call, async_exch_t *exch,
+static errno_t async_forward_slow(ipc_call_t *call, async_exch_t *exch,
     sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t arg3,
     sysarg_t arg4, sysarg_t arg5, unsigned int mode)
 {
@@ -1126,6 +1131,47 @@ errno_t async_forward_slow(ipc_call_t *call, async_exch_t *exch,
 
 	return ipc_forward_slow(chandle, exch->phone, imethod, arg1, arg2, arg3,
 	    arg4, arg5, mode);
+}
+
+errno_t async_forward_0(ipc_call_t *call, async_exch_t *exch, sysarg_t imethod,
+    unsigned int mode)
+{
+	return async_forward_fast(call, exch, imethod, 0, 0, mode);
+}
+
+errno_t async_forward_1(ipc_call_t *call, async_exch_t *exch, sysarg_t imethod,
+    sysarg_t arg1, unsigned int mode)
+{
+	return async_forward_fast(call, exch, imethod, arg1, 0, mode);
+}
+
+errno_t async_forward_2(ipc_call_t *call, async_exch_t *exch, sysarg_t imethod,
+    sysarg_t arg1, sysarg_t arg2, unsigned int mode)
+{
+	return async_forward_fast(call, exch, imethod, arg1, arg2, mode);
+}
+
+errno_t async_forward_3(ipc_call_t *call, async_exch_t *exch, sysarg_t imethod,
+    sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, unsigned int mode)
+{
+	return async_forward_slow(call, exch, imethod, arg1, arg2, arg3, 0, 0,
+	    mode);
+}
+
+errno_t async_forward_4(ipc_call_t *call, async_exch_t *exch, sysarg_t imethod,
+    sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t arg4,
+    unsigned int mode)
+{
+	return async_forward_slow(call, exch, imethod, arg1, arg2, arg3, arg4,
+	    0, mode);
+}
+
+errno_t async_forward_5(ipc_call_t *call, async_exch_t *exch, sysarg_t imethod,
+    sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t arg4, sysarg_t arg5,
+    unsigned int mode)
+{
+	return async_forward_slow(call, exch, imethod, arg1, arg2, arg3, arg4,
+	    arg5, mode);
 }
 
 /** Wrapper for making IPC_M_CONNECT_TO_ME calls using the async framework.
@@ -1319,7 +1365,7 @@ errno_t async_data_read_finalize(ipc_call_t *call, const void *src, size_t size)
 /** Wrapper for forwarding any read request
  *
  */
-errno_t async_data_read_forward_fast(async_exch_t *exch, sysarg_t imethod,
+static errno_t async_data_read_forward_fast(async_exch_t *exch, sysarg_t imethod,
     sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t arg4,
     ipc_call_t *dataptr)
 {
@@ -1332,7 +1378,7 @@ errno_t async_data_read_forward_fast(async_exch_t *exch, sysarg_t imethod,
 		return EINVAL;
 	}
 
-	aid_t msg = async_send_fast(exch, imethod, arg1, arg2, arg3, arg4,
+	aid_t msg = async_send_4(exch, imethod, arg1, arg2, arg3, arg4,
 	    dataptr);
 	if (msg == 0) {
 		async_answer_0(&call, EINVAL);
@@ -1351,6 +1397,14 @@ errno_t async_data_read_forward_fast(async_exch_t *exch, sysarg_t imethod,
 	async_wait_for(msg, &rc);
 
 	return (errno_t) rc;
+}
+
+errno_t async_data_read_forward_4_1(async_exch_t *exch, sysarg_t imethod,
+    sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t arg4,
+    ipc_call_t *dataptr)
+{
+	return async_data_read_forward_fast(exch, imethod, arg1, arg2, arg3,
+	    arg4, dataptr);
 }
 
 /** Wrapper for receiving the IPC_M_DATA_WRITE calls using the async framework.
@@ -1496,9 +1550,9 @@ void async_data_write_void(errno_t retval)
 /** Wrapper for forwarding any data that is about to be received
  *
  */
-errno_t async_data_write_forward_fast(async_exch_t *exch, sysarg_t imethod,
-    sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t arg4,
-    ipc_call_t *dataptr)
+static errno_t async_data_write_forward_fast(async_exch_t *exch,
+    sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, sysarg_t arg3,
+    sysarg_t arg4, ipc_call_t *dataptr)
 {
 	if (exch == NULL)
 		return ENOENT;
@@ -1509,7 +1563,7 @@ errno_t async_data_write_forward_fast(async_exch_t *exch, sysarg_t imethod,
 		return EINVAL;
 	}
 
-	aid_t msg = async_send_fast(exch, imethod, arg1, arg2, arg3, arg4,
+	aid_t msg = async_send_4(exch, imethod, arg1, arg2, arg3, arg4,
 	    dataptr);
 	if (msg == 0) {
 		async_answer_0(&call, EINVAL);
@@ -1528,6 +1582,14 @@ errno_t async_data_write_forward_fast(async_exch_t *exch, sysarg_t imethod,
 	async_wait_for(msg, &rc);
 
 	return (errno_t) rc;
+}
+
+errno_t async_data_write_forward_4_1(async_exch_t *exch, sysarg_t imethod,
+    sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t arg4,
+    ipc_call_t *dataptr)
+{
+	return async_data_write_forward_fast(exch, imethod, arg1, arg2, arg3,
+	    arg4, dataptr);
 }
 
 /** Wrapper for receiving the IPC_M_CONNECT_TO_ME calls.

--- a/uspace/lib/c/generic/async/server.c
+++ b/uspace/lib/c/generic/async/server.c
@@ -1399,6 +1399,66 @@ static errno_t async_data_read_forward_fast(async_exch_t *exch, sysarg_t imethod
 	return (errno_t) rc;
 }
 
+errno_t async_data_read_forward_0_0(async_exch_t *exch, sysarg_t imethod)
+{
+	return async_data_read_forward_fast(exch, imethod, 0, 0, 0, 0, NULL);
+}
+
+errno_t async_data_read_forward_1_0(async_exch_t *exch, sysarg_t imethod,
+    sysarg_t arg1)
+{
+	return async_data_read_forward_fast(exch, imethod, arg1, 0, 0, 0, NULL);
+}
+
+errno_t async_data_read_forward_2_0(async_exch_t *exch, sysarg_t imethod,
+    sysarg_t arg1, sysarg_t arg2)
+{
+	return async_data_read_forward_fast(exch, imethod, arg1, arg2, 0,
+	    0, NULL);
+}
+
+errno_t async_data_read_forward_3_0(async_exch_t *exch, sysarg_t imethod,
+    sysarg_t arg1, sysarg_t arg2, sysarg_t arg3)
+{
+	return async_data_read_forward_fast(exch, imethod, arg1, arg2, arg3,
+	    0, NULL);
+}
+
+errno_t async_data_read_forward_4_0(async_exch_t *exch, sysarg_t imethod,
+    sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t arg4)
+{
+	return async_data_read_forward_fast(exch, imethod, arg1, arg2, arg3,
+	    arg4, NULL);
+}
+
+errno_t async_data_read_forward_0_1(async_exch_t *exch, sysarg_t imethod,
+    ipc_call_t *dataptr)
+{
+	return async_data_read_forward_fast(exch, imethod, 0, 0, 0,
+	    0, dataptr);
+}
+
+errno_t async_data_read_forward_1_1(async_exch_t *exch, sysarg_t imethod,
+    sysarg_t arg1, ipc_call_t *dataptr)
+{
+	return async_data_read_forward_fast(exch, imethod, arg1, 0, 0,
+	    0, dataptr);
+}
+
+errno_t async_data_read_forward_2_1(async_exch_t *exch, sysarg_t imethod,
+    sysarg_t arg1, sysarg_t arg2, ipc_call_t *dataptr)
+{
+	return async_data_read_forward_fast(exch, imethod, arg1, arg2, 0,
+	    0, dataptr);
+}
+
+errno_t async_data_read_forward_3_1(async_exch_t *exch, sysarg_t imethod,
+    sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, ipc_call_t *dataptr)
+{
+	return async_data_read_forward_fast(exch, imethod, arg1, arg2, arg3,
+	    0, dataptr);
+}
+
 errno_t async_data_read_forward_4_1(async_exch_t *exch, sysarg_t imethod,
     sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t arg4,
     ipc_call_t *dataptr)
@@ -1582,6 +1642,68 @@ static errno_t async_data_write_forward_fast(async_exch_t *exch,
 	async_wait_for(msg, &rc);
 
 	return (errno_t) rc;
+}
+
+errno_t async_data_write_forward_0_0(async_exch_t *exch, sysarg_t imethod)
+{
+	return async_data_write_forward_fast(exch, imethod, 0, 0, 0,
+	    0, NULL);
+}
+
+errno_t async_data_write_forward_1_0(async_exch_t *exch, sysarg_t imethod,
+    sysarg_t arg1)
+{
+	return async_data_write_forward_fast(exch, imethod, arg1, 0, 0,
+	    0, NULL);
+}
+
+errno_t async_data_write_forward_2_0(async_exch_t *exch, sysarg_t imethod,
+    sysarg_t arg1, sysarg_t arg2)
+{
+	return async_data_write_forward_fast(exch, imethod, arg1, arg2, 0,
+	    0, NULL);
+}
+
+errno_t async_data_write_forward_3_0(async_exch_t *exch, sysarg_t imethod,
+    sysarg_t arg1, sysarg_t arg2, sysarg_t arg3)
+{
+	return async_data_write_forward_fast(exch, imethod, arg1, arg2, arg3,
+	    0, NULL);
+}
+
+errno_t async_data_write_forward_4_0(async_exch_t *exch, sysarg_t imethod,
+    sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t arg4)
+{
+	return async_data_write_forward_fast(exch, imethod, arg1, arg2, arg3,
+	    arg4, NULL);
+}
+
+errno_t async_data_write_forward_0_1(async_exch_t *exch, sysarg_t imethod,
+    ipc_call_t *dataptr)
+{
+	return async_data_write_forward_fast(exch, imethod, 0, 0, 0,
+	    0, dataptr);
+}
+
+errno_t async_data_write_forward_1_1(async_exch_t *exch, sysarg_t imethod,
+    sysarg_t arg1, ipc_call_t *dataptr)
+{
+	return async_data_write_forward_fast(exch, imethod, arg1, 0, 0,
+	    0, dataptr);
+}
+
+errno_t async_data_write_forward_2_1(async_exch_t *exch, sysarg_t imethod,
+    sysarg_t arg1, sysarg_t arg2, ipc_call_t *dataptr)
+{
+	return async_data_write_forward_fast(exch, imethod, arg1, arg2, 0,
+	    0, dataptr);
+}
+
+errno_t async_data_write_forward_3_1(async_exch_t *exch, sysarg_t imethod,
+    sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, ipc_call_t *dataptr)
+{
+	return async_data_write_forward_fast(exch, imethod, arg1, arg2, arg3,
+	    0, dataptr);
 }
 
 errno_t async_data_write_forward_4_1(async_exch_t *exch, sysarg_t imethod,

--- a/uspace/lib/c/include/async.h
+++ b/uspace/lib/c/include/async.h
@@ -107,34 +107,18 @@ typedef struct async_exch async_exch_t;
 
 extern __noreturn void async_manager(void);
 
-#define async_get_call(data) \
-	async_get_call_timeout(data, 0)
-
+extern bool async_get_call(ipc_call_t *);
 extern bool async_get_call_timeout(ipc_call_t *, usec_t);
 
-/*
- * User-friendly wrappers for async_send_fast() and async_send_slow(). The
- * macros are in the form async_send_m(), where m denotes the number of payload
- * arguments. Each macros chooses between the fast and the slow version based
- * on m.
- */
-
-#define async_send_0(exch, method, dataptr) \
-	async_send_fast(exch, method, 0, 0, 0, 0, dataptr)
-#define async_send_1(exch, method, arg1, dataptr) \
-	async_send_fast(exch, method, arg1, 0, 0, 0, dataptr)
-#define async_send_2(exch, method, arg1, arg2, dataptr) \
-	async_send_fast(exch, method, arg1, arg2, 0, 0, dataptr)
-#define async_send_3(exch, method, arg1, arg2, arg3, dataptr) \
-	async_send_fast(exch, method, arg1, arg2, arg3, 0, dataptr)
-#define async_send_4(exch, method, arg1, arg2, arg3, arg4, dataptr) \
-	async_send_fast(exch, method, arg1, arg2, arg3, arg4, dataptr)
-#define async_send_5(exch, method, arg1, arg2, arg3, arg4, arg5, dataptr) \
-	async_send_slow(exch, method, arg1, arg2, arg3, arg4, arg5, dataptr)
-
-extern aid_t async_send_fast(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+extern aid_t async_send_0(async_exch_t *, sysarg_t, ipc_call_t *);
+extern aid_t async_send_1(async_exch_t *, sysarg_t, sysarg_t, ipc_call_t *);
+extern aid_t async_send_2(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+    ipc_call_t *);
+extern aid_t async_send_3(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+    sysarg_t, ipc_call_t *);
+extern aid_t async_send_4(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
     sysarg_t, sysarg_t, ipc_call_t *);
-extern aid_t async_send_slow(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+extern aid_t async_send_5(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
     sysarg_t, sysarg_t, sysarg_t, ipc_call_t *);
 
 extern void async_wait_for(aid_t, errno_t *);
@@ -197,136 +181,92 @@ extern errno_t async_answer_5(ipc_call_t *, errno_t, sysarg_t, sysarg_t,
  * Wrappers for forwarding routines.
  */
 
-extern errno_t async_forward_fast(ipc_call_t *, async_exch_t *, sysarg_t,
+extern errno_t async_forward_0(ipc_call_t *, async_exch_t *, sysarg_t,
+    unsigned int);
+extern errno_t async_forward_1(ipc_call_t *, async_exch_t *, sysarg_t,
+    sysarg_t, unsigned int);
+extern errno_t async_forward_2(ipc_call_t *, async_exch_t *, sysarg_t,
     sysarg_t, sysarg_t, unsigned int);
-extern errno_t async_forward_slow(ipc_call_t *, async_exch_t *, sysarg_t,
+extern errno_t async_forward_3(ipc_call_t *, async_exch_t *, sysarg_t,
+    sysarg_t, sysarg_t, sysarg_t, unsigned int);
+extern errno_t async_forward_4(ipc_call_t *, async_exch_t *, sysarg_t,
+    sysarg_t, sysarg_t, sysarg_t, sysarg_t, unsigned int);
+extern errno_t async_forward_5(ipc_call_t *, async_exch_t *, sysarg_t,
     sysarg_t, sysarg_t, sysarg_t, sysarg_t, sysarg_t, unsigned int);
 
 /*
- * User-friendly wrappers for async_req_fast() and async_req_slow(). The macros
- * are in the form async_req_m_n(), where m is the number of payload arguments
- * and n is the number of return arguments. The macros decide between the fast
- * and slow verion based on m.
+ * User-friendly wrappers for async_req_*_*().
+ * The functions are in the form async_req_m_n(), where m is the number of
+ * payload arguments and n is the number of return arguments.
  */
 
-#define async_req_0_0(exch, method) \
-	async_req_fast(exch, method, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL)
-#define async_req_0_1(exch, method, r1) \
-	async_req_fast(exch, method, 0, 0, 0, 0, r1, NULL, NULL, NULL, NULL)
-#define async_req_0_2(exch, method, r1, r2) \
-	async_req_fast(exch, method, 0, 0, 0, 0, r1, r2, NULL, NULL, NULL)
-#define async_req_0_3(exch, method, r1, r2, r3) \
-	async_req_fast(exch, method, 0, 0, 0, 0, r1, r2, r3, NULL, NULL)
-#define async_req_0_4(exch, method, r1, r2, r3, r4) \
-	async_req_fast(exch, method, 0, 0, 0, 0, r1, r2, r3, r4, NULL)
-#define async_req_0_5(exch, method, r1, r2, r3, r4, r5) \
-	async_req_fast(exch, method, 0, 0, 0, 0, r1, r2, r3, r4, r5)
-
-#define async_req_1_0(exch, method, arg1) \
-	async_req_fast(exch, method, arg1, 0, 0, 0, NULL, NULL, NULL, NULL, \
-	    NULL)
-#define async_req_1_1(exch, method, arg1, rc1) \
-	async_req_fast(exch, method, arg1, 0, 0, 0, rc1, NULL, NULL, NULL, \
-	    NULL)
-#define async_req_1_2(exch, method, arg1, rc1, rc2) \
-	async_req_fast(exch, method, arg1, 0, 0, 0, rc1, rc2, NULL, NULL, \
-	    NULL)
-#define async_req_1_3(exch, method, arg1, rc1, rc2, rc3) \
-	async_req_fast(exch, method, arg1, 0, 0, 0, rc1, rc2, rc3, NULL, \
-	    NULL)
-#define async_req_1_4(exch, method, arg1, rc1, rc2, rc3, rc4) \
-	async_req_fast(exch, method, arg1, 0, 0, 0, rc1, rc2, rc3, rc4, \
-	    NULL)
-#define async_req_1_5(exch, method, arg1, rc1, rc2, rc3, rc4, rc5) \
-	async_req_fast(exch, method, arg1, 0, 0, 0, rc1, rc2, rc3, rc4, \
-	    rc5)
-
-#define async_req_2_0(exch, method, arg1, arg2) \
-	async_req_fast(exch, method, arg1, arg2, 0, 0, NULL, NULL, NULL, \
-	    NULL, NULL)
-#define async_req_2_1(exch, method, arg1, arg2, rc1) \
-	async_req_fast(exch, method, arg1, arg2, 0, 0, rc1, NULL, NULL, \
-	    NULL, NULL)
-#define async_req_2_2(exch, method, arg1, arg2, rc1, rc2) \
-	async_req_fast(exch, method, arg1, arg2, 0, 0, rc1, rc2, NULL, NULL, \
-	    NULL)
-#define async_req_2_3(exch, method, arg1, arg2, rc1, rc2, rc3) \
-	async_req_fast(exch, method, arg1, arg2, 0, 0, rc1, rc2, rc3, NULL, \
-	    NULL)
-#define async_req_2_4(exch, method, arg1, arg2, rc1, rc2, rc3, rc4) \
-	async_req_fast(exch, method, arg1, arg2, 0, 0, rc1, rc2, rc3, rc4, \
-	    NULL)
-#define async_req_2_5(exch, method, arg1, arg2, rc1, rc2, rc3, rc4, rc5) \
-	async_req_fast(exch, method, arg1, arg2, 0, 0, rc1, rc2, rc3, rc4, \
-	    rc5)
-
-#define async_req_3_0(exch, method, arg1, arg2, arg3) \
-	async_req_fast(exch, method, arg1, arg2, arg3, 0, NULL, NULL, NULL, \
-	    NULL, NULL)
-#define async_req_3_1(exch, method, arg1, arg2, arg3, rc1) \
-	async_req_fast(exch, method, arg1, arg2, arg3, 0, rc1, NULL, NULL, \
-	    NULL, NULL)
-#define async_req_3_2(exch, method, arg1, arg2, arg3, rc1, rc2) \
-	async_req_fast(exch, method, arg1, arg2, arg3, 0, rc1, rc2, NULL, \
-	    NULL, NULL)
-#define async_req_3_3(exch, method, arg1, arg2, arg3, rc1, rc2, rc3) \
-	async_req_fast(exch, method, arg1, arg2, arg3, 0, rc1, rc2, rc3, \
-	    NULL, NULL)
-#define async_req_3_4(exch, method, arg1, arg2, arg3, rc1, rc2, rc3, rc4) \
-	async_req_fast(exch, method, arg1, arg2, arg3, 0, rc1, rc2, rc3, \
-	    rc4, NULL)
-#define async_req_3_5(exch, method, arg1, arg2, arg3, rc1, rc2, rc3, rc4, \
-    rc5) \
-	async_req_fast(exch, method, arg1, arg2, arg3, 0, rc1, rc2, rc3, \
-	    rc4, rc5)
-
-#define async_req_4_0(exch, method, arg1, arg2, arg3, arg4) \
-	async_req_fast(exch, method, arg1, arg2, arg3, arg4, NULL, NULL, \
-	    NULL, NULL, NULL)
-#define async_req_4_1(exch, method, arg1, arg2, arg3, arg4, rc1) \
-	async_req_fast(exch, method, arg1, arg2, arg3, arg4, rc1, NULL, \
-	    NULL, NULL, NULL)
-#define async_req_4_2(exch, method, arg1, arg2, arg3, arg4, rc1, rc2) \
-	async_req_fast(exch, method, arg1, arg2, arg3, arg4, rc1, rc2, NULL, \
-	    NULL, NULL)
-#define async_req_4_3(exch, method, arg1, arg2, arg3, arg4, rc1, rc2, rc3) \
-	async_req_fast(exch, method, arg1, arg2, arg3, arg4, rc1, rc2, rc3, \
-	    NULL, NULL)
-#define async_req_4_4(exch, method, arg1, arg2, arg3, arg4, rc1, rc2, rc3, \
-    rc4) \
-	async_req_fast(exch, method, arg1, arg2, arg3, arg4, rc1, rc2, rc3, \
-	    rc4, NULL)
-#define async_req_4_5(exch, method, arg1, arg2, arg3, arg4, rc1, rc2, rc3, \
-    rc4, rc5) \
-	async_req_fast(exch, method, arg1, arg2, arg3, arg4, rc1, rc2, rc3, \
-	    rc4, rc5)
-
-#define async_req_5_0(exch, method, arg1, arg2, arg3, arg4, arg5) \
-	async_req_slow(exch, method, arg1, arg2, arg3, arg4, arg5, NULL, \
-	    NULL, NULL, NULL, NULL)
-#define async_req_5_1(exch, method, arg1, arg2, arg3, arg4, arg5, rc1) \
-	async_req_slow(exch, method, arg1, arg2, arg3, arg4, arg5, rc1, \
-	    NULL, NULL, NULL, NULL)
-#define async_req_5_2(exch, method, arg1, arg2, arg3, arg4, arg5, rc1, rc2) \
-	async_req_slow(exch, method, arg1, arg2, arg3, arg4, arg5, rc1, rc2, \
-	    NULL, NULL, NULL)
-#define async_req_5_3(exch, method, arg1, arg2, arg3, arg4, arg5, rc1, rc2, \
-    rc3) \
-	async_req_slow(exch, method, arg1, arg2, arg3, arg4, arg5, rc1, rc2, \
-	    rc3, NULL, NULL)
-#define async_req_5_4(exch, method, arg1, arg2, arg3, arg4, arg5, rc1, rc2, \
-    rc3, rc4) \
-	async_req_slow(exch, method, arg1, arg2, arg3, arg4, arg5, rc1, rc2, \
-	    rc3, rc4, NULL)
-#define async_req_5_5(exch, method, arg1, arg2, arg3, arg4, arg5, rc1, rc2, \
-    rc3, rc4, rc5) \
-	async_req_slow(exch, method, arg1, arg2, arg3, arg4, arg5, rc1, rc2, \
-	    rc3, rc4, rc5)
-
-extern errno_t async_req_fast(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+extern errno_t async_req_0_0(async_exch_t *, sysarg_t);
+extern errno_t async_req_0_1(async_exch_t *, sysarg_t, sysarg_t *);
+extern errno_t async_req_0_2(async_exch_t *, sysarg_t, sysarg_t *, sysarg_t *);
+extern errno_t async_req_0_3(async_exch_t *, sysarg_t, sysarg_t *, sysarg_t *,
+    sysarg_t *);
+extern errno_t async_req_0_4(async_exch_t *, sysarg_t, sysarg_t *, sysarg_t *,
+    sysarg_t *, sysarg_t *);
+extern errno_t async_req_0_5(async_exch_t *, sysarg_t, sysarg_t *, sysarg_t *,
+    sysarg_t *, sysarg_t *, sysarg_t *);
+extern errno_t async_req_1_0(async_exch_t *, sysarg_t, sysarg_t);
+extern errno_t async_req_1_1(async_exch_t *, sysarg_t, sysarg_t, sysarg_t *);
+extern errno_t async_req_1_2(async_exch_t *, sysarg_t, sysarg_t, sysarg_t *,
+    sysarg_t *);
+extern errno_t async_req_1_3(async_exch_t *, sysarg_t, sysarg_t, sysarg_t *,
+    sysarg_t *, sysarg_t *);
+extern errno_t async_req_1_4(async_exch_t *, sysarg_t, sysarg_t, sysarg_t *,
+    sysarg_t *, sysarg_t *, sysarg_t *);
+extern errno_t async_req_1_5(async_exch_t *, sysarg_t, sysarg_t, sysarg_t *,
+    sysarg_t *, sysarg_t *, sysarg_t *, sysarg_t *);
+extern errno_t async_req_2_0(async_exch_t *, sysarg_t, sysarg_t, sysarg_t);
+extern errno_t async_req_2_1(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+    sysarg_t *);
+extern errno_t async_req_2_2(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+    sysarg_t *, sysarg_t *);
+extern errno_t async_req_2_3(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+    sysarg_t *, sysarg_t *, sysarg_t *);
+extern errno_t async_req_2_4(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+    sysarg_t *, sysarg_t *, sysarg_t *, sysarg_t *);
+extern errno_t async_req_2_5(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+    sysarg_t *, sysarg_t *, sysarg_t *, sysarg_t *, sysarg_t *);
+extern errno_t async_req_3_0(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+    sysarg_t);
+extern errno_t async_req_3_1(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+    sysarg_t, sysarg_t *);
+extern errno_t async_req_3_2(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+    sysarg_t, sysarg_t *, sysarg_t *);
+extern errno_t async_req_3_3(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+    sysarg_t, sysarg_t *, sysarg_t *, sysarg_t *);
+extern errno_t async_req_3_4(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+    sysarg_t, sysarg_t *, sysarg_t *, sysarg_t *, sysarg_t *);
+extern errno_t async_req_3_5(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+    sysarg_t, sysarg_t *, sysarg_t *, sysarg_t *, sysarg_t *, sysarg_t *);
+extern errno_t async_req_4_0(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+    sysarg_t, sysarg_t);
+extern errno_t async_req_4_1(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+    sysarg_t, sysarg_t, sysarg_t *);
+extern errno_t async_req_4_2(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+    sysarg_t, sysarg_t, sysarg_t *, sysarg_t *);
+extern errno_t async_req_4_3(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+    sysarg_t, sysarg_t, sysarg_t *, sysarg_t *, sysarg_t *);
+extern errno_t async_req_4_4(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+    sysarg_t, sysarg_t, sysarg_t *, sysarg_t *, sysarg_t *, sysarg_t *);
+extern errno_t async_req_4_5(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
     sysarg_t, sysarg_t, sysarg_t *, sysarg_t *, sysarg_t *, sysarg_t *,
     sysarg_t *);
-extern errno_t async_req_slow(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+extern errno_t async_req_5_0(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+    sysarg_t, sysarg_t, sysarg_t);
+extern errno_t async_req_5_1(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+    sysarg_t, sysarg_t, sysarg_t, sysarg_t *);
+extern errno_t async_req_5_2(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+    sysarg_t, sysarg_t, sysarg_t, sysarg_t *, sysarg_t *);
+extern errno_t async_req_5_3(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+    sysarg_t, sysarg_t, sysarg_t, sysarg_t *, sysarg_t *, sysarg_t *);
+extern errno_t async_req_5_4(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
+    sysarg_t, sysarg_t, sysarg_t, sysarg_t *, sysarg_t *, sysarg_t *,
+    sysarg_t *);
+extern errno_t async_req_5_5(async_exch_t *, sysarg_t, sysarg_t, sysarg_t,
     sysarg_t, sysarg_t, sysarg_t, sysarg_t *, sysarg_t *, sysarg_t *,
     sysarg_t *, sysarg_t *);
 
@@ -356,17 +296,14 @@ extern void async_sess_args_set(async_sess_t *, iface_t, sysarg_t, sysarg_t);
  * User-friendly wrappers for async_share_in_start().
  */
 
-#define async_share_in_start_0_0(exch, size, dst) \
-	async_share_in_start(exch, size, 0, NULL, dst)
-#define async_share_in_start_0_1(exch, size, flags, dst) \
-	async_share_in_start(exch, size, 0, flags, dst)
-#define async_share_in_start_1_0(exch, size, arg, dst) \
-	async_share_in_start(exch, size, arg, NULL, dst)
-#define async_share_in_start_1_1(exch, size, arg, flags, dst) \
-	async_share_in_start(exch, size, arg, flags, dst)
-
-extern errno_t async_share_in_start(async_exch_t *, size_t, sysarg_t,
+extern errno_t async_share_in_start_0_0(async_exch_t *, size_t, void **);
+extern errno_t async_share_in_start_0_1(async_exch_t *, size_t,
     unsigned int *, void **);
+extern errno_t async_share_in_start_1_0(async_exch_t *, size_t, sysarg_t,
+    void **);
+extern errno_t async_share_in_start_1_1(async_exch_t *, size_t, sysarg_t,
+    unsigned int *, void **);
+
 extern bool async_share_in_receive(ipc_call_t *, size_t *);
 extern errno_t async_share_in_finalize(ipc_call_t *, void *, unsigned int);
 
@@ -374,74 +311,16 @@ extern errno_t async_share_out_start(async_exch_t *, void *, unsigned int);
 extern bool async_share_out_receive(ipc_call_t *, size_t *, unsigned int *);
 extern errno_t async_share_out_finalize(ipc_call_t *, void **);
 
-/*
- * User-friendly wrappers for async_data_read_forward_fast().
- */
-
-#define async_data_read_forward_0_0(exch, method, answer) \
-	async_data_read_forward_fast(exch, method, 0, 0, 0, 0, NULL)
-#define async_data_read_forward_0_1(exch, method, answer) \
-	async_data_read_forward_fast(exch, method, 0, 0, 0, 0, answer)
-#define async_data_read_forward_1_0(exch, method, arg1, answer) \
-	async_data_read_forward_fast(exch, method, arg1, 0, 0, 0, NULL)
-#define async_data_read_forward_1_1(exch, method, arg1, answer) \
-	async_data_read_forward_fast(exch, method, arg1, 0, 0, 0, answer)
-#define async_data_read_forward_2_0(exch, method, arg1, arg2, answer) \
-	async_data_read_forward_fast(exch, method, arg1, arg2, 0, 0, NULL)
-#define async_data_read_forward_2_1(exch, method, arg1, arg2, answer) \
-	async_data_read_forward_fast(exch, method, arg1, arg2, 0, 0, answer)
-#define async_data_read_forward_3_0(exch, method, arg1, arg2, arg3, answer) \
-	async_data_read_forward_fast(exch, method, arg1, arg2, arg3, 0, NULL)
-#define async_data_read_forward_3_1(exch, method, arg1, arg2, arg3, answer) \
-	async_data_read_forward_fast(exch, method, arg1, arg2, arg3, 0, \
-	    answer)
-#define async_data_read_forward_4_0(exch, method, arg1, arg2, arg3, arg4, \
-    answer) \
-	async_data_read_forward_fast(exch, method, arg1, arg2, arg3, arg4, \
-	    NULL)
-#define async_data_read_forward_4_1(exch, method, arg1, arg2, arg3, arg4, \
-    answer) \
-	async_data_read_forward_fast(exch, method, arg1, arg2, arg3, arg4, \
-	    answer)
+extern errno_t async_data_read_forward_4_1(async_exch_t *, sysarg_t, sysarg_t,
+    sysarg_t, sysarg_t, sysarg_t, ipc_call_t *);
 
 extern aid_t async_data_read(async_exch_t *, void *, size_t, ipc_call_t *);
 extern errno_t async_data_read_start(async_exch_t *, void *, size_t);
 extern bool async_data_read_receive(ipc_call_t *, size_t *);
 extern errno_t async_data_read_finalize(ipc_call_t *, const void *, size_t);
 
-extern errno_t async_data_read_forward_fast(async_exch_t *, sysarg_t, sysarg_t,
+extern errno_t async_data_write_forward_4_1(async_exch_t *, sysarg_t, sysarg_t,
     sysarg_t, sysarg_t, sysarg_t, ipc_call_t *);
-
-/*
- * User-friendly wrappers for async_data_write_forward_fast().
- */
-
-#define async_data_write_forward_0_0(exch, method, answer) \
-	async_data_write_forward_fast(exch, method, 0, 0, 0, 0, NULL)
-#define async_data_write_forward_0_1(exch, method, answer) \
-	async_data_write_forward_fast(exch, method, 0, 0, 0, 0, answer)
-#define async_data_write_forward_1_0(exch, method, arg1, answer) \
-	async_data_write_forward_fast(exch, method, arg1, 0, 0, 0, NULL)
-#define async_data_write_forward_1_1(exch, method, arg1, answer) \
-	async_data_write_forward_fast(exch, method, arg1, 0, 0, 0, answer)
-#define async_data_write_forward_2_0(exch, method, arg1, arg2, answer) \
-	async_data_write_forward_fast(exch, method, arg1, arg2, 0, 0, NULL)
-#define async_data_write_forward_2_1(exch, method, arg1, arg2, answer) \
-	async_data_write_forward_fast(exch, method, arg1, arg2, 0, 0, answer)
-#define async_data_write_forward_3_0(exch, method, arg1, arg2, arg3, answer) \
-	async_data_write_forward_fast(exch, method, arg1, arg2, arg3, 0, \
-	    NULL)
-#define async_data_write_forward_3_1(exch, method, arg1, arg2, arg3, answer) \
-	async_data_write_forward_fast(exch, method, arg1, arg2, arg3, 0, \
-	    answer)
-#define async_data_write_forward_4_0(exch, method, arg1, arg2, arg3, arg4, \
-    answer) \
-	async_data_write_forward_fast(exch, method, arg1, arg2, arg3, arg4, \
-	    NULL)
-#define async_data_write_forward_4_1(exch, method, arg1, arg2, arg3, arg4, \
-    answer) \
-	async_data_write_forward_fast(exch, method, arg1, arg2, arg3, arg4, \
-	    answer)
 
 extern errno_t async_data_write_start(async_exch_t *, const void *, size_t);
 extern bool async_data_write_receive(ipc_call_t *, size_t *);
@@ -450,9 +329,6 @@ extern errno_t async_data_write_finalize(ipc_call_t *, void *, size_t);
 extern errno_t async_data_write_accept(void **, const bool, const size_t,
     const size_t, const size_t, size_t *);
 extern void async_data_write_void(errno_t);
-
-extern errno_t async_data_write_forward_fast(async_exch_t *, sysarg_t, sysarg_t,
-    sysarg_t, sysarg_t, sysarg_t, ipc_call_t *);
 
 extern async_sess_t *async_callback_receive(exch_mgmt_t);
 extern async_sess_t *async_callback_receive_start(exch_mgmt_t, ipc_call_t *);

--- a/uspace/lib/c/include/async.h
+++ b/uspace/lib/c/include/async.h
@@ -311,6 +311,23 @@ extern errno_t async_share_out_start(async_exch_t *, void *, unsigned int);
 extern bool async_share_out_receive(ipc_call_t *, size_t *, unsigned int *);
 extern errno_t async_share_out_finalize(ipc_call_t *, void **);
 
+extern errno_t async_data_read_forward_0_0(async_exch_t *, sysarg_t);
+extern errno_t async_data_read_forward_1_0(async_exch_t *, sysarg_t, sysarg_t);
+extern errno_t async_data_read_forward_2_0(async_exch_t *, sysarg_t, sysarg_t,
+    sysarg_t);
+extern errno_t async_data_read_forward_3_0(async_exch_t *, sysarg_t, sysarg_t,
+    sysarg_t, sysarg_t);
+extern errno_t async_data_read_forward_4_0(async_exch_t *, sysarg_t, sysarg_t,
+    sysarg_t, sysarg_t, sysarg_t);
+
+extern errno_t async_data_read_forward_0_1(async_exch_t *, sysarg_t,
+    ipc_call_t *);
+extern errno_t async_data_read_forward_1_1(async_exch_t *, sysarg_t, sysarg_t,
+    ipc_call_t *);
+extern errno_t async_data_read_forward_2_1(async_exch_t *, sysarg_t, sysarg_t,
+    sysarg_t, ipc_call_t *);
+extern errno_t async_data_read_forward_3_1(async_exch_t *, sysarg_t, sysarg_t,
+    sysarg_t, sysarg_t, ipc_call_t *);
 extern errno_t async_data_read_forward_4_1(async_exch_t *, sysarg_t, sysarg_t,
     sysarg_t, sysarg_t, sysarg_t, ipc_call_t *);
 
@@ -319,6 +336,23 @@ extern errno_t async_data_read_start(async_exch_t *, void *, size_t);
 extern bool async_data_read_receive(ipc_call_t *, size_t *);
 extern errno_t async_data_read_finalize(ipc_call_t *, const void *, size_t);
 
+extern errno_t async_data_write_forward_0_0(async_exch_t *, sysarg_t);
+extern errno_t async_data_write_forward_1_0(async_exch_t *, sysarg_t, sysarg_t);
+extern errno_t async_data_write_forward_2_0(async_exch_t *, sysarg_t, sysarg_t,
+    sysarg_t);
+extern errno_t async_data_write_forward_3_0(async_exch_t *, sysarg_t, sysarg_t,
+    sysarg_t, sysarg_t);
+extern errno_t async_data_write_forward_4_0(async_exch_t *, sysarg_t, sysarg_t,
+    sysarg_t, sysarg_t, sysarg_t);
+
+extern errno_t async_data_write_forward_0_1(async_exch_t *, sysarg_t,
+    ipc_call_t *);
+extern errno_t async_data_write_forward_1_1(async_exch_t *, sysarg_t, sysarg_t,
+    ipc_call_t *);
+extern errno_t async_data_write_forward_2_1(async_exch_t *, sysarg_t, sysarg_t,
+    sysarg_t, ipc_call_t *);
+extern errno_t async_data_write_forward_3_1(async_exch_t *, sysarg_t, sysarg_t,
+    sysarg_t, sysarg_t, ipc_call_t *);
 extern errno_t async_data_write_forward_4_1(async_exch_t *, sysarg_t, sysarg_t,
     sysarg_t, sysarg_t, sysarg_t, ipc_call_t *);
 

--- a/uspace/srv/devman/main.c
+++ b/uspace/srv/devman/main.c
@@ -135,7 +135,7 @@ static void devman_connection_device(ipc_call_t *icall, void *arg)
 	}
 
 	async_exch_t *exch = async_exchange_begin(driver->sess);
-	async_forward_fast(icall, exch, INTERFACE_DDF_CLIENT, handle, 0, IPC_FF_NONE);
+	async_forward_1(icall, exch, INTERFACE_DDF_CLIENT, handle, IPC_FF_NONE);
 	async_exchange_end(exch);
 
 cleanup:
@@ -214,7 +214,7 @@ static void devman_connection_parent(ipc_call_t *icall, void *arg)
 	}
 
 	async_exch_t *exch = async_exchange_begin(driver->sess);
-	async_forward_fast(icall, exch, INTERFACE_DDF_DRIVER, fun_handle, 0, IPC_FF_NONE);
+	async_forward_1(icall, exch, INTERFACE_DDF_DRIVER, fun_handle, IPC_FF_NONE);
 	async_exchange_end(exch);
 
 cleanup:
@@ -249,7 +249,7 @@ static void devman_forward(ipc_call_t *icall, void *arg)
 	fibril_rwlock_read_unlock(&device_tree.rwlock);
 
 	async_exch_t *exch = async_exchange_begin(driver->sess);
-	async_forward_fast(icall, exch, iface, handle, 0, IPC_FF_NONE);
+	async_forward_1(icall, exch, iface, handle, IPC_FF_NONE);
 	async_exchange_end(exch);
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG,

--- a/uspace/srv/fs/locfs/locfs_ops.c
+++ b/uspace/srv/fs/locfs/locfs_ops.c
@@ -582,7 +582,7 @@ locfs_read(service_id_t service_id, fs_index_t index, aoff64_t pos,
 		    index, LOWER32(pos), UPPER32(pos), &answer);
 
 		/* Forward the IPC_M_DATA_READ request to the driver */
-		async_forward_fast(&call, exch, 0, 0, 0, IPC_FF_ROUTE_FROM_ME);
+		async_forward_0(&call, exch, 0, IPC_FF_ROUTE_FROM_ME);
 
 		async_exchange_end(exch);
 
@@ -646,7 +646,7 @@ locfs_write(service_id_t service_id, fs_index_t index, aoff64_t pos,
 		    index, LOWER32(pos), UPPER32(pos), &answer);
 
 		/* Forward the IPC_M_DATA_WRITE request to the driver */
-		async_forward_fast(&call, exch, 0, 0, 0, IPC_FF_ROUTE_FROM_ME);
+		async_forward_0(&call, exch, 0, IPC_FF_ROUTE_FROM_ME);
 
 		async_exchange_end(exch);
 

--- a/uspace/srv/locsrv/locsrv.c
+++ b/uspace/srv/locsrv/locsrv.c
@@ -725,7 +725,7 @@ static void loc_forward(ipc_call_t *call, void *arg)
 	}
 
 	async_exch_t *exch = async_exchange_begin(svc->server->sess);
-	async_forward_fast(call, exch, iface, svc->id, 0, IPC_FF_NONE);
+	async_forward_1(call, exch, iface, svc->id, IPC_FF_NONE);
 	async_exchange_end(exch);
 
 	fibril_mutex_unlock(&services_list_mutex);

--- a/uspace/srv/ns/clonable.c
+++ b/uspace/srv/ns/clonable.c
@@ -93,8 +93,8 @@ void ns_clonable_register(ipc_call_t *call)
 		async_answer_0(call, EIO);
 
 	async_exch_t *exch = async_exchange_begin(sess);
-	async_forward_fast(&csr->call, exch, csr->iface,
-	    IPC_GET_ARG3(csr->call), 0, IPC_FF_NONE);
+	async_forward_1(&csr->call, exch, csr->iface,
+	    IPC_GET_ARG3(csr->call), IPC_FF_NONE);
 	async_exchange_end(exch);
 
 	free(csr);

--- a/uspace/srv/ns/service.c
+++ b/uspace/srv/ns/service.c
@@ -153,8 +153,7 @@ errno_t ns_service_init(void)
 static void ns_forward(async_sess_t *sess, ipc_call_t *call, iface_t iface)
 {
 	async_exch_t *exch = async_exchange_begin(sess);
-	async_forward_fast(call, exch, iface, IPC_GET_ARG3(*call), 0,
-	    IPC_FF_NONE);
+	async_forward_1(call, exch, iface, IPC_GET_ARG3(*call), IPC_FF_NONE);
 	async_exchange_end(exch);
 }
 

--- a/uspace/srv/vfs/vfs_ops.c
+++ b/uspace/srv/vfs/vfs_ops.c
@@ -636,8 +636,8 @@ errno_t vfs_op_stat(int fd)
 	vfs_node_t *node = file->node;
 
 	async_exch_t *exch = vfs_exchange_grab(node->fs_handle);
-	errno_t rc = async_data_read_forward_4_1(exch, VFS_OUT_STAT,
-	    node->service_id, node->index, true, 0, NULL);
+	errno_t rc = async_data_read_forward_3_0(exch, VFS_OUT_STAT,
+	    node->service_id, node->index, true);
 	vfs_exchange_release(exch);
 
 	vfs_file_put(file);
@@ -653,8 +653,8 @@ errno_t vfs_op_statfs(int fd)
 	vfs_node_t *node = file->node;
 
 	async_exch_t *exch = vfs_exchange_grab(node->fs_handle);
-	errno_t rc = async_data_read_forward_4_1(exch, VFS_OUT_STATFS,
-	    node->service_id, node->index, false, 0, NULL);
+	errno_t rc = async_data_read_forward_3_0(exch, VFS_OUT_STATFS,
+	    node->service_id, node->index, false);
 	vfs_exchange_release(exch);
 
 	vfs_file_put(file);

--- a/uspace/srv/vfs/vfs_ops.c
+++ b/uspace/srv/vfs/vfs_ops.c
@@ -636,7 +636,7 @@ errno_t vfs_op_stat(int fd)
 	vfs_node_t *node = file->node;
 
 	async_exch_t *exch = vfs_exchange_grab(node->fs_handle);
-	errno_t rc = async_data_read_forward_fast(exch, VFS_OUT_STAT,
+	errno_t rc = async_data_read_forward_4_1(exch, VFS_OUT_STAT,
 	    node->service_id, node->index, true, 0, NULL);
 	vfs_exchange_release(exch);
 
@@ -653,7 +653,7 @@ errno_t vfs_op_statfs(int fd)
 	vfs_node_t *node = file->node;
 
 	async_exch_t *exch = vfs_exchange_grab(node->fs_handle);
-	errno_t rc = async_data_read_forward_fast(exch, VFS_OUT_STATFS,
+	errno_t rc = async_data_read_forward_4_1(exch, VFS_OUT_STATFS,
 	    node->service_id, node->index, false, 0, NULL);
 	vfs_exchange_release(exch);
 


### PR DESCRIPTION
"fast" and "slow" paths are implementation detail.
All macros in <async.h> are turned into external functions, so that
this implementation detail doesn't leak. Additionally, removing macros is
A Good Thing on its own, e.g. helping C++ interoperability.