### PR TITLE
Abort and report when an unimplemented function is called

### DIFF
--- a/uspace/lib/cpp/include/__bits/adt/list.hpp
+++ b/uspace/lib/cpp/include/__bits/adt/list.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Jaroslav Jindrak
+ * Copyright (c) 2019 Jaroslav Jindrak
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,6 +31,7 @@
 
 #include <__bits/adt/list_node.hpp>
 #include <__bits/insert_iterator.hpp>
+#include <cassert>
 #include <cstdlib>
 #include <iterator>
 #include <memory>
@@ -579,11 +580,13 @@ namespace std
             void resize(size_type sz)
             {
                 // TODO: implement
+                __unimplemented();
             }
 
             void resize(size_type sz, const value_type& val)
             {
                 // TODO: implement
+                __unimplemented();
             }
 
             reference front()
@@ -1041,6 +1044,7 @@ namespace std
             void merge(list& other)
             {
                 // TODO: implement
+                __unimplemented();
             }
 
             void merge(list&& other)
@@ -1052,6 +1056,7 @@ namespace std
             void merge(list& other, Compare comp)
             {
                 // TODO: implement
+                __unimplemented();
             }
 
             template<class Compare>
@@ -1063,17 +1068,20 @@ namespace std
             void reverse() noexcept
             {
                 // TODO: implement
+                __unimplemented();
             }
 
             void sort()
             {
                 // TODO: implement
+                __unimplemented();
             }
 
             template<class Compare>
             void sort(Compare comp)
             {
                 // TODO: implement
+                __unimplemented();
             }
 
         private:

--- a/uspace/lib/cpp/include/__bits/complex.hpp
+++ b/uspace/lib/cpp/include/__bits/complex.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Jaroslav Jindrak
+ * Copyright (c) 2019 Jaroslav Jindrak
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,6 +29,7 @@
 #ifndef LIBCPP_BITS_COMPLEX
 #define LIBCPP_BITS_COMPLEX
 
+#include <cassert>
 #include <iosfwd>
 #include <sstream>
 
@@ -723,6 +724,8 @@ namespace std
                                             const complex<T>& c)
     {
         // TODO: implement
+        __unimplemented();
+        return is;
     }
 
     template<class T, class Char, class Traits>
@@ -765,6 +768,7 @@ namespace std
     T arg(const complex<T>& c)
     {
         // TODO: implement
+        __unimplemented();
         return c;
     }
 
@@ -778,6 +782,7 @@ namespace std
     complex<T> conj(const complex<T>& c)
     {
         // TODO: implement
+        __unimplemented();
         return c;
     }
 
@@ -785,6 +790,7 @@ namespace std
     complex<T> proj(const complex<T>& c)
     {
         // TODO: implement
+        __unimplemented();
         return c;
     }
 
@@ -792,6 +798,7 @@ namespace std
     complex<T> polar(const T&, const T& = T{})
     {
         // TODO: implement
+        __unimplemented();
         return complex<T>{};
     }
 
@@ -803,6 +810,7 @@ namespace std
     complex<T> acos(const complex<T>& c)
     {
         // TODO: implement
+        __unimplemented();
         return c;
     }
 
@@ -810,6 +818,7 @@ namespace std
     complex<T> asin(const complex<T>& c)
     {
         // TODO: implement
+        __unimplemented();
         return c;
     }
 
@@ -817,6 +826,7 @@ namespace std
     complex<T> atan(const complex<T>& c)
     {
         // TODO: implement
+        __unimplemented();
         return c;
     }
 
@@ -824,6 +834,7 @@ namespace std
     complex<T> acosh(const complex<T>& c)
     {
         // TODO: implement
+        __unimplemented();
         return c;
     }
 
@@ -831,6 +842,7 @@ namespace std
     complex<T> asinh(const complex<T>& c)
     {
         // TODO: implement
+        __unimplemented();
         return c;
     }
 
