### PR TITLE
Avoid directly using .head/.next/.prev of list_t/link_t

### DIFF
--- a/uspace/app/taskdump/fibrildump.c
+++ b/uspace/app/taskdump/fibrildump.c
@@ -106,7 +106,7 @@ errno_t fibrils_dump(symtab_t *symtab, async_sess_t *sess)
 		if (rc != EOK)
 			return EIO;
 
-		addr = (uintptr_t) link.next;
+		addr = (uintptr_t) link.__adt_link_next;
 		if (addr == fibril_list_addr)
 			break;
 

--- a/uspace/drv/bus/usb/ehci/endpoint_list.c
+++ b/uspace/drv/bus/usb/ehci/endpoint_list.c
@@ -159,13 +159,15 @@ void endpoint_list_remove_ep(endpoint_list_t *instance, ehci_endpoint_t *ep)
 
 	const char *qpos = NULL;
 	qh_t *prev_qh;
+	link_t *prev = list_prev(&ep->eplist_link, &instance->endpoint_list);
+
 	/* Remove from the hardware queue */
-	if (list_first(&instance->endpoint_list) == &ep->eplist_link) {
+	if (!prev) {
 		/* I'm the first one here */
 		prev_qh = instance->list_head;
 		qpos = "FIRST";
 	} else {
-		prev_qh = ehci_endpoint_list_instance(ep->eplist_link.prev)->qh;
+		prev_qh = ehci_endpoint_list_instance(prev)->qh;
 		qpos = "NOT FIRST";
 	}
 	assert(qh_next(prev_qh) == addr_to_phys(ep->qh));

--- a/uspace/drv/bus/usb/ohci/endpoint_list.c
+++ b/uspace/drv/bus/usb/ohci/endpoint_list.c
@@ -155,14 +155,15 @@ void endpoint_list_remove_ep(endpoint_list_t *instance, ohci_endpoint_t *ep)
 
 	const char *qpos = NULL;
 	ed_t *prev_ed;
+	link_t *prev_link = list_prev(&ep->eplist_link, &instance->endpoint_list);
 	/* Remove from the hardware queue */
-	if (list_first(&instance->endpoint_list) == &ep->eplist_link) {
+	if (!prev_link) {
 		/* I'm the first one here */
 		prev_ed = instance->list_head;
 		qpos = "FIRST";
 	} else {
 		ohci_endpoint_t *prev =
-		    list_get_instance(ep->eplist_link.prev, ohci_endpoint_t, eplist_link);
+		    list_get_instance(prev_link, ohci_endpoint_t, eplist_link);
 		prev_ed = prev->ed;
 		qpos = "NOT FIRST";
 	}

--- a/uspace/drv/bus/usb/uhci/transfer_list.c
+++ b/uspace/drv/bus/usb/uhci/transfer_list.c
@@ -232,11 +232,11 @@ void transfer_list_remove_batch(
 	/* Assume I'm the first */
 	const char *qpos = "FIRST";
 	qh_t *prev_qh = instance->queue_head;
+	link_t *prev = list_prev(&uhci_batch->link, &instance->batch_list);
 	/* Remove from the hardware queue */
-	if (list_first(&instance->batch_list) != &uhci_batch->link) {
+	if (prev) {
 		/* There is a batch in front of me */
-		prev_qh =
-		    uhci_transfer_batch_from_link(uhci_batch->link.prev)->qh;
+		prev_qh = uhci_transfer_batch_from_link(prev)->qh;
 		qpos = "NOT FIRST";
 	}
 	assert((prev_qh->next & LINK_POINTER_ADDRESS_MASK) ==

--- a/uspace/lib/c/generic/adt/hash_table.c
+++ b/uspace/lib/c/generic/adt/hash_table.c
@@ -272,14 +272,14 @@ hash_table_find_next(const hash_table_t *h, ht_link_t *first, ht_link_t *item)
 	assert(h && h->bucket);
 
 	size_t idx = h->op->hash(item) % h->bucket_cnt;
+	list_t *list = &h->bucket[idx];
 
 	/* Traverse the circular list until we reach the starting item again. */
-	for (link_t *cur = item->link.next; cur != &first->link;
-	    cur = cur->next) {
-		assert(cur);
+	for (link_t *cur = list_next(&item->link, list); cur != &first->link;
+	    cur = list_next(cur, list)) {
 
-		if (cur == &h->bucket[idx].head)
-			continue;
+		if (!cur)
+			cur = list_first(list);
 
 		ht_link_t *cur_link = member_to_inst(cur, ht_link_t, link);
 		/*

--- a/uspace/lib/c/generic/adt/list.c
+++ b/uspace/lib/c/generic/adt/list.c
@@ -54,18 +54,18 @@
  */
 bool list_member(const link_t *link, const list_t *list)
 {
-	bool found = false;
-	link_t *hlp = list->head.next;
+	if (list_empty(list))
+		return false;
 
-	while (hlp != &list->head) {
-		if (hlp == link) {
-			found = true;
-			break;
-		}
-		hlp = hlp->next;
+	link_t *hlp = list->__adt_list_head.__adt_link_next;
+
+	while (hlp != &list->__adt_list_head) {
+		if (hlp == link)
+			return true;
+		hlp = hlp->__adt_link_next;
 	}
 
-	return found;
+	return false;
 }
 
 /** Moves items of one list into another after the specified item.
@@ -82,12 +82,12 @@ void list_splice(list_t *list, link_t *pos)
 		return;
 
 	/* Attach list to destination. */
-	list->head.next->prev = pos;
-	list->head.prev->next = pos->next;
+	list->__adt_list_head.__adt_link_next->__adt_link_prev = pos;
+	list->__adt_list_head.__adt_link_prev->__adt_link_next = pos->__adt_link_next;
 
 	/* Link destination list to the added list. */
-	pos->next->prev = list->head.prev;
-	pos->next = list->head.next;
+	pos->__adt_link_next->__adt_link_prev = list->__adt_list_head.__adt_link_prev;
+	pos->__adt_link_next = list->__adt_list_head.__adt_link_next;
 
 	list_initialize(list);
 }

--- a/uspace/lib/c/generic/thread/fibril.c
+++ b/uspace/lib/c/generic/thread/fibril.c
@@ -600,17 +600,14 @@ static void _insert_timeout(_timeout_t *timeout)
 	futex_assert_is_locked(&fibril_futex);
 	assert(timeout);
 
-	link_t *tmp = timeout_list.head.next;
-	while (tmp != &timeout_list.head) {
-		_timeout_t *cur = list_get_instance(tmp, _timeout_t, link);
-
-		if (ts_gteq(&cur->expires, &timeout->expires))
-			break;
-
-		tmp = tmp->next;
+	list_foreach(timeout_list, link, _timeout_t, cur) {
+		if (ts_gteq(&cur->expires, &timeout->expires)) {
+			list_insert_before(&timeout->link, &cur->link);
+			return;
+		}
 	}
 
-	list_insert_before(&timeout->link, tmp);
+	list_append(&timeout->link, &timeout_list);
 }
 
 /**

--- a/uspace/lib/c/include/ipc/devman.h
+++ b/uspace/lib/c/include/ipc/devman.h
@@ -107,18 +107,14 @@ static inline void delete_match_id(match_id_t *id)
 
 static inline void add_match_id(match_id_list_t *ids, match_id_t *id)
 {
-	match_id_t *mid = NULL;
-	link_t *link = ids->ids.head.next;
-
-	while (link != &ids->ids.head) {
-		mid = list_get_instance(link, match_id_t, link);
+	list_foreach(ids->ids, link, match_id_t, mid) {
 		if (mid->score < id->score) {
-			break;
+			list_insert_before(&id->link, &mid->link);
+			return;
 		}
-		link = link->next;
 	}
 
-	list_insert_before(&id->link, link);
+	list_append(&id->link, &ids->ids);
 }
 
 static inline void init_match_ids(match_id_list_t *id_list)

--- a/uspace/lib/nic/include/nic.h
+++ b/uspace/lib/nic/include/nic.h
@@ -70,7 +70,10 @@ typedef struct {
 	size_t size;
 } nic_frame_t;
 
-typedef list_t nic_frame_list_t;
+typedef union {
+	list_t list;
+	link_t link;
+} nic_frame_list_t;
 
 /**
  * Handler for writing frame data to the NIC device.

--- a/uspace/lib/posix/src/signal.c
+++ b/uspace/lib/posix/src/signal.c
@@ -382,23 +382,16 @@ static int _raise_sigaction(int signo, siginfo_t *siginfo)
  */
 static void _dequeue_unblocked_signals(void)
 {
-	link_t *iterator = _signal_queue.head.next;
-	link_t *next;
-
-	while (iterator != &(_signal_queue).head) {
-		next = iterator->next;
-
+	list_foreach_safe(_signal_queue, cur_link, next_link) {
 		signal_queue_item *item =
-		    list_get_instance(iterator, signal_queue_item, link);
+		    list_get_instance(cur_link, signal_queue_item, link);
 
 		if (!sigismember(&_signal_mask, item->signo) &&
 		    _signal_actions[item->signo].sa_handler != SIG_HOLD) {
-			list_remove(&(item->link));
-			_raise_sigaction(item->signo, &(item->siginfo));
+			list_remove(cur_link);
+			_raise_sigaction(item->signo, &item->siginfo);
 			free(item);
 		}
-
-		iterator = next;
 	}
 }
 

--- a/uspace/lib/usbhid/src/hidparser.c
+++ b/uspace/lib/usbhid/src/hidparser.c
@@ -492,12 +492,12 @@ usb_hid_report_field_t *usb_hid_report_get_sibling(usb_hid_report_t *report,
 	}
 
 	if (field == NULL) {
-		field_it = report_des->report_items.head.next;
+		field_it = list_first(&report_des->report_items);
 	} else {
-		field_it = field->ritems_link.next;
+		field_it = list_next(&field->ritems_link, &report_des->report_items);
 	}
 
-	while (field_it != &report_des->report_items.head) {
+	while (field_it != NULL) {
 		field = list_get_instance(field_it, usb_hid_report_field_t,
 		    ritems_link);
 
@@ -513,7 +513,7 @@ usb_hid_report_field_t *usb_hid_report_get_sibling(usb_hid_report_t *report,
 			}
 			usb_hid_report_remove_last_item(field->collection_path);
 		}
-		field_it = field_it->next;
+		field_it = list_next(field_it, &report_des->report_items);
 	}
 
 	return NULL;
@@ -546,13 +546,14 @@ uint8_t usb_hid_get_next_report_id(usb_hid_report_t *report, uint8_t report_id,
 		if (report_des == NULL) {
 			return 0;
 		} else {
-			report_it = report_des->reports_link.next;
+			report_it = list_next(&report_des->reports_link,
+			    &report->reports);
 		}
 	} else {
-		report_it = report->reports.head.next;
+		report_it = list_first(&report->reports);
 	}
 
-	while (report_it != &report->reports.head) {
+	while (report_it != NULL) {
 		report_des = list_get_instance(report_it,
 		    usb_hid_report_description_t, reports_link);
 
@@ -560,7 +561,7 @@ uint8_t usb_hid_get_next_report_id(usb_hid_report_t *report, uint8_t report_id,
 			return report_des->report_id;
 		}
 
-		report_it = report_it->next;
+		report_it = list_next(report_it, &report->reports);
 	}
 
 	return 0;

--- a/uspace/lib/usbhid/src/hidpath.c
+++ b/uspace/lib/usbhid/src/hidpath.c
@@ -249,11 +249,10 @@ int usb_hid_report_compare_usage_path(usb_hid_report_path_t *report_path,
 		/*
 		 * Path is prefix of the report_path
 		 */
-		report_link = report_path->items.head.next;
-		path_link = path->items.head.next;
+		report_link = list_first(&report_path->items);
+		path_link = list_first(&path->items);
 
-		while ((report_link != &report_path->items.head) &&
-		    (path_link != &path->items.head)) {
+		while (report_link != NULL && path_link != NULL) {
 
 			report_item = list_get_instance(report_link,
 			    usb_hid_report_usage_path_t, rpath_items_link);
@@ -267,15 +266,14 @@ int usb_hid_report_compare_usage_path(usb_hid_report_path_t *report_path,
 			    path_item->usage))) {
 				return 1;
 			} else {
-				report_link = report_link->next;
-				path_link = path_link->next;
+				report_link = list_next(report_link, &report_path->items);
+				path_link = list_next(path_link, &path->items);
 			}
 		}
 
 		if ((((flags & USB_HID_PATH_COMPARE_BEGIN) != 0) &&
-		    (path_link == &path->items.head)) ||
-		    ((report_link == &report_path->items.head) &&
-		    (path_link == &path->items.head))) {
+		    (path_link == NULL)) ||
+		    (report_link == NULL && path_link == NULL)) {
 			return 0;
 		} else {
 			return 1;
@@ -286,15 +284,14 @@ int usb_hid_report_compare_usage_path(usb_hid_report_path_t *report_path,
 		/*
 		 * Path is suffix of report_path
 		 */
-		report_link = report_path->items.head.prev;
-		path_link = path->items.head.prev;
+		report_link = list_last(&report_path->items);
+		path_link = list_last(&path->items);
 
 		if (list_empty(&path->items)) {
 			return 0;
 		}
 
-		while ((report_link != &report_path->items.head) &&
-		    (path_link != &path->items.head)) {
+		while (report_link != NULL && path_link != NULL) {
 			report_item = list_get_instance(report_link,
 			    usb_hid_report_usage_path_t, rpath_items_link);
 
@@ -307,12 +304,12 @@ int usb_hid_report_compare_usage_path(usb_hid_report_path_t *report_path,
 			    path_item->usage))) {
 				return 1;
 			} else {
-				report_link = report_link->prev;
-				path_link = path_link->prev;
+				report_link = list_prev(report_link, &report_path->items);
+				path_link = list_prev(path_link, &path->items);
 			}
 		}
 
-		if (path_link == &path->items.head) {
+		if (path_link == NULL) {
 			return 0;
 		} else {
 			return 1;

--- a/uspace/srv/devman/driver.c
+++ b/uspace/srv/devman/driver.c
@@ -434,14 +434,14 @@ static void pass_devices_to_driver(driver_t *driver, dev_tree_t *tree)
 	 * Go through devices list as long as there is some device
 	 * that has not been passed to the driver.
 	 */
-	link = driver->devices.head.next;
-	while (link != &driver->devices.head) {
+	link = list_first(&driver->devices);
+	while (link != NULL) {
 		dev = list_get_instance(link, dev_node_t, driver_devices);
 		fibril_rwlock_write_lock(&tree->rwlock);
 
 		if (dev->passed_to_driver) {
 			fibril_rwlock_write_unlock(&tree->rwlock);
-			link = link->next;
+			link = list_next(link, &driver->devices);
 			continue;
 		}
 
@@ -483,7 +483,7 @@ static void pass_devices_to_driver(driver_t *driver, dev_tree_t *tree)
 		/*
 		 * Restart the cycle to go through all devices again.
 		 */
-		link = driver->devices.head.next;
+		link = list_first(&driver->devices);
 	}
 
 	/*

--- a/uspace/srv/devman/match.c
+++ b/uspace/srv/devman/match.c
@@ -66,35 +66,23 @@ static int compute_match_score(match_id_t *driver, match_id_t *device)
 
 int get_match_score(driver_t *drv, dev_node_t *dev)
 {
-	link_t *drv_head = &drv->match_ids.ids.head;
-	link_t *dev_head = &dev->pfun->match_ids.ids.head;
+	list_t *drv_list = &drv->match_ids.ids;
+	list_t *dev_list = &dev->pfun->match_ids.ids;
 
-	if (list_empty(&drv->match_ids.ids) ||
-	    list_empty(&dev->pfun->match_ids.ids)) {
+	if (list_empty(drv_list) || list_empty(dev_list))
 		return 0;
-	}
 
 	/*
 	 * Go through all pairs, return the highest score obtained.
 	 */
 	int highest_score = 0;
 
-	link_t *drv_link = drv->match_ids.ids.head.next;
-	while (drv_link != drv_head) {
-		link_t *dev_link = dev_head->next;
-		while (dev_link != dev_head) {
-			match_id_t *drv_id = list_get_instance(drv_link, match_id_t, link);
-			match_id_t *dev_id = list_get_instance(dev_link, match_id_t, link);
-
+	list_foreach(*drv_list, link, match_id_t, drv_id) {
+		list_foreach(*dev_list, link, match_id_t, dev_id) {
 			int score = compute_match_score(drv_id, dev_id);
-			if (score > highest_score) {
+			if (score > highest_score)
 				highest_score = score;
-			}
-
-			dev_link = dev_link->next;
 		}
-
-		drv_link = drv_link->next;
 	}
 
 	return highest_score;

--- a/uspace/srv/fs/exfat/exfat_idx.c
+++ b/uspace/srv/fs/exfat/exfat_idx.c
@@ -283,22 +283,22 @@ static void exfat_index_free(service_id_t service_id, fs_index_t index)
 		 */
 		link_t *lnk;
 		freed_t *n;
-		for (lnk = u->freed_list.head.next; lnk != &u->freed_list.head;
-		    lnk = lnk->next) {
+		for (lnk = list_first(&u->freed_list); lnk != NULL;
+		    lnk = list_next(lnk, &u->freed_list)) {
 			freed_t *f = list_get_instance(lnk, freed_t, link);
 			if (f->first == index + 1) {
 				f->first--;
-				if (lnk->prev != &u->freed_list.head)
-					try_coalesce_intervals(lnk->prev, lnk,
-					    lnk);
+				link_t *prev = list_prev(lnk, &u->freed_list);
+				if (prev)
+					try_coalesce_intervals(prev, lnk, lnk);
 				fibril_mutex_unlock(&unused_lock);
 				return;
 			}
 			if (f->last == index - 1) {
 				f->last++;
-				if (lnk->next != &u->freed_list.head)
-					try_coalesce_intervals(lnk, lnk->next,
-					    lnk);
+				link_t *next = list_next(lnk, &u->freed_list);
+				if (next)
+					try_coalesce_intervals(lnk, next, lnk);
 				fibril_mutex_unlock(&unused_lock);
 				return;
 			}

--- a/uspace/srv/fs/fat/fat_idx.c
+++ b/uspace/srv/fs/fat/fat_idx.c
@@ -283,22 +283,22 @@ static void fat_index_free(service_id_t service_id, fs_index_t index)
 		 */
 		link_t *lnk;
 		freed_t *n;
-		for (lnk = u->freed_list.head.next; lnk != &u->freed_list.head;
-		    lnk = lnk->next) {
+		for (lnk = list_first(&u->freed_list); lnk != NULL;
+		    lnk = list_next(lnk, &u->freed_list)) {
 			freed_t *f = list_get_instance(lnk, freed_t, link);
 			if (f->first == index + 1) {
 				f->first--;
-				if (lnk->prev != &u->freed_list.head)
-					try_coalesce_intervals(lnk->prev, lnk,
-					    lnk);
+				link_t *prev = list_prev(lnk, &u->freed_list);
+				if (prev)
+					try_coalesce_intervals(prev, lnk, lnk);
 				fibril_mutex_unlock(&unused_lock);
 				return;
 			}
 			if (f->last == index - 1) {
 				f->last++;
-				if (lnk->next != &u->freed_list.head)
-					try_coalesce_intervals(lnk, lnk->next,
-					    lnk);
+				link_t *next = list_next(lnk, &u->freed_list);
+				if (next)
+					try_coalesce_intervals(lnk, next, lnk);
 				fibril_mutex_unlock(&unused_lock);
 				return;
 			}

--- a/uspace/srv/hid/compositor/compositor.c
+++ b/uspace/srv/hid/compositor/compositor.c
@@ -426,17 +426,14 @@ static void comp_damage(sysarg_t x_dmg_glob, sysarg_t y_dmg_glob,
 			drawctx_set_source(&context, &source);
 
 			/* For each window. */
-			for (link_t *link = window_list.head.prev;
-			    link != &window_list.head; link = link->prev) {
-
+			list_foreach_rev(window_list, link, window_t, win) {
 				/*
 				 * Determine what part of the window intersects with the
 				 * updated area of the current viewport.
 				 */
-				window_t *win = list_get_instance(link, window_t, link);
-				if (!win->surface) {
+				if (!win->surface)
 					continue;
-				}
+
 				sysarg_t x_dmg_win, y_dmg_win, w_dmg_win, h_dmg_win;
 				surface_get_resolution(win->surface, &w_dmg_win, &h_dmg_win);
 				comp_coord_bounding_rect(0, 0, w_dmg_win, h_dmg_win, win->transform,

--- a/uspace/srv/net/tcp/ncsim.c
+++ b/uspace/srv/net/tcp/ncsim.c
@@ -107,9 +107,7 @@ void tcp_ncsim_bounce_seg(inet_ep2_t *epp, tcp_segment_t *seg)
 
 		sqe->delay -= old_qe->delay;
 
-		link = link->next;
-		if (link == &sim_queue.head)
-			link = NULL;
+		link = list_next(link, &sim_queue);
 	}
 
 	if (link != NULL)

--- a/uspace/srv/net/tcp/tqueue.c
+++ b/uspace/srv/net/tcp/tqueue.c
@@ -244,16 +244,10 @@ void tcp_tqueue_new_data(tcp_conn_t *conn)
  */
 void tcp_tqueue_ack_received(tcp_conn_t *conn)
 {
-	link_t *cur, *next;
-
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "%s: tcp_tqueue_ack_received(%p)", conn->name,
 	    conn);
 
-	cur = conn->retransmit.list.head.next;
-
-	while (cur != &conn->retransmit.list.head) {
-		next = cur->next;
-
+	list_foreach_safe(conn->retransmit.list, cur, next) {
 		tcp_tqueue_entry_t *tqe = list_get_instance(cur,
 		    tcp_tqueue_entry_t, link);
 
@@ -276,8 +270,6 @@ void tcp_tqueue_ack_received(tcp_conn_t *conn)
 			/* Reset retransmission timer */
 			tcp_tqueue_timer_set(conn);
 		}
-
-		cur = next;
 	}
 
 	/* Clear retransmission timer if the queue is empty. */


### PR DESCRIPTION
Use existing constructs from <adt/list.h> instead.

---

Probably needs to be reviewed a few more times.

Apart from making better use of the existing abstraction, this could also allow possibly changing some painful aspects of the lists, in particular their self-referential initialization. This is a personal opinion, but I feel like they should work properly with just zero initialization. Either way, avoiding direct use of member pointers makes it possible to experiment with alternatives.