### PR TITLE
Change the meaning of `counter` in fibril mutex

### DIFF
--- a/uspace/lib/c/include/fibril_synch.h
+++ b/uspace/lib/c/include/fibril_synch.h
@@ -43,7 +43,7 @@
 
 typedef struct {
 	fibril_owner_info_t oi;  /**< Keep this the first thing. */
-	int counter;
+	int counter;  /**< # of fibrils currently waiting for or running in the critical section. */
 	list_t waiters;
 } fibril_mutex_t;
 
@@ -52,7 +52,7 @@ typedef struct {
 		.oi = { \
 			.owned_by = NULL \
 		}, \
-		.counter = 1, \
+		.counter = 0, \
 		.waiters = LIST_INITIALIZER((name).waiters), \
 	}
 


### PR DESCRIPTION
Previously analogous to semaphore tokens, initially 1 and
counting downward into negative numbers.

Now the number of fibrils currently accessing or waiting for access
to the critical section. Initially 0 (unlocked mutex), and counting
up. Never negative when used correctly. Also consistent with
readers/writers counts in rwlock.

This way is IMO easier to understand.