@@ -838,6 +850,7 @@ namespace std
     complex<T> atanh(const complex<T>& c)
     {
         // TODO: implement
+        __unimplemented();
         return c;
     }
 
@@ -845,6 +858,7 @@ namespace std
     complex<T> cos(const complex<T>& c)
     {
         // TODO: implement
+        __unimplemented();
         return c;
     }
 
@@ -852,6 +866,7 @@ namespace std
     complex<T> cosh(const complex<T>& c)
     {
         // TODO: implement
+        __unimplemented();
         return c;
     }
 
@@ -859,6 +874,7 @@ namespace std
     complex<T> exp(const complex<T>& c)
     {
         // TODO: implement
+        __unimplemented();
         return c;
     }
 
@@ -866,6 +882,7 @@ namespace std
     complex<T> log(const complex<T>& c)
     {
         // TODO: implement
+        __unimplemented();
         return c;
     }
 
@@ -873,6 +890,7 @@ namespace std
     complex<T> log10(const complex<T>& c)
     {
         // TODO: implement
+        __unimplemented();
         return c;
     }
 
@@ -880,6 +898,7 @@ namespace std
     complex<T> pow(const complex<T>& base, const T& exp)
     {
         // TODO: implement
+        __unimplemented();
         return base;
     }
 
@@ -887,6 +906,7 @@ namespace std
     complex<T> pow(const complex<T>& base, const complex<T>& exp)
     {
         // TODO: implement
+        __unimplemented();
         return base;
     }
 
@@ -894,6 +914,7 @@ namespace std
     complex<T> pow(const T& base, const complex<T>& exp)
     {
         // TODO: implement
+        __unimplemented();
         return complex<T>{base};
     }
 
@@ -901,6 +922,7 @@ namespace std
     complex<T> sin(const complex<T>& c)
     {
         // TODO: implement
+        __unimplemented();
         return c;
     }
 
@@ -908,6 +930,7 @@ namespace std
     complex<T> sinh(const complex<T>& c)
     {
         // TODO: implement
+        __unimplemented();
         return c;
     }
 
@@ -915,6 +938,7 @@ namespace std
     complex<T> sqrt(const complex<T>& c)
     {
         // TODO: implement
+        __unimplemented();
         return c;
     }
 
@@ -922,6 +946,7 @@ namespace std
     complex<T> tan(const complex<T>& c)
     {
         // TODO: implement
+        __unimplemented();
         return c;
     }
 
@@ -929,6 +954,7 @@ namespace std
     complex<T> tanh(const complex<T>& c)
     {
         // TODO: implement
+        __unimplemented();
         return c;
     }
 

--- a/uspace/lib/cpp/include/__bits/functional/bind.hpp
+++ b/uspace/lib/cpp/include/__bits/functional/bind.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Jaroslav Jindrak
+ * Copyright (c) 2019 Jaroslav Jindrak
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,6 +32,7 @@
 #include <__bits/functional/function.hpp>
 #include <__bits/functional/invoke.hpp>
 #include <__bits/functional/reference_wrapper.hpp>
+#include <cassert>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -132,6 +133,7 @@ namespace std
                 template<class R, bool B, class F, class... BindArgs>
                 constexpr decltype(auto) operator[](const bind_t<R, B, F, BindArgs...> b)
                 {
+                    __unimplemented();
                     return b; // TODO: bind subexpressions
                 }
 

--- a/uspace/lib/cpp/include/__bits/io/fstream.hpp
+++ b/uspace/lib/cpp/include/__bits/io/fstream.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Jaroslav Jindrak
+ * Copyright (c) 2019 Jaroslav Jindrak
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,6 +29,7 @@
 #ifndef LIBCPP_BITS_IO_FSTREAM
 #define LIBCPP_BITS_IO_FSTREAM
 
+#include <cassert>
 #include <cstdio>
 #include <ios>
 #include <iosfwd>
@@ -266,6 +267,7 @@ namespace std
             setbuf(char_type* s, streamsize n) override
             {
                 // TODO: implement
+                __unimplemented();
                 return nullptr;
             }
 
@@ -273,6 +275,7 @@ namespace std
                              ios_base::openmode mode = ios_base::in | ios_base::out) override
             {
                 // TODO: implement
+                __unimplemented();
                 return pos_type{};
             }
 
@@ -280,6 +283,7 @@ namespace std
                              ios_base::openmode mode = ios_base::in | ios_base::out) override
             {
                 // TODO: implement
+                __unimplemented();
                 return pos_type{};
             }
 

--- a/uspace/lib/cpp/include/__bits/io/istream.hpp
+++ b/uspace/lib/cpp/include/__bits/io/istream.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Jaroslav Jindrak
+ * Copyright (c) 2019 Jaroslav Jindrak
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,6 +29,7 @@
 #ifndef LIBCPP_BITS_IO_ISTREAM
 #define LIBCPP_BITS_IO_ISTREAM
 
+#include <cassert>
 #include <ios>
 #include <iosfwd>
 #include <limits>
@@ -338,21 +339,29 @@ namespace std
             basic_istream<Char, Traits>& operator>>(float& x)
             {
                 // TODO: implement
+                __unimplemented();
+                return *this;
             }
 
             basic_istream<Char, Traits>& operator>>(double& x)
             {
                 // TODO: implement
+                __unimplemented();
+                return *this;
             }
 
             basic_istream<Char, Traits>& operator>>(long double& x)
             {
                 // TODO: implement
+                __unimplemented();
+                return *this;
             }
 
             basic_istream<Char, Traits>& operator>>(void*& p)
             {
                 // TODO: implement
+                __unimplemented();
+                return *this;
             }
 
             basic_istream<Char, Traits>& operator>>(basic_streambuf<Char, Traits>* sb)

--- a/uspace/lib/cpp/include/__bits/io/ostream.hpp
+++ b/uspace/lib/cpp/include/__bits/io/ostream.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Jaroslav Jindrak
+ * Copyright (c) 2019 Jaroslav Jindrak
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,6 +29,7 @@
 #ifndef LIBCPP_BITS_IO_OSTREAM
 #define LIBCPP_BITS_IO_OSTREAM
 
+#include <cassert>
 #include <ios>
 #include <iosfwd>
 #include <locale>
@@ -457,18 +458,21 @@ namespace std
             pos_type tellp()
             {
                 // TODO: implement
+                __unimplemented();
                 return pos_type{};
             }
 
             basic_ostream<Char, Traits>& seekp(pos_type pos)
             {
                 // TODO: implement
+                __unimplemented();
                 return *this;
             }
 
             basic_ostream<Char, Traits>& seekp(off_type off, ios_base::seekdir dir)
             {
                 // TODO: implement
+                __unimplemented();
                 return *this;
             }
 

--- a/uspace/lib/cpp/include/__bits/new.hpp
+++ b/uspace/lib/cpp/include/__bits/new.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Jaroslav Jindrak
+ * Copyright (c) 2019 Jaroslav Jindrak
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,6 +29,7 @@
 #ifndef LIBCPP_BITS_NEW
 #define LIBCPP_BITS_NEW
 
+#include <cstddef>
 #include <exception>
 
 namespace std

--- a/uspace/lib/cpp/include/__bits/string/string.hpp
+++ b/uspace/lib/cpp/include/__bits/string/string.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Jaroslav Jindrak
+ * Copyright (c) 2019 Jaroslav Jindrak
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,6 +31,7 @@
 
 #include <__bits/string/stringfwd.hpp>
 #include <algorithm>
+#include <cassert>
 #include <initializer_list>
 #include <iosfwd>
 #include <iterator>
@@ -177,36 +178,42 @@ namespace std
         static int compare(const char_type* s1, const char_type* s2, size_t n)
         {
             // TODO: implement
+            __unimplemented();
             return 0;
         }
 
         static size_t length(const char_type* s)
         {
             // TODO: implement
+            __unimplemented();
             return 0;
         }
 
         static const char_type* find(const char_type* s, size_t n, const char_type& c)
         {
             // TODO: implement
+            __unimplemented();
             return nullptr;
         }
 
         static char_type* move(char_type* s1, const char_type* s2, size_t n)
         {
             // TODO: implement
+            __unimplemented();
             return nullptr;
         }
 
         static char_type* copy(char_type* s1, const char_type* s2, size_t n)
         {
             // TODO: implement
+            __unimplemented();
             return nullptr;
         }
 
         static char_type* assign(char_type* s, size_t n, char_type c)
         {
             // TODO: implement
+            __unimplemented();
             return nullptr;
         }
 
@@ -265,36 +272,42 @@ namespace std
         static int compare(const char_type* s1, const char_type* s2, size_t n)
         {
             // TODO: implement
+            __unimplemented();
             return 0;
         }
 
         static size_t length(const char_type* s)
         {
             // TODO: implement
+            __unimplemented();
             return 0;
         }
 
         static const char_type* find(const char_type* s, size_t n, const char_type& c)
         {
             // TODO: implement
+            __unimplemented();
             return nullptr;
         }
 
         static char_type* move(char_type* s1, const char_type* s2, size_t n)
         {
             // TODO: implement
+            __unimplemented();
             return nullptr;
         }
 
         static char_type* copy(char_type* s1, const char_type* s2, size_t n)
         {
             // TODO: implement
+            __unimplemented();
             return nullptr;
         }
 
         static char_type* assign(char_type* s, size_t n, char_type c)
         {
             // TODO: implement
+            __unimplemented();
             return nullptr;
         }
 
@@ -352,6 +365,7 @@ namespace std
         static int compare(const char_type* s1, const char_type* s2, size_t n)
         {
             // TODO: This function does not exits...
+            __unimplemented();
             //return hel::wstr_lcmp(s1, s2, n);
             return 0;
         }
@@ -1938,6 +1952,7 @@ namespace std
         size_t operator()(const wstring& str) const noexcept
         {
             // TODO: implement
+            __unimplemented();
             return size_t{};
         }
 

--- a/uspace/lib/cpp/include/__bits/thread/future.hpp
+++ b/uspace/lib/cpp/include/__bits/thread/future.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Jaroslav Jindrak
+ * Copyright (c) 2019 Jaroslav Jindrak
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,6 +29,7 @@
 #ifndef LIBCPP_BITS_THREAD_FUTURE
 #define LIBCPP_BITS_THREAD_FUTURE
 
+#include <cassert>
 #include <memory>
 #include <system_error>
 #include <type_traits>
@@ -170,6 +171,7 @@ namespace std
     async(F&& f, Args&&... args)
     {
         // TODO: implement
+        __unimplemented();
     }
 
     template<class F, class... Args>
@@ -177,6 +179,7 @@ namespace std
     async(launch, F&& f, Args&&... args)
     {
         // TODO: implement
+        __unimplemented();
     }
 }
 

--- a/uspace/lib/cpp/include/cassert
+++ b/uspace/lib/cpp/include/cassert
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Jaroslav Jindrak
+ * Copyright (c) 2019 Jaroslav Jindrak
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,29 +30,16 @@
 #define LIBCPP_CASSERT
 
 
-namespace std::hel
-{
-    extern "C" {
-        #include <assert.h>
-    }
+extern "C" {
+    #include <assert.h>
 }
 
-namespace std
-{
-    // Note: The only thing imported is assert
-    //       and that is a macro.
-}
+// TODO: For some reason, this function isn't visible (maybe the
+//       noreturn attribute?), adding a redeclaration here for the
+//       time being.
 
-/**
- * We need to fix the assert macro because it uses
- * a non-standard function that we have in the
- * std::hel namespace.
- */
-#undef assert
-#define assert(expr) \
-	do { \
-		if (!(expr)) \
-			std::hel::assert_abort(#expr, __FILE__, __LINE__); \
-	} while (0)
+extern void __helenos_assert_abort(const char *, const char *, unsigned int);
+
+#define __unimplemented() assert(!"Not implemented!")
 
 #endif

--- a/uspace/lib/cpp/src/__bits/runtime.cpp
+++ b/uspace/lib/cpp/src/__bits/runtime.cpp
@@ -32,6 +32,8 @@
 #include <exception>
 #include <mutex>
 
+void* __dso_handle = nullptr;
+
 namespace __cxxabiv1
 {
     namespace aux

--- a/uspace/lib/cpp/src/__bits/unwind.cpp
+++ b/uspace/lib/cpp/src/__bits/unwind.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Jaroslav Jindrak
+ * Copyright (c) 2019 Jaroslav Jindrak
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,6 +26,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <cassert>
 #include <cstdint>
 #include <cstdlib>
 
@@ -174,54 +175,64 @@ namespace __cxxabiv1
     extern "C" void* __cxa_allocate_exception(std::size_t thrown_size)
     {
         // TODO: implement
+        __unimplemented();
         return nullptr;
     }
 
     extern "C" void __cxa_free_exception(void* thrown_exception)
     {
         // TODO: implement
+        __unimplemented();
     }
 
     extern "C" void __cxa_throw(void* thrown_exception, std::type_info* tinfo, void (*dest)(void*))
     {
         // TODO: implement
+        __unimplemented();
     }
 
     extern "C" void* __cxa_get_exception_ptr(void*  exception_object)
     {
         // TODO: implement
+        __unimplemented();
         return nullptr;
     }
 
     extern "C" void* __cxa_begin_catch(void* exception_object)
     {
         // TODO: implement
+        __unimplemented();
         return nullptr;
     }
 
     extern "C" void __cxa_end_catch()
     {
         // TODO: implement
+        __unimplemented();
     }
 
     extern "C" void __cxa_rethrow()
     {
         // TODO: implement
+        __unimplemented();
     }
 
     extern "C" void __cxa_bad_cast()
     {
         // TODO: implement
+        __unimplemented();
     }
 
     extern "C" void __cxa_bad_typeid()
     {
         // TODO: implement
+        __unimplemented();
     }
 
     extern "C" void __cxa_throw_bad_array_new_length()
     {
         // TODO: implement
+        __unimplemented();
     }
 
     extern "C" _Unwind_Reason_Code __gxx_personality_v0(
@@ -230,6 +241,7 @@ namespace __cxxabiv1
     )
     {
         // TODO: implement
+        __unimplemented();
         return _URC_NO_REASON;
     }
 }

--- a/uspace/lib/cpp/src/condition_variable.cpp
+++ b/uspace/lib/cpp/src/condition_variable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Jaroslav Jindrak
+ * Copyright (c) 2019 Jaroslav Jindrak
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,6 +26,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <cassert>
 #include <condition_variable>
 
 namespace std
@@ -87,5 +88,6 @@ namespace std
     void notify_all_at_thread_exit(condition_variable&, unique_lock<mutex>&)
     {
         // TODO: implement
+        __unimplemented();
     }
 }

--- a/uspace/lib/cpp/src/string.cpp
+++ b/uspace/lib/cpp/src/string.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Jaroslav Jindrak
+ * Copyright (c) 2019 Jaroslav Jindrak
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,6 +26,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <cassert>
 #include <string>
 
 namespace std
@@ -33,6 +34,7 @@ namespace std
     int stoi(const string& str, size_t* idx, int base)
     {
         // TODO: implement using stol once we have numeric limits
+        __unimplemented();
         return 0;
     }
 
@@ -71,30 +73,35 @@ namespace std
     long long stoll(const string& str, size_t* idx, int base)
     {
         // TODO: implement using stol once we have numeric limits
+        __unimplemented();
         return 0;
     }
 
     unsigned long long stoull(const string& str, size_t* idx, int base)
     {
         // TODO: implement using stoul once we have numeric limits
+        __unimplemented();
         return 0;
     }
 
     float stof(const string& str, size_t* idx)
     {
         // TODO: implement
+        __unimplemented();
         return 0.f;
     }
 
     double stod(const string& str, size_t* idx)
     {
         // TODO: implement
+        __unimplemented();
         return 0.0;
     }
 
     long double stold(const string& str, size_t* idx)
     {
         // TODO: implement
+        __unimplemented();
         return 0.0l;
     }
 
@@ -205,102 +212,119 @@ namespace std
     int stoi(const wstring& str, size_t* idx, int base)
     {
         // TODO: implement
+        __unimplemented();
         return 0;
     }
 
     long stol(const wstring& str, size_t* idx, int base)
     {
         // TODO: implement
+        __unimplemented();
         return 0;
     }
 
     unsigned long stoul(const wstring& str, size_t* idx, int base)
     {
         // TODO: implement
+        __unimplemented();
         return 0;
     }
 
     long long stoll(const wstring& str, size_t* idx, int base)
     {
         // TODO: implement
+        __unimplemented();
         return 0;
     }
 
     unsigned long long stoull(const wstring& str, size_t* idx, int base)
     {
         // TODO: implement
+        __unimplemented();
         return 0;
     }
 
     float stof(const wstring& str, size_t* idx)
     {
         // TODO: implement
+        __unimplemented();
         return 0.f;
     }
 
     double stod(const wstring& str, size_t* idx)
     {
         // TODO: implement
+        __unimplemented();
         return 0.0;
     }
 
     long double stold(const wstring& str, size_t* idx)
     {
         // TODO: implement
+        __unimplemented();
         return 0.0l;
     }
 
     wstring to_wstring(int val)
     {
         // TODO: implement
+        __unimplemented();
         return wstring{};
     }
 
     wstring to_wstring(unsigned val)
     {
         // TODO: implement
+        __unimplemented();
         return wstring{};
     }
 
     wstring to_wstring(long val)
     {
         // TODO: implement
+        __unimplemented();
         return wstring{};
     }
 
     wstring to_wstring(unsigned long val)
     {
         // TODO: implement
+        __unimplemented();
         return wstring{};
     }
 
     wstring to_wstring(long long val)
     {
         // TODO: implement
+        __unimplemented();
         return wstring{};
     }
 
     wstring to_wstring(unsigned long long val)
     {
         // TODO: implement
+        __unimplemented();
         return wstring{};
     }
 
     wstring to_wstring(float val)
     {
         // TODO: implement
+        __unimplemented();
         return wstring{};
     }
 
     wstring to_wstring(double val)
     {
         // TODO: implement
+        __unimplemented();
         return wstring{};
     }
 
     wstring to_wstring(long double val)
     {
         // TODO: implement
+        __unimplemented();
         return wstring{};
     }
 

--- a/uspace/lib/cpp/src/thread.cpp
+++ b/uspace/lib/cpp/src/thread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Jaroslav Jindrak
+ * Copyright (c) 2019 Jaroslav Jindrak
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,6 +26,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <cassert>
 #include <cstdlib>
 #include <exception>
 #include <thread>
@@ -119,6 +120,7 @@ namespace std
     unsigned thread::hardware_concurrency() noexcept
     {
         // TODO:
+        __unimplemented();
         return 0;
     }
 


### PR DESCRIPTION
As discussed with @le-jzr , I added a macro that is used in unimplemented functions to abort the program and report the source code location.

There were some cases ignored:
  - rbtree: the missing functions are meant to be no-op (it's missing balancing operations, but the
                structure works without them)
  - locale: these functions modify their input to another localization (e.g. encoding), but they are stubs
  - constexpr functions: these can't be done without implementation or removal, there were two cases:
    - string.hpp: does not matter, their return value is valid
    - limits.hpp: 3 floating point functions, I will look for a fix (or remove them)

Also added missing include in <new> and a missing symbol needed for the runtime (it was part of the custom linker scripts which are now gone).