### PR TITLE
Turn some function-like macros into functions

### DIFF
--- a/abi/include/abi/cap.h
+++ b/abi/include/abi/cap.h
@@ -35,10 +35,10 @@
 #ifndef ABI_CAP_H_
 #define ABI_CAP_H_
 
-#define CAP_NIL  0
+#include <stdbool.h>
+#include <stdint.h>
 
-#define CAP_HANDLE_VALID(handle)  ((handle) != CAP_NIL)
-#define CAP_HANDLE_RAW(handle)    ((intptr_t) (handle))
+#define CAP_NIL  0
 
 typedef void *cap_handle_t;
 
@@ -53,6 +53,16 @@ typedef struct {
 
 typedef struct {
 } *cap_waitq_handle_t;
+
+static inline bool cap_handle_valid(cap_handle_t handle)
+{
+	return handle != CAP_NIL;
+}
+
+static inline intptr_t cap_handle_raw(cap_handle_t handle)
+{
+	return (intptr_t) handle;
+}
 
 #endif
 

--- a/abi/include/abi/ipc/ipc.h
+++ b/abi/include/abi/ipc/ipc.h
@@ -35,8 +35,10 @@
 #ifndef ABI_IPC_IPC_H_
 #define ABI_IPC_IPC_H_
 
+#include <stdint.h>
 #include <abi/proc/task.h>
 #include <abi/cap.h>
+#include <_bits/errno.h>
 
 /** Length of data being transferred with IPC call
  *
@@ -70,24 +72,6 @@
  * IPC_M_DATA_READ requests.
  */
 #define DATA_XFER_LIMIT  (64 * 1024)
-
-/* Macros for manipulating calling data */
-#define ipc_set_retval(data, retval)  ((data)->args[0] = (sysarg_t) (retval))
-#define ipc_set_imethod(data, val)    ((data)->args[0] = (val))
-#define ipc_set_arg1(data, val)       ((data)->args[1] = (val))
-#define ipc_set_arg2(data, val)       ((data)->args[2] = (val))
-#define ipc_set_arg3(data, val)       ((data)->args[3] = (val))
-#define ipc_set_arg4(data, val)       ((data)->args[4] = (val))
-#define ipc_set_arg5(data, val)       ((data)->args[5] = (val))
-
-#define ipc_get_imethod(data)  ((data)->args[0])
-#define ipc_get_retval(data)   ((errno_t) (data)->args[0])
-
-#define ipc_get_arg1(data)  ((data)->args[1])
-#define ipc_get_arg2(data)  ((data)->args[2])
-#define ipc_get_arg3(data)  ((data)->args[3])
-#define ipc_get_arg4(data)  ((data)->args[4])
-#define ipc_get_arg5(data)  ((data)->args[5])
 
 /* Forwarding flags. */
 #define IPC_FF_NONE  0
@@ -126,6 +110,77 @@ typedef struct {
 	/** Capability handle */
 	cap_call_handle_t cap_handle;
 } ipc_data_t;
+
+/* Functions for manipulating calling data */
+
+static inline void ipc_set_retval(ipc_data_t *data, errno_t retval)
+{
+	data->args[0] = (sysarg_t) retval;
+}
+
+static inline void ipc_set_imethod(ipc_data_t *data, sysarg_t val)
+{
+	data->args[0] = val;
+}
+
+static inline void ipc_set_arg1(ipc_data_t *data, sysarg_t val)
+{
+	data->args[1] = val;
+}
+
+static inline void ipc_set_arg2(ipc_data_t *data, sysarg_t val)
+{
+	data->args[2] = val;
+}
+
+static inline void ipc_set_arg3(ipc_data_t *data, sysarg_t val)
+{
+	data->args[3] = val;
+}
+
+static inline void ipc_set_arg4(ipc_data_t *data, sysarg_t val)
+{
+	data->args[4] = val;
+}
+
+static inline void ipc_set_arg5(ipc_data_t *data, sysarg_t val)
+{
+	data->args[5] = val;
+}
+
+static inline sysarg_t ipc_get_imethod(ipc_data_t *data)
+{
+	return data->args[0];
+}
+static inline errno_t ipc_get_retval(ipc_data_t *data)
+{
+	return (errno_t) data->args[0];
+}
+
+static inline sysarg_t ipc_get_arg1(ipc_data_t *data)
+{
+	return data->args[1];
+}
+
+static inline sysarg_t ipc_get_arg2(ipc_data_t *data)
+{
+	return data->args[2];
+}
+
+static inline sysarg_t ipc_get_arg3(ipc_data_t *data)
+{
+	return data->args[3];
+}
+
+static inline sysarg_t ipc_get_arg4(ipc_data_t *data)
+{
+	return data->args[4];
+}
+
+static inline sysarg_t ipc_get_arg5(ipc_data_t *data)
+{
+	return data->args[5];
+}
 
 #endif
 

--- a/abi/include/abi/ipc/ipc.h
+++ b/abi/include/abi/ipc/ipc.h
@@ -72,22 +72,22 @@
 #define DATA_XFER_LIMIT  (64 * 1024)
 
 /* Macros for manipulating calling data */
-#define IPC_SET_RETVAL(data, retval)  ((data)->args[0] = (sysarg_t) (retval))
-#define IPC_SET_IMETHOD(data, val)    ((data)->args[0] = (val))
-#define IPC_SET_ARG1(data, val)       ((data)->args[1] = (val))
-#define IPC_SET_ARG2(data, val)       ((data)->args[2] = (val))
-#define IPC_SET_ARG3(data, val)       ((data)->args[3] = (val))
-#define IPC_SET_ARG4(data, val)       ((data)->args[4] = (val))
-#define IPC_SET_ARG5(data, val)       ((data)->args[5] = (val))
+#define ipc_set_retval(data, retval)  ((data)->args[0] = (sysarg_t) (retval))
+#define ipc_set_imethod(data, val)    ((data)->args[0] = (val))
+#define ipc_set_arg1(data, val)       ((data)->args[1] = (val))
+#define ipc_set_arg2(data, val)       ((data)->args[2] = (val))
+#define ipc_set_arg3(data, val)       ((data)->args[3] = (val))
+#define ipc_set_arg4(data, val)       ((data)->args[4] = (val))
+#define ipc_set_arg5(data, val)       ((data)->args[5] = (val))
 
-#define IPC_GET_IMETHOD(data)  ((data)->args[0])
-#define IPC_GET_RETVAL(data)   ((errno_t) (data)->args[0])
+#define ipc_get_imethod(data)  ((data)->args[0])
+#define ipc_get_retval(data)   ((errno_t) (data)->args[0])
 
-#define IPC_GET_ARG1(data)  ((data)->args[1])
-#define IPC_GET_ARG2(data)  ((data)->args[2])
-#define IPC_GET_ARG3(data)  ((data)->args[3])
-#define IPC_GET_ARG4(data)  ((data)->args[4])
-#define IPC_GET_ARG5(data)  ((data)->args[5])
+#define ipc_get_arg1(data)  ((data)->args[1])
+#define ipc_get_arg2(data)  ((data)->args[2])
+#define ipc_get_arg3(data)  ((data)->args[3])
+#define ipc_get_arg4(data)  ((data)->args[4])
+#define ipc_get_arg5(data)  ((data)->args[5])
 
 /* Forwarding flags. */
 #define IPC_FF_NONE  0

--- a/abi/include/abi/ipc/ipc.h
+++ b/abi/include/abi/ipc/ipc.h
@@ -72,22 +72,22 @@
 #define DATA_XFER_LIMIT  (64 * 1024)
 
 /* Macros for manipulating calling data */
-#define IPC_SET_RETVAL(data, retval)  ((data).args[0] = (sysarg_t) (retval))
-#define IPC_SET_IMETHOD(data, val)    ((data).args[0] = (val))
-#define IPC_SET_ARG1(data, val)       ((data).args[1] = (val))
-#define IPC_SET_ARG2(data, val)       ((data).args[2] = (val))
-#define IPC_SET_ARG3(data, val)       ((data).args[3] = (val))
-#define IPC_SET_ARG4(data, val)       ((data).args[4] = (val))
-#define IPC_SET_ARG5(data, val)       ((data).args[5] = (val))
+#define IPC_SET_RETVAL(data, retval)  ((data)->args[0] = (sysarg_t) (retval))
+#define IPC_SET_IMETHOD(data, val)    ((data)->args[0] = (val))
+#define IPC_SET_ARG1(data, val)       ((data)->args[1] = (val))
+#define IPC_SET_ARG2(data, val)       ((data)->args[2] = (val))
+#define IPC_SET_ARG3(data, val)       ((data)->args[3] = (val))
+#define IPC_SET_ARG4(data, val)       ((data)->args[4] = (val))
+#define IPC_SET_ARG5(data, val)       ((data)->args[5] = (val))
 
-#define IPC_GET_IMETHOD(data)  ((data).args[0])
-#define IPC_GET_RETVAL(data)   ((errno_t) (data).args[0])
+#define IPC_GET_IMETHOD(data)  ((data)->args[0])
+#define IPC_GET_RETVAL(data)   ((errno_t) (data)->args[0])
 
-#define IPC_GET_ARG1(data)  ((data).args[1])
-#define IPC_GET_ARG2(data)  ((data).args[2])
-#define IPC_GET_ARG3(data)  ((data).args[3])
-#define IPC_GET_ARG4(data)  ((data).args[4])
-#define IPC_GET_ARG5(data)  ((data).args[5])
+#define IPC_GET_ARG1(data)  ((data)->args[1])
+#define IPC_GET_ARG2(data)  ((data)->args[2])
+#define IPC_GET_ARG3(data)  ((data)->args[3])
+#define IPC_GET_ARG4(data)  ((data)->args[4])
+#define IPC_GET_ARG5(data)  ((data)->args[5])
 
 /* Forwarding flags. */
 #define IPC_FF_NONE  0

--- a/kernel/generic/src/cap/cap.c
+++ b/kernel/generic/src/cap/cap.c
@@ -97,13 +97,13 @@ static slab_cache_t *kobject_cache;
 static size_t caps_hash(const ht_link_t *item)
 {
 	cap_t *cap = hash_table_get_inst(item, cap_t, caps_link);
-	return hash_mix(CAP_HANDLE_RAW(cap->handle));
+	return hash_mix(cap_handle_raw(cap->handle));
 }
 
 static size_t caps_key_hash(void *key)
 {
 	cap_handle_t *handle = (cap_handle_t *) key;
-	return hash_mix(CAP_HANDLE_RAW(*handle));
+	return hash_mix(cap_handle_raw(*handle));
 }
 
 static bool caps_key_equal(void *key, const ht_link_t *item)
@@ -231,8 +231,8 @@ static cap_t *cap_get(task_t *task, cap_handle_t handle, cap_state_t state)
 {
 	assert(mutex_locked(&task->cap_info->lock));
 
-	if ((CAP_HANDLE_RAW(handle) < CAPS_START) ||
-	    (CAP_HANDLE_RAW(handle) > CAPS_LAST))
+	if ((cap_handle_raw(handle) < CAPS_START) ||
+	    (cap_handle_raw(handle) > CAPS_LAST))
 		return NULL;
 	ht_link_t *link = hash_table_find(&task->cap_info->caps, &handle);
 	if (!link)
@@ -382,8 +382,8 @@ void cap_revoke(kobject_t *kobj)
  */
 void cap_free(task_t *task, cap_handle_t handle)
 {
-	assert(CAP_HANDLE_RAW(handle) >= CAPS_START);
-	assert(CAP_HANDLE_RAW(handle) <= CAPS_LAST);
+	assert(cap_handle_raw(handle) >= CAPS_START);
+	assert(cap_handle_raw(handle) <= CAPS_LAST);
 
 	mutex_lock(&task->cap_info->lock);
 	cap_t *cap = cap_get(task, handle, CAP_STATE_ALLOCATED);
@@ -391,7 +391,7 @@ void cap_free(task_t *task, cap_handle_t handle)
 	assert(cap);
 
 	hash_table_remove_item(&task->cap_info->caps, &cap->caps_link);
-	ra_free(task->cap_info->handles, CAP_HANDLE_RAW(handle), 1);
+	ra_free(task->cap_info->handles, cap_handle_raw(handle), 1);
 	slab_free(cap_cache, cap);
 	mutex_unlock(&task->cap_info->lock);
 }

--- a/kernel/generic/src/ipc/event.c
+++ b/kernel/generic/src/ipc/event.c
@@ -152,12 +152,12 @@ static errno_t event_enqueue(event_t *event, bool mask, sysarg_t a1, sysarg_t a2
 				call->flags |= IPC_CALL_NOTIF;
 				call->priv = ++event->counter;
 
-				IPC_SET_IMETHOD(&call->data, event->imethod);
-				IPC_SET_ARG1(&call->data, a1);
-				IPC_SET_ARG2(&call->data, a2);
-				IPC_SET_ARG3(&call->data, a3);
-				IPC_SET_ARG4(&call->data, a4);
-				IPC_SET_ARG5(&call->data, a5);
+				ipc_set_imethod(&call->data, event->imethod);
+				ipc_set_arg1(&call->data, a1);
+				ipc_set_arg2(&call->data, a2);
+				ipc_set_arg3(&call->data, a3);
+				ipc_set_arg4(&call->data, a4);
+				ipc_set_arg5(&call->data, a5);
 
 				call->data.task_id = TASK ? TASK->taskid : 0;
 

--- a/kernel/generic/src/ipc/event.c
+++ b/kernel/generic/src/ipc/event.c
@@ -152,12 +152,12 @@ static errno_t event_enqueue(event_t *event, bool mask, sysarg_t a1, sysarg_t a2
 				call->flags |= IPC_CALL_NOTIF;
 				call->priv = ++event->counter;
 
-				IPC_SET_IMETHOD(call->data, event->imethod);
-				IPC_SET_ARG1(call->data, a1);
-				IPC_SET_ARG2(call->data, a2);
-				IPC_SET_ARG3(call->data, a3);
-				IPC_SET_ARG4(call->data, a4);
-				IPC_SET_ARG5(call->data, a5);
+				IPC_SET_IMETHOD(&call->data, event->imethod);
+				IPC_SET_ARG1(&call->data, a1);
+				IPC_SET_ARG2(&call->data, a2);
+				IPC_SET_ARG3(&call->data, a3);
+				IPC_SET_ARG4(&call->data, a4);
+				IPC_SET_ARG5(&call->data, a5);
 
 				call->data.task_id = TASK ? TASK->taskid : 0;
 

--- a/kernel/generic/src/ipc/ipc.c
+++ b/kernel/generic/src/ipc/ipc.c
@@ -386,7 +386,7 @@ static void _ipc_call_actions_internal(phone_t *phone, call_t *call,
 void ipc_backsend_err(phone_t *phone, call_t *call, errno_t err)
 {
 	_ipc_call_actions_internal(phone, call, false);
-	IPC_SET_RETVAL(call->data, err);
+	IPC_SET_RETVAL(&call->data, err);
 	_ipc_answer_free_call(call, false);
 }
 
@@ -484,7 +484,7 @@ errno_t ipc_phone_hangup(phone_t *phone)
 		phone->hangup_call = NULL;
 		assert(call);
 
-		IPC_SET_IMETHOD(call->data, IPC_M_PHONE_HUNGUP);
+		IPC_SET_IMETHOD(&call->data, IPC_M_PHONE_HUNGUP);
 		call->request_method = IPC_M_PHONE_HUNGUP;
 		call->flags |= IPC_CALL_DISCARD_ANSWER;
 		_ipc_call(phone, box, call, false);
@@ -633,7 +633,7 @@ void ipc_cleanup_call_list(answerbox_t *box, list_t *lst)
 			SYSIPC_OP(request_process, call, box);
 
 		ipc_data_t old = call->data;
-		IPC_SET_RETVAL(call->data, EHANGUP);
+		IPC_SET_RETVAL(&call->data, EHANGUP);
 		answer_preprocess(call, &old);
 		_ipc_answer_free_call(call, true);
 
@@ -689,7 +689,7 @@ restart_phones:
 			phone->hangup_call = NULL;
 			assert(call);
 
-			IPC_SET_IMETHOD(call->data, IPC_M_PHONE_HUNGUP);
+			IPC_SET_IMETHOD(&call->data, IPC_M_PHONE_HUNGUP);
 			call->request_method = IPC_M_PHONE_HUNGUP;
 			call->flags |= IPC_CALL_DISCARD_ANSWER;
 			_ipc_call(phone, box, call, true);
@@ -908,9 +908,9 @@ static void ipc_print_call_list(list_t *list)
 
 		printf("%-8" PRIun " %-6" PRIun " %-6" PRIun " %-6" PRIun
 		    " %-6" PRIun " %-6" PRIun " %-7x",
-		    IPC_GET_IMETHOD(call->data), IPC_GET_ARG1(call->data),
-		    IPC_GET_ARG2(call->data), IPC_GET_ARG3(call->data),
-		    IPC_GET_ARG4(call->data), IPC_GET_ARG5(call->data),
+		    IPC_GET_IMETHOD(&call->data), IPC_GET_ARG1(&call->data),
+		    IPC_GET_ARG2(&call->data), IPC_GET_ARG3(&call->data),
+		    IPC_GET_ARG4(&call->data), IPC_GET_ARG5(&call->data),
 		    call->flags);
 
 		if (call->forget) {

--- a/kernel/generic/src/ipc/ipc.c
+++ b/kernel/generic/src/ipc/ipc.c
@@ -930,7 +930,7 @@ static bool print_task_phone_cb(cap_t *cap, void *arg)
 
 	mutex_lock(&phone->lock);
 	if (phone->state != IPC_PHONE_FREE) {
-		printf("%-11d %7" PRIun " ", (int) CAP_HANDLE_RAW(cap->handle),
+		printf("%-11d %7" PRIun " ", (int) cap_handle_raw(cap->handle),
 		    atomic_load(&phone->active_calls));
 
 		switch (phone->state) {

--- a/kernel/generic/src/ipc/ipc.c
+++ b/kernel/generic/src/ipc/ipc.c
@@ -386,7 +386,7 @@ static void _ipc_call_actions_internal(phone_t *phone, call_t *call,
 void ipc_backsend_err(phone_t *phone, call_t *call, errno_t err)
 {
 	_ipc_call_actions_internal(phone, call, false);
-	IPC_SET_RETVAL(&call->data, err);
+	ipc_set_retval(&call->data, err);
 	_ipc_answer_free_call(call, false);
 }
 
@@ -484,7 +484,7 @@ errno_t ipc_phone_hangup(phone_t *phone)
 		phone->hangup_call = NULL;
 		assert(call);
 
-		IPC_SET_IMETHOD(&call->data, IPC_M_PHONE_HUNGUP);
+		ipc_set_imethod(&call->data, IPC_M_PHONE_HUNGUP);
 		call->request_method = IPC_M_PHONE_HUNGUP;
 		call->flags |= IPC_CALL_DISCARD_ANSWER;
 		_ipc_call(phone, box, call, false);
@@ -633,7 +633,7 @@ void ipc_cleanup_call_list(answerbox_t *box, list_t *lst)
 			SYSIPC_OP(request_process, call, box);
 
 		ipc_data_t old = call->data;
-		IPC_SET_RETVAL(&call->data, EHANGUP);
+		ipc_set_retval(&call->data, EHANGUP);
 		answer_preprocess(call, &old);
 		_ipc_answer_free_call(call, true);
 
@@ -689,7 +689,7 @@ restart_phones:
 			phone->hangup_call = NULL;
 			assert(call);
 
-			IPC_SET_IMETHOD(&call->data, IPC_M_PHONE_HUNGUP);
+			ipc_set_imethod(&call->data, IPC_M_PHONE_HUNGUP);
 			call->request_method = IPC_M_PHONE_HUNGUP;
 			call->flags |= IPC_CALL_DISCARD_ANSWER;
 			_ipc_call(phone, box, call, true);
@@ -908,9 +908,9 @@ static void ipc_print_call_list(list_t *list)
 
 		printf("%-8" PRIun " %-6" PRIun " %-6" PRIun " %-6" PRIun
 		    " %-6" PRIun " %-6" PRIun " %-7x",
-		    IPC_GET_IMETHOD(&call->data), IPC_GET_ARG1(&call->data),
-		    IPC_GET_ARG2(&call->data), IPC_GET_ARG3(&call->data),
-		    IPC_GET_ARG4(&call->data), IPC_GET_ARG5(&call->data),
+		    ipc_get_imethod(&call->data), ipc_get_arg1(&call->data),
+		    ipc_get_arg2(&call->data), ipc_get_arg3(&call->data),
+		    ipc_get_arg4(&call->data), ipc_get_arg5(&call->data),
 		    call->flags);
 
 		if (call->forget) {

--- a/kernel/generic/src/ipc/irq.c
+++ b/kernel/generic/src/ipc/irq.c
@@ -538,12 +538,12 @@ void ipc_irq_top_half_handler(irq_t *irq)
 		call->priv = ++irq->notif_cfg.counter;
 
 		/* Set up args */
-		IPC_SET_IMETHOD(&call->data, irq->notif_cfg.imethod);
-		IPC_SET_ARG1(&call->data, irq->notif_cfg.scratch[1]);
-		IPC_SET_ARG2(&call->data, irq->notif_cfg.scratch[2]);
-		IPC_SET_ARG3(&call->data, irq->notif_cfg.scratch[3]);
-		IPC_SET_ARG4(&call->data, irq->notif_cfg.scratch[4]);
-		IPC_SET_ARG5(&call->data, irq->notif_cfg.scratch[5]);
+		ipc_set_imethod(&call->data, irq->notif_cfg.imethod);
+		ipc_set_arg1(&call->data, irq->notif_cfg.scratch[1]);
+		ipc_set_arg2(&call->data, irq->notif_cfg.scratch[2]);
+		ipc_set_arg3(&call->data, irq->notif_cfg.scratch[3]);
+		ipc_set_arg4(&call->data, irq->notif_cfg.scratch[4]);
+		ipc_set_arg5(&call->data, irq->notif_cfg.scratch[5]);
 
 		send_call(irq, call);
 	}
@@ -575,12 +575,12 @@ void ipc_irq_send_msg(irq_t *irq, sysarg_t a1, sysarg_t a2, sysarg_t a3,
 		/* Put a counter to the message */
 		call->priv = ++irq->notif_cfg.counter;
 
-		IPC_SET_IMETHOD(&call->data, irq->notif_cfg.imethod);
-		IPC_SET_ARG1(&call->data, a1);
-		IPC_SET_ARG2(&call->data, a2);
-		IPC_SET_ARG3(&call->data, a3);
-		IPC_SET_ARG4(&call->data, a4);
-		IPC_SET_ARG5(&call->data, a5);
+		ipc_set_imethod(&call->data, irq->notif_cfg.imethod);
+		ipc_set_arg1(&call->data, a1);
+		ipc_set_arg2(&call->data, a2);
+		ipc_set_arg3(&call->data, a3);
+		ipc_set_arg4(&call->data, a4);
+		ipc_set_arg5(&call->data, a5);
 
 		send_call(irq, call);
 	}

--- a/kernel/generic/src/ipc/irq.c
+++ b/kernel/generic/src/ipc/irq.c
@@ -538,12 +538,12 @@ void ipc_irq_top_half_handler(irq_t *irq)
 		call->priv = ++irq->notif_cfg.counter;
 
 		/* Set up args */
-		IPC_SET_IMETHOD(call->data, irq->notif_cfg.imethod);
-		IPC_SET_ARG1(call->data, irq->notif_cfg.scratch[1]);
-		IPC_SET_ARG2(call->data, irq->notif_cfg.scratch[2]);
-		IPC_SET_ARG3(call->data, irq->notif_cfg.scratch[3]);
-		IPC_SET_ARG4(call->data, irq->notif_cfg.scratch[4]);
-		IPC_SET_ARG5(call->data, irq->notif_cfg.scratch[5]);
+		IPC_SET_IMETHOD(&call->data, irq->notif_cfg.imethod);
+		IPC_SET_ARG1(&call->data, irq->notif_cfg.scratch[1]);
+		IPC_SET_ARG2(&call->data, irq->notif_cfg.scratch[2]);
+		IPC_SET_ARG3(&call->data, irq->notif_cfg.scratch[3]);
+		IPC_SET_ARG4(&call->data, irq->notif_cfg.scratch[4]);
+		IPC_SET_ARG5(&call->data, irq->notif_cfg.scratch[5]);
 
 		send_call(irq, call);
 	}
@@ -575,12 +575,12 @@ void ipc_irq_send_msg(irq_t *irq, sysarg_t a1, sysarg_t a2, sysarg_t a3,
 		/* Put a counter to the message */
 		call->priv = ++irq->notif_cfg.counter;
 
-		IPC_SET_IMETHOD(call->data, irq->notif_cfg.imethod);
-		IPC_SET_ARG1(call->data, a1);
-		IPC_SET_ARG2(call->data, a2);
-		IPC_SET_ARG3(call->data, a3);
-		IPC_SET_ARG4(call->data, a4);
-		IPC_SET_ARG5(call->data, a5);
+		IPC_SET_IMETHOD(&call->data, irq->notif_cfg.imethod);
+		IPC_SET_ARG1(&call->data, a1);
+		IPC_SET_ARG2(&call->data, a2);
+		IPC_SET_ARG3(&call->data, a3);
+		IPC_SET_ARG4(&call->data, a4);
+		IPC_SET_ARG5(&call->data, a5);
 
 		send_call(irq, call);
 	}

--- a/kernel/generic/src/ipc/kbox.c
+++ b/kernel/generic/src/ipc/kbox.c
@@ -120,7 +120,7 @@ static void kbox_proc_phone_hungup(call_t *call, bool *last)
 	}
 
 	LOG("Continue with hangup message.");
-	IPC_SET_RETVAL(&call->data, 0);
+	ipc_set_retval(&call->data, 0);
 	ipc_answer(&TASK->kb.box, call);
 
 	mutex_lock(&TASK->kb.cleanup_lock);
@@ -173,7 +173,7 @@ static void kbox_thread_proc(void *arg)
 		if (call == NULL)
 			continue;  /* Try again. */
 
-		switch (IPC_GET_IMETHOD(&call->data)) {
+		switch (ipc_get_imethod(&call->data)) {
 
 		case IPC_M_DEBUG:
 			/* Handle debug call. */

--- a/kernel/generic/src/ipc/kbox.c
+++ b/kernel/generic/src/ipc/kbox.c
@@ -120,7 +120,7 @@ static void kbox_proc_phone_hungup(call_t *call, bool *last)
 	}
 
 	LOG("Continue with hangup message.");
-	IPC_SET_RETVAL(call->data, 0);
+	IPC_SET_RETVAL(&call->data, 0);
 	ipc_answer(&TASK->kb.box, call);
 
 	mutex_lock(&TASK->kb.cleanup_lock);
@@ -173,7 +173,7 @@ static void kbox_thread_proc(void *arg)
 		if (call == NULL)
 			continue;  /* Try again. */
 
-		switch (IPC_GET_IMETHOD(call->data)) {
+		switch (IPC_GET_IMETHOD(&call->data)) {
 
 		case IPC_M_DEBUG:
 			/* Handle debug call. */

--- a/kernel/generic/src/ipc/ops/conctmeto.c
+++ b/kernel/generic/src/ipc/ops/conctmeto.c
@@ -58,14 +58,14 @@ static errno_t request_preprocess(call_t *call, phone_t *phone)
 	pobj = NULL;
 
 	/* Remember the handle */
-	IPC_SET_ARG5(call->data, (sysarg_t) phandle);
+	IPC_SET_ARG5(&call->data, (sysarg_t) phandle);
 
 	return EOK;
 }
 
 static errno_t request_forget(call_t *call)
 {
-	cap_phone_handle_t phandle = (cap_handle_t) IPC_GET_ARG5(call->data);
+	cap_phone_handle_t phandle = (cap_handle_t) IPC_GET_ARG5(&call->data);
 
 	if (cap_handle_raw(phandle) < 0)
 		return EOK;
@@ -87,13 +87,13 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 	kobject_add_ref(pobj);
 
 	/* Set the recipient-assigned label */
-	pobj->phone->label = IPC_GET_ARG5(answer->data);
+	pobj->phone->label = IPC_GET_ARG5(&answer->data);
 
 	/* Restore phone handle in answer's ARG5 */
-	IPC_SET_ARG5(answer->data, IPC_GET_ARG5(*olddata));
+	IPC_SET_ARG5(&answer->data, IPC_GET_ARG5(olddata));
 
 	/* If the user accepted the call, connect */
-	if (IPC_GET_RETVAL(answer->data) == EOK) {
+	if (IPC_GET_RETVAL(&answer->data) == EOK) {
 		/* Hand over reference from pobj to the answerbox */
 		(void) ipc_phone_connect(pobj->phone, &TASK->answerbox);
 	} else {
@@ -106,12 +106,12 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 
 static errno_t answer_process(call_t *answer)
 {
-	cap_phone_handle_t phandle = (cap_handle_t) IPC_GET_ARG5(answer->data);
+	cap_phone_handle_t phandle = (cap_handle_t) IPC_GET_ARG5(&answer->data);
 	/* Move the reference from answer->priv to pobj */
 	kobject_t *pobj = (kobject_t *) answer->priv;
 	answer->priv = 0;
 
-	if (IPC_GET_RETVAL(answer->data)) {
+	if (IPC_GET_RETVAL(&answer->data)) {
 		if (cap_handle_raw(phandle) >= 0) {
 			/*
 			 * Cleanup the unpublished capability and drop

--- a/kernel/generic/src/ipc/ops/conctmeto.c
+++ b/kernel/generic/src/ipc/ops/conctmeto.c
@@ -67,7 +67,7 @@ static errno_t request_forget(call_t *call)
 {
 	cap_phone_handle_t phandle = (cap_handle_t) IPC_GET_ARG5(call->data);
 
-	if (CAP_HANDLE_RAW(phandle) < 0)
+	if (cap_handle_raw(phandle) < 0)
 		return EOK;
 
 	/* Move reference from call->priv to pobj */
@@ -112,7 +112,7 @@ static errno_t answer_process(call_t *answer)
 	answer->priv = 0;
 
 	if (IPC_GET_RETVAL(answer->data)) {
-		if (CAP_HANDLE_RAW(phandle) >= 0) {
+		if (cap_handle_raw(phandle) >= 0) {
 			/*
 			 * Cleanup the unpublished capability and drop
 			 * phone->kobject's reference.

--- a/kernel/generic/src/ipc/ops/conctmeto.c
+++ b/kernel/generic/src/ipc/ops/conctmeto.c
@@ -58,14 +58,14 @@ static errno_t request_preprocess(call_t *call, phone_t *phone)
 	pobj = NULL;
 
 	/* Remember the handle */
-	IPC_SET_ARG5(&call->data, (sysarg_t) phandle);
+	ipc_set_arg5(&call->data, (sysarg_t) phandle);
 
 	return EOK;
 }
 
 static errno_t request_forget(call_t *call)
 {
-	cap_phone_handle_t phandle = (cap_handle_t) IPC_GET_ARG5(&call->data);
+	cap_phone_handle_t phandle = (cap_handle_t) ipc_get_arg5(&call->data);
 
 	if (cap_handle_raw(phandle) < 0)
 		return EOK;
@@ -87,13 +87,13 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 	kobject_add_ref(pobj);
 
 	/* Set the recipient-assigned label */
-	pobj->phone->label = IPC_GET_ARG5(&answer->data);
+	pobj->phone->label = ipc_get_arg5(&answer->data);
 
 	/* Restore phone handle in answer's ARG5 */
-	IPC_SET_ARG5(&answer->data, IPC_GET_ARG5(olddata));
+	ipc_set_arg5(&answer->data, ipc_get_arg5(olddata));
 
 	/* If the user accepted the call, connect */
-	if (IPC_GET_RETVAL(&answer->data) == EOK) {
+	if (ipc_get_retval(&answer->data) == EOK) {
 		/* Hand over reference from pobj to the answerbox */
 		(void) ipc_phone_connect(pobj->phone, &TASK->answerbox);
 	} else {
@@ -106,12 +106,12 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 
 static errno_t answer_process(call_t *answer)
 {
-	cap_phone_handle_t phandle = (cap_handle_t) IPC_GET_ARG5(&answer->data);
+	cap_phone_handle_t phandle = (cap_handle_t) ipc_get_arg5(&answer->data);
 	/* Move the reference from answer->priv to pobj */
 	kobject_t *pobj = (kobject_t *) answer->priv;
 	answer->priv = 0;
 
-	if (IPC_GET_RETVAL(&answer->data)) {
+	if (ipc_get_retval(&answer->data)) {
 		if (cap_handle_raw(phandle) >= 0) {
 			/*
 			 * Cleanup the unpublished capability and drop

--- a/kernel/generic/src/ipc/ops/concttome.c
+++ b/kernel/generic/src/ipc/ops/concttome.c
@@ -51,7 +51,7 @@ static int request_process(call_t *call, answerbox_t *box)
 		pobj->phone->label = IPC_GET_ARG5(call->data);
 	}
 	call->priv = (sysarg_t) pobj;
-	IPC_SET_ARG5(call->data, CAP_HANDLE_RAW(phandle));
+	IPC_SET_ARG5(call->data, cap_handle_raw(phandle));
 	return 0;
 }
 
@@ -60,7 +60,7 @@ static errno_t answer_cleanup(call_t *answer, ipc_data_t *olddata)
 	cap_phone_handle_t phandle = (cap_handle_t) IPC_GET_ARG5(*olddata);
 	kobject_t *pobj = (kobject_t *) answer->priv;
 
-	if (CAP_HANDLE_VALID(phandle)) {
+	if (cap_handle_valid(phandle)) {
 		kobject_put(pobj);
 		cap_free(TASK, phandle);
 	}
@@ -76,7 +76,7 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 	if (IPC_GET_RETVAL(answer->data) != EOK) {
 		/* The connection was not accepted */
 		answer_cleanup(answer, olddata);
-	} else if (CAP_HANDLE_VALID(phandle)) {
+	} else if (cap_handle_valid(phandle)) {
 		/*
 		 * The connection was accepted
 		 */

--- a/kernel/generic/src/ipc/ops/concttome.c
+++ b/kernel/generic/src/ipc/ops/concttome.c
@@ -48,16 +48,16 @@ static int request_process(call_t *call, answerbox_t *box)
 		/*
 		 * Set the sender-assigned label to the new phone.
 		 */
-		pobj->phone->label = IPC_GET_ARG5(&call->data);
+		pobj->phone->label = ipc_get_arg5(&call->data);
 	}
 	call->priv = (sysarg_t) pobj;
-	IPC_SET_ARG5(&call->data, cap_handle_raw(phandle));
+	ipc_set_arg5(&call->data, cap_handle_raw(phandle));
 	return 0;
 }
 
 static errno_t answer_cleanup(call_t *answer, ipc_data_t *olddata)
 {
-	cap_phone_handle_t phandle = (cap_handle_t) IPC_GET_ARG5(olddata);
+	cap_phone_handle_t phandle = (cap_handle_t) ipc_get_arg5(olddata);
 	kobject_t *pobj = (kobject_t *) answer->priv;
 
 	if (cap_handle_valid(phandle)) {
@@ -70,10 +70,10 @@ static errno_t answer_cleanup(call_t *answer, ipc_data_t *olddata)
 
 static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 {
-	cap_phone_handle_t phandle = (cap_handle_t) IPC_GET_ARG5(olddata);
+	cap_phone_handle_t phandle = (cap_handle_t) ipc_get_arg5(olddata);
 	kobject_t *pobj = (kobject_t *) answer->priv;
 
-	if (IPC_GET_RETVAL(&answer->data) != EOK) {
+	if (ipc_get_retval(&answer->data) != EOK) {
 		/* The connection was not accepted */
 		answer_cleanup(answer, olddata);
 	} else if (cap_handle_valid(phandle)) {
@@ -93,11 +93,11 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 			cap_publish(TASK, phandle, pobj);
 		} else {
 			/* The answerbox is shutting down. */
-			IPC_SET_RETVAL(&answer->data, ENOENT);
+			ipc_set_retval(&answer->data, ENOENT);
 			answer_cleanup(answer, olddata);
 		}
 	} else {
-		IPC_SET_RETVAL(&answer->data, ELIMIT);
+		ipc_set_retval(&answer->data, ELIMIT);
 	}
 
 	return EOK;

--- a/kernel/generic/src/ipc/ops/concttome.c
+++ b/kernel/generic/src/ipc/ops/concttome.c
@@ -48,16 +48,16 @@ static int request_process(call_t *call, answerbox_t *box)
 		/*
 		 * Set the sender-assigned label to the new phone.
 		 */
-		pobj->phone->label = IPC_GET_ARG5(call->data);
+		pobj->phone->label = IPC_GET_ARG5(&call->data);
 	}
 	call->priv = (sysarg_t) pobj;
-	IPC_SET_ARG5(call->data, cap_handle_raw(phandle));
+	IPC_SET_ARG5(&call->data, cap_handle_raw(phandle));
 	return 0;
 }
 
 static errno_t answer_cleanup(call_t *answer, ipc_data_t *olddata)
 {
-	cap_phone_handle_t phandle = (cap_handle_t) IPC_GET_ARG5(*olddata);
+	cap_phone_handle_t phandle = (cap_handle_t) IPC_GET_ARG5(olddata);
 	kobject_t *pobj = (kobject_t *) answer->priv;
 
 	if (cap_handle_valid(phandle)) {
@@ -70,10 +70,10 @@ static errno_t answer_cleanup(call_t *answer, ipc_data_t *olddata)
 
 static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 {
-	cap_phone_handle_t phandle = (cap_handle_t) IPC_GET_ARG5(*olddata);
+	cap_phone_handle_t phandle = (cap_handle_t) IPC_GET_ARG5(olddata);
 	kobject_t *pobj = (kobject_t *) answer->priv;
 
-	if (IPC_GET_RETVAL(answer->data) != EOK) {
+	if (IPC_GET_RETVAL(&answer->data) != EOK) {
 		/* The connection was not accepted */
 		answer_cleanup(answer, olddata);
 	} else if (cap_handle_valid(phandle)) {
@@ -93,11 +93,11 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 			cap_publish(TASK, phandle, pobj);
 		} else {
 			/* The answerbox is shutting down. */
-			IPC_SET_RETVAL(answer->data, ENOENT);
+			IPC_SET_RETVAL(&answer->data, ENOENT);
 			answer_cleanup(answer, olddata);
 		}
 	} else {
-		IPC_SET_RETVAL(answer->data, ELIMIT);
+		IPC_SET_RETVAL(&answer->data, ELIMIT);
 	}
 
 	return EOK;

--- a/kernel/generic/src/ipc/ops/dataread.c
+++ b/kernel/generic/src/ipc/ops/dataread.c
@@ -42,13 +42,13 @@
 
 static errno_t request_preprocess(call_t *call, phone_t *phone)
 {
-	size_t size = IPC_GET_ARG2(call->data);
+	size_t size = IPC_GET_ARG2(&call->data);
 
 	if (size > DATA_XFER_LIMIT) {
-		int flags = IPC_GET_ARG3(call->data);
+		int flags = IPC_GET_ARG3(&call->data);
 
 		if (flags & IPC_XF_RESTRICT)
-			IPC_SET_ARG2(call->data, DATA_XFER_LIMIT);
+			IPC_SET_ARG2(&call->data, DATA_XFER_LIMIT);
 		else
 			return ELIMIT;
 	}
@@ -60,29 +60,29 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 {
 	assert(!answer->buffer);
 
-	if (!IPC_GET_RETVAL(answer->data)) {
+	if (!IPC_GET_RETVAL(&answer->data)) {
 		/* The recipient agreed to send data. */
-		uintptr_t src = IPC_GET_ARG1(answer->data);
-		uintptr_t dst = IPC_GET_ARG1(*olddata);
-		size_t max_size = IPC_GET_ARG2(*olddata);
-		size_t size = IPC_GET_ARG2(answer->data);
+		uintptr_t src = IPC_GET_ARG1(&answer->data);
+		uintptr_t dst = IPC_GET_ARG1(olddata);
+		size_t max_size = IPC_GET_ARG2(olddata);
+		size_t size = IPC_GET_ARG2(&answer->data);
 
 		if (size && size <= max_size) {
 			/*
 			 * Copy the destination VA so that this piece of
 			 * information is not lost.
 			 */
-			IPC_SET_ARG1(answer->data, dst);
+			IPC_SET_ARG1(&answer->data, dst);
 
 			answer->buffer = malloc(size);
 			if (!answer->buffer) {
-				IPC_SET_RETVAL(answer->data, ENOMEM);
+				IPC_SET_RETVAL(&answer->data, ENOMEM);
 				return EOK;
 			}
 			errno_t rc = copy_from_uspace(answer->buffer,
 			    (void *) src, size);
 			if (rc) {
-				IPC_SET_RETVAL(answer->data, rc);
+				IPC_SET_RETVAL(&answer->data, rc);
 				/*
 				 * answer->buffer will be cleaned up in
 				 * ipc_call_free().
@@ -90,9 +90,9 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 				return EOK;
 			}
 		} else if (!size) {
-			IPC_SET_RETVAL(answer->data, EOK);
+			IPC_SET_RETVAL(&answer->data, EOK);
 		} else {
-			IPC_SET_RETVAL(answer->data, ELIMIT);
+			IPC_SET_RETVAL(&answer->data, ELIMIT);
 		}
 	}
 
@@ -102,13 +102,13 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 static errno_t answer_process(call_t *answer)
 {
 	if (answer->buffer) {
-		uintptr_t dst = IPC_GET_ARG1(answer->data);
-		size_t size = IPC_GET_ARG2(answer->data);
+		uintptr_t dst = IPC_GET_ARG1(&answer->data);
+		size_t size = IPC_GET_ARG2(&answer->data);
 		errno_t rc;
 
 		rc = copy_to_uspace((void *) dst, answer->buffer, size);
 		if (rc)
-			IPC_SET_RETVAL(answer->data, rc);
+			IPC_SET_RETVAL(&answer->data, rc);
 	}
 
 	return EOK;

--- a/kernel/generic/src/ipc/ops/dataread.c
+++ b/kernel/generic/src/ipc/ops/dataread.c
@@ -42,13 +42,13 @@
 
 static errno_t request_preprocess(call_t *call, phone_t *phone)
 {
-	size_t size = IPC_GET_ARG2(&call->data);
+	size_t size = ipc_get_arg2(&call->data);
 
 	if (size > DATA_XFER_LIMIT) {
-		int flags = IPC_GET_ARG3(&call->data);
+		int flags = ipc_get_arg3(&call->data);
 
 		if (flags & IPC_XF_RESTRICT)
-			IPC_SET_ARG2(&call->data, DATA_XFER_LIMIT);
+			ipc_set_arg2(&call->data, DATA_XFER_LIMIT);
 		else
 			return ELIMIT;
 	}
@@ -60,29 +60,29 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 {
 	assert(!answer->buffer);
 
-	if (!IPC_GET_RETVAL(&answer->data)) {
+	if (!ipc_get_retval(&answer->data)) {
 		/* The recipient agreed to send data. */
-		uintptr_t src = IPC_GET_ARG1(&answer->data);
-		uintptr_t dst = IPC_GET_ARG1(olddata);
-		size_t max_size = IPC_GET_ARG2(olddata);
-		size_t size = IPC_GET_ARG2(&answer->data);
+		uintptr_t src = ipc_get_arg1(&answer->data);
+		uintptr_t dst = ipc_get_arg1(olddata);
+		size_t max_size = ipc_get_arg2(olddata);
+		size_t size = ipc_get_arg2(&answer->data);
 
 		if (size && size <= max_size) {
 			/*
 			 * Copy the destination VA so that this piece of
 			 * information is not lost.
 			 */
-			IPC_SET_ARG1(&answer->data, dst);
+			ipc_set_arg1(&answer->data, dst);
 
 			answer->buffer = malloc(size);
 			if (!answer->buffer) {
-				IPC_SET_RETVAL(&answer->data, ENOMEM);
+				ipc_set_retval(&answer->data, ENOMEM);
 				return EOK;
 			}
 			errno_t rc = copy_from_uspace(answer->buffer,
 			    (void *) src, size);
 			if (rc) {
-				IPC_SET_RETVAL(&answer->data, rc);
+				ipc_set_retval(&answer->data, rc);
 				/*
 				 * answer->buffer will be cleaned up in
 				 * ipc_call_free().
@@ -90,9 +90,9 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 				return EOK;
 			}
 		} else if (!size) {
-			IPC_SET_RETVAL(&answer->data, EOK);
+			ipc_set_retval(&answer->data, EOK);
 		} else {
-			IPC_SET_RETVAL(&answer->data, ELIMIT);
+			ipc_set_retval(&answer->data, ELIMIT);
 		}
 	}
 
@@ -102,13 +102,13 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 static errno_t answer_process(call_t *answer)
 {
 	if (answer->buffer) {
-		uintptr_t dst = IPC_GET_ARG1(&answer->data);
-		size_t size = IPC_GET_ARG2(&answer->data);
+		uintptr_t dst = ipc_get_arg1(&answer->data);
+		size_t size = ipc_get_arg2(&answer->data);
 		errno_t rc;
 
 		rc = copy_to_uspace((void *) dst, answer->buffer, size);
 		if (rc)
-			IPC_SET_RETVAL(&answer->data, rc);
+			ipc_set_retval(&answer->data, rc);
 	}
 
 	return EOK;

--- a/kernel/generic/src/ipc/ops/datawrite.c
+++ b/kernel/generic/src/ipc/ops/datawrite.c
@@ -42,15 +42,15 @@
 
 static errno_t request_preprocess(call_t *call, phone_t *phone)
 {
-	uintptr_t src = IPC_GET_ARG1(call->data);
-	size_t size = IPC_GET_ARG2(call->data);
+	uintptr_t src = IPC_GET_ARG1(&call->data);
+	size_t size = IPC_GET_ARG2(&call->data);
 
 	if (size > DATA_XFER_LIMIT) {
-		int flags = IPC_GET_ARG3(call->data);
+		int flags = IPC_GET_ARG3(&call->data);
 
 		if (flags & IPC_XF_RESTRICT) {
 			size = DATA_XFER_LIMIT;
-			IPC_SET_ARG2(call->data, size);
+			IPC_SET_ARG2(&call->data, size);
 		} else
 			return ELIMIT;
 	}
@@ -74,19 +74,19 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 {
 	assert(answer->buffer);
 
-	if (!IPC_GET_RETVAL(answer->data)) {
+	if (!IPC_GET_RETVAL(&answer->data)) {
 		/* The recipient agreed to receive data. */
-		uintptr_t dst = (uintptr_t)IPC_GET_ARG1(answer->data);
-		size_t size = (size_t)IPC_GET_ARG2(answer->data);
-		size_t max_size = (size_t)IPC_GET_ARG2(*olddata);
+		uintptr_t dst = (uintptr_t)IPC_GET_ARG1(&answer->data);
+		size_t size = (size_t)IPC_GET_ARG2(&answer->data);
+		size_t max_size = (size_t)IPC_GET_ARG2(olddata);
 
 		if (size <= max_size) {
 			errno_t rc = copy_to_uspace((void *) dst,
 			    answer->buffer, size);
 			if (rc)
-				IPC_SET_RETVAL(answer->data, rc);
+				IPC_SET_RETVAL(&answer->data, rc);
 		} else {
-			IPC_SET_RETVAL(answer->data, ELIMIT);
+			IPC_SET_RETVAL(&answer->data, ELIMIT);
 		}
 	}
 

--- a/kernel/generic/src/ipc/ops/datawrite.c
+++ b/kernel/generic/src/ipc/ops/datawrite.c
@@ -42,15 +42,15 @@
 
 static errno_t request_preprocess(call_t *call, phone_t *phone)
 {
-	uintptr_t src = IPC_GET_ARG1(&call->data);
-	size_t size = IPC_GET_ARG2(&call->data);
+	uintptr_t src = ipc_get_arg1(&call->data);
+	size_t size = ipc_get_arg2(&call->data);
 
 	if (size > DATA_XFER_LIMIT) {
-		int flags = IPC_GET_ARG3(&call->data);
+		int flags = ipc_get_arg3(&call->data);
 
 		if (flags & IPC_XF_RESTRICT) {
 			size = DATA_XFER_LIMIT;
-			IPC_SET_ARG2(&call->data, size);
+			ipc_set_arg2(&call->data, size);
 		} else
 			return ELIMIT;
 	}
@@ -74,19 +74,19 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 {
 	assert(answer->buffer);
 
-	if (!IPC_GET_RETVAL(&answer->data)) {
+	if (!ipc_get_retval(&answer->data)) {
 		/* The recipient agreed to receive data. */
-		uintptr_t dst = (uintptr_t)IPC_GET_ARG1(&answer->data);
-		size_t size = (size_t)IPC_GET_ARG2(&answer->data);
-		size_t max_size = (size_t)IPC_GET_ARG2(olddata);
+		uintptr_t dst = (uintptr_t)ipc_get_arg1(&answer->data);
+		size_t size = (size_t)ipc_get_arg2(&answer->data);
+		size_t max_size = (size_t)ipc_get_arg2(olddata);
 
 		if (size <= max_size) {
 			errno_t rc = copy_to_uspace((void *) dst,
 			    answer->buffer, size);
 			if (rc)
-				IPC_SET_RETVAL(&answer->data, rc);
+				ipc_set_retval(&answer->data, rc);
 		} else {
-			IPC_SET_RETVAL(&answer->data, ELIMIT);
+			ipc_set_retval(&answer->data, ELIMIT);
 		}
 	}
 

--- a/kernel/generic/src/ipc/ops/debug.c
+++ b/kernel/generic/src/ipc/ops/debug.c
@@ -46,13 +46,13 @@ static int request_process(call_t *call, answerbox_t *box)
 static errno_t answer_process(call_t *answer)
 {
 	if (answer->buffer) {
-		uintptr_t dst = IPC_GET_ARG1(&answer->data);
-		size_t size = IPC_GET_ARG2(&answer->data);
+		uintptr_t dst = ipc_get_arg1(&answer->data);
+		size_t size = ipc_get_arg2(&answer->data);
 		errno_t rc;
 
 		rc = copy_to_uspace((void *) dst, answer->buffer, size);
 		if (rc)
-			IPC_SET_RETVAL(&answer->data, rc);
+			ipc_set_retval(&answer->data, rc);
 	}
 
 	return EOK;

--- a/kernel/generic/src/ipc/ops/debug.c
+++ b/kernel/generic/src/ipc/ops/debug.c
@@ -46,13 +46,13 @@ static int request_process(call_t *call, answerbox_t *box)
 static errno_t answer_process(call_t *answer)
 {
 	if (answer->buffer) {
-		uintptr_t dst = IPC_GET_ARG1(answer->data);
-		size_t size = IPC_GET_ARG2(answer->data);
+		uintptr_t dst = IPC_GET_ARG1(&answer->data);
+		size_t size = IPC_GET_ARG2(&answer->data);
 		errno_t rc;
 
 		rc = copy_to_uspace((void *) dst, answer->buffer, size);
 		if (rc)
-			IPC_SET_RETVAL(answer->data, rc);
+			IPC_SET_RETVAL(&answer->data, rc);
 	}
 
 	return EOK;

--- a/kernel/generic/src/ipc/ops/pagein.c
+++ b/kernel/generic/src/ipc/ops/pagein.c
@@ -67,13 +67,13 @@ static errno_t pagein_answer_preprocess(call_t *answer, ipc_data_t *olddata)
 	if (!answer->priv)
 		return EOK;
 
-	if (!IPC_GET_RETVAL(answer->data)) {
+	if (!IPC_GET_RETVAL(&answer->data)) {
 
 		pte_t pte;
 		uintptr_t frame;
 
 		page_table_lock(AS, true);
-		bool found = page_mapping_find(AS, IPC_GET_ARG1(answer->data),
+		bool found = page_mapping_find(AS, IPC_GET_ARG1(&answer->data),
 		    false, &pte);
 		if (found & PTE_PRESENT(&pte)) {
 			frame = PTE_GET_FRAME(&pte);
@@ -85,9 +85,9 @@ static errno_t pagein_answer_preprocess(call_t *answer, ipc_data_t *olddata)
 				 */
 				frame_reference_add(ADDR2PFN(frame));
 			}
-			IPC_SET_ARG1(answer->data, frame);
+			IPC_SET_ARG1(&answer->data, frame);
 		} else {
-			IPC_SET_RETVAL(answer->data, ENOENT);
+			IPC_SET_RETVAL(&answer->data, ENOENT);
 		}
 		page_table_unlock(AS, true);
 	}

--- a/kernel/generic/src/ipc/ops/pagein.c
+++ b/kernel/generic/src/ipc/ops/pagein.c
@@ -67,13 +67,13 @@ static errno_t pagein_answer_preprocess(call_t *answer, ipc_data_t *olddata)
 	if (!answer->priv)
 		return EOK;
 
-	if (!IPC_GET_RETVAL(&answer->data)) {
+	if (!ipc_get_retval(&answer->data)) {
 
 		pte_t pte;
 		uintptr_t frame;
 
 		page_table_lock(AS, true);
-		bool found = page_mapping_find(AS, IPC_GET_ARG1(&answer->data),
+		bool found = page_mapping_find(AS, ipc_get_arg1(&answer->data),
 		    false, &pte);
 		if (found & PTE_PRESENT(&pte)) {
 			frame = PTE_GET_FRAME(&pte);
@@ -85,9 +85,9 @@ static errno_t pagein_answer_preprocess(call_t *answer, ipc_data_t *olddata)
 				 */
 				frame_reference_add(ADDR2PFN(frame));
 			}
-			IPC_SET_ARG1(&answer->data, frame);
+			ipc_set_arg1(&answer->data, frame);
 		} else {
-			IPC_SET_RETVAL(&answer->data, ENOENT);
+			ipc_set_retval(&answer->data, ENOENT);
 		}
 		page_table_unlock(AS, true);
 	}

--- a/kernel/generic/src/ipc/ops/sharein.c
+++ b/kernel/generic/src/ipc/ops/sharein.c
@@ -42,17 +42,17 @@
 
 static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 {
-	if (!IPC_GET_RETVAL(answer->data)) {
+	if (!IPC_GET_RETVAL(&answer->data)) {
 		irq_spinlock_lock(&answer->sender->lock, true);
 		as_t *as = answer->sender->as;
 		irq_spinlock_unlock(&answer->sender->lock, true);
 
 		uintptr_t dst_base = (uintptr_t) -1;
-		errno_t rc = as_area_share(AS, IPC_GET_ARG1(answer->data),
-		    IPC_GET_ARG1(*olddata), as, IPC_GET_ARG2(answer->data),
-		    &dst_base, IPC_GET_ARG2(*olddata));
-		IPC_SET_ARG5(answer->data, dst_base);
-		IPC_SET_RETVAL(answer->data, rc);
+		errno_t rc = as_area_share(AS, IPC_GET_ARG1(&answer->data),
+		    IPC_GET_ARG1(olddata), as, IPC_GET_ARG2(&answer->data),
+		    &dst_base, IPC_GET_ARG2(olddata));
+		IPC_SET_ARG5(&answer->data, dst_base);
+		IPC_SET_RETVAL(&answer->data, rc);
 	}
 
 	return EOK;

--- a/kernel/generic/src/ipc/ops/sharein.c
+++ b/kernel/generic/src/ipc/ops/sharein.c
@@ -42,17 +42,17 @@
 
 static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 {
-	if (!IPC_GET_RETVAL(&answer->data)) {
+	if (!ipc_get_retval(&answer->data)) {
 		irq_spinlock_lock(&answer->sender->lock, true);
 		as_t *as = answer->sender->as;
 		irq_spinlock_unlock(&answer->sender->lock, true);
 
 		uintptr_t dst_base = (uintptr_t) -1;
-		errno_t rc = as_area_share(AS, IPC_GET_ARG1(&answer->data),
-		    IPC_GET_ARG1(olddata), as, IPC_GET_ARG2(&answer->data),
-		    &dst_base, IPC_GET_ARG2(olddata));
-		IPC_SET_ARG5(&answer->data, dst_base);
-		IPC_SET_RETVAL(&answer->data, rc);
+		errno_t rc = as_area_share(AS, ipc_get_arg1(&answer->data),
+		    ipc_get_arg1(olddata), as, ipc_get_arg2(&answer->data),
+		    &dst_base, ipc_get_arg2(olddata));
+		ipc_set_arg5(&answer->data, dst_base);
+		ipc_set_retval(&answer->data, rc);
 	}
 
 	return EOK;

--- a/kernel/generic/src/ipc/ops/shareout.c
+++ b/kernel/generic/src/ipc/ops/shareout.c
@@ -43,11 +43,11 @@
 
 static errno_t request_preprocess(call_t *call, phone_t *phone)
 {
-	size_t size = as_area_get_size(IPC_GET_ARG1(call->data));
+	size_t size = as_area_get_size(IPC_GET_ARG1(&call->data));
 
 	if (!size)
 		return EPERM;
-	IPC_SET_ARG2(call->data, size);
+	IPC_SET_ARG2(&call->data, size);
 
 	return EOK;
 }
@@ -56,7 +56,7 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 {
 	errno_t rc = EOK;
 
-	if (!IPC_GET_RETVAL(answer->data)) {
+	if (!IPC_GET_RETVAL(&answer->data)) {
 		/* Accepted, handle as_area receipt */
 
 		irq_spinlock_lock(&answer->sender->lock, true);
@@ -64,16 +64,16 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 		irq_spinlock_unlock(&answer->sender->lock, true);
 
 		uintptr_t dst_base = (uintptr_t) -1;
-		rc = as_area_share(as, IPC_GET_ARG1(*olddata),
-		    IPC_GET_ARG2(*olddata), AS, IPC_GET_ARG3(*olddata),
-		    &dst_base, IPC_GET_ARG1(answer->data));
+		rc = as_area_share(as, IPC_GET_ARG1(olddata),
+		    IPC_GET_ARG2(olddata), AS, IPC_GET_ARG3(olddata),
+		    &dst_base, IPC_GET_ARG1(&answer->data));
 
 		if (rc == EOK) {
-			rc = copy_to_uspace((void *) IPC_GET_ARG2(answer->data),
+			rc = copy_to_uspace((void *) IPC_GET_ARG2(&answer->data),
 			    &dst_base, sizeof(dst_base));
 		}
 
-		IPC_SET_RETVAL(answer->data, rc);
+		IPC_SET_RETVAL(&answer->data, rc);
 	}
 
 	return rc;

--- a/kernel/generic/src/ipc/ops/shareout.c
+++ b/kernel/generic/src/ipc/ops/shareout.c
@@ -43,11 +43,11 @@
 
 static errno_t request_preprocess(call_t *call, phone_t *phone)
 {
-	size_t size = as_area_get_size(IPC_GET_ARG1(&call->data));
+	size_t size = as_area_get_size(ipc_get_arg1(&call->data));
 
 	if (!size)
 		return EPERM;
-	IPC_SET_ARG2(&call->data, size);
+	ipc_set_arg2(&call->data, size);
 
 	return EOK;
 }
@@ -56,7 +56,7 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 {
 	errno_t rc = EOK;
 
-	if (!IPC_GET_RETVAL(&answer->data)) {
+	if (!ipc_get_retval(&answer->data)) {
 		/* Accepted, handle as_area receipt */
 
 		irq_spinlock_lock(&answer->sender->lock, true);
@@ -64,16 +64,16 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 		irq_spinlock_unlock(&answer->sender->lock, true);
 
 		uintptr_t dst_base = (uintptr_t) -1;
-		rc = as_area_share(as, IPC_GET_ARG1(olddata),
-		    IPC_GET_ARG2(olddata), AS, IPC_GET_ARG3(olddata),
-		    &dst_base, IPC_GET_ARG1(&answer->data));
+		rc = as_area_share(as, ipc_get_arg1(olddata),
+		    ipc_get_arg2(olddata), AS, ipc_get_arg3(olddata),
+		    &dst_base, ipc_get_arg1(&answer->data));
 
 		if (rc == EOK) {
-			rc = copy_to_uspace((void *) IPC_GET_ARG2(&answer->data),
+			rc = copy_to_uspace((void *) ipc_get_arg2(&answer->data),
 			    &dst_base, sizeof(dst_base));
 		}
 
-		IPC_SET_RETVAL(&answer->data, rc);
+		ipc_set_retval(&answer->data, rc);
 	}
 
 	return rc;

--- a/kernel/generic/src/ipc/ops/stchngath.c
+++ b/kernel/generic/src/ipc/ops/stchngath.c
@@ -45,7 +45,7 @@ static errno_t request_preprocess(call_t *call, phone_t *phone)
 	task_t *other_task_s;
 
 	kobject_t *sender_obj = kobject_get(TASK,
-	    (cap_handle_t) IPC_GET_ARG5(&call->data), KOBJECT_TYPE_PHONE);
+	    (cap_handle_t) ipc_get_arg5(&call->data), KOBJECT_TYPE_PHONE);
 	if (!sender_obj)
 		return ENOENT;
 
@@ -61,7 +61,7 @@ static errno_t request_preprocess(call_t *call, phone_t *phone)
 	mutex_unlock(&sender_obj->phone->lock);
 
 	/* Remember the third party task hash. */
-	IPC_SET_ARG5(&call->data, (sysarg_t) other_task_s);
+	ipc_set_arg5(&call->data, (sysarg_t) other_task_s);
 
 	kobject_put(sender_obj);
 	return EOK;
@@ -71,46 +71,46 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 {
 	errno_t rc = EOK;
 
-	if (!IPC_GET_RETVAL(&answer->data)) {
+	if (!ipc_get_retval(&answer->data)) {
 		/* The recipient authorized the change of state. */
 		task_t *other_task_s;
 		task_t *other_task_r;
 
 		kobject_t *recipient_obj = kobject_get(TASK,
-		    (cap_handle_t) IPC_GET_ARG1(&answer->data),
+		    (cap_handle_t) ipc_get_arg1(&answer->data),
 		    KOBJECT_TYPE_PHONE);
 		if (!recipient_obj) {
-			IPC_SET_RETVAL(&answer->data, ENOENT);
+			ipc_set_retval(&answer->data, ENOENT);
 			return ENOENT;
 		}
 
 		mutex_lock(&recipient_obj->phone->lock);
 		if (recipient_obj->phone->state != IPC_PHONE_CONNECTED) {
 			mutex_unlock(&recipient_obj->phone->lock);
-			IPC_SET_RETVAL(&answer->data, EINVAL);
+			ipc_set_retval(&answer->data, EINVAL);
 			kobject_put(recipient_obj);
 			return EINVAL;
 		}
 
 		other_task_r = recipient_obj->phone->callee->task;
-		other_task_s = (task_t *) IPC_GET_ARG5(olddata);
+		other_task_s = (task_t *) ipc_get_arg5(olddata);
 
 		/*
 		 * See if both the sender and the recipient meant the
 		 * same third party task.
 		 */
 		if (other_task_r != other_task_s) {
-			IPC_SET_RETVAL(&answer->data, EINVAL);
+			ipc_set_retval(&answer->data, EINVAL);
 			rc = EINVAL;
 		} else {
 			rc = event_task_notify_5(other_task_r,
 			    EVENT_TASK_STATE_CHANGE, false,
-			    IPC_GET_ARG1(olddata),
-			    IPC_GET_ARG2(olddata),
-			    IPC_GET_ARG3(olddata),
+			    ipc_get_arg1(olddata),
+			    ipc_get_arg2(olddata),
+			    ipc_get_arg3(olddata),
 			    LOWER32(olddata->task_id),
 			    UPPER32(olddata->task_id));
-			IPC_SET_RETVAL(&answer->data, rc);
+			ipc_set_retval(&answer->data, rc);
 		}
 
 		mutex_unlock(&recipient_obj->phone->lock);

--- a/kernel/generic/src/ipc/ops/stchngath.c
+++ b/kernel/generic/src/ipc/ops/stchngath.c
@@ -45,7 +45,7 @@ static errno_t request_preprocess(call_t *call, phone_t *phone)
 	task_t *other_task_s;
 
 	kobject_t *sender_obj = kobject_get(TASK,
-	    (cap_handle_t) IPC_GET_ARG5(call->data), KOBJECT_TYPE_PHONE);
+	    (cap_handle_t) IPC_GET_ARG5(&call->data), KOBJECT_TYPE_PHONE);
 	if (!sender_obj)
 		return ENOENT;
 
@@ -61,7 +61,7 @@ static errno_t request_preprocess(call_t *call, phone_t *phone)
 	mutex_unlock(&sender_obj->phone->lock);
 
 	/* Remember the third party task hash. */
-	IPC_SET_ARG5(call->data, (sysarg_t) other_task_s);
+	IPC_SET_ARG5(&call->data, (sysarg_t) other_task_s);
 
 	kobject_put(sender_obj);
 	return EOK;
@@ -71,46 +71,46 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 {
 	errno_t rc = EOK;
 
-	if (!IPC_GET_RETVAL(answer->data)) {
+	if (!IPC_GET_RETVAL(&answer->data)) {
 		/* The recipient authorized the change of state. */
 		task_t *other_task_s;
 		task_t *other_task_r;
 
 		kobject_t *recipient_obj = kobject_get(TASK,
-		    (cap_handle_t) IPC_GET_ARG1(answer->data),
+		    (cap_handle_t) IPC_GET_ARG1(&answer->data),
 		    KOBJECT_TYPE_PHONE);
 		if (!recipient_obj) {
-			IPC_SET_RETVAL(answer->data, ENOENT);
+			IPC_SET_RETVAL(&answer->data, ENOENT);
 			return ENOENT;
 		}
 
 		mutex_lock(&recipient_obj->phone->lock);
 		if (recipient_obj->phone->state != IPC_PHONE_CONNECTED) {
 			mutex_unlock(&recipient_obj->phone->lock);
-			IPC_SET_RETVAL(answer->data, EINVAL);
+			IPC_SET_RETVAL(&answer->data, EINVAL);
 			kobject_put(recipient_obj);
 			return EINVAL;
 		}
 
 		other_task_r = recipient_obj->phone->callee->task;
-		other_task_s = (task_t *) IPC_GET_ARG5(*olddata);
+		other_task_s = (task_t *) IPC_GET_ARG5(olddata);
 
 		/*
 		 * See if both the sender and the recipient meant the
 		 * same third party task.
 		 */
 		if (other_task_r != other_task_s) {
-			IPC_SET_RETVAL(answer->data, EINVAL);
+			IPC_SET_RETVAL(&answer->data, EINVAL);
 			rc = EINVAL;
 		} else {
 			rc = event_task_notify_5(other_task_r,
 			    EVENT_TASK_STATE_CHANGE, false,
-			    IPC_GET_ARG1(*olddata),
-			    IPC_GET_ARG2(*olddata),
-			    IPC_GET_ARG3(*olddata),
+			    IPC_GET_ARG1(olddata),
+			    IPC_GET_ARG2(olddata),
+			    IPC_GET_ARG3(olddata),
 			    LOWER32(olddata->task_id),
 			    UPPER32(olddata->task_id));
-			IPC_SET_RETVAL(answer->data, rc);
+			IPC_SET_RETVAL(&answer->data, rc);
 		}
 
 		mutex_unlock(&recipient_obj->phone->lock);

--- a/kernel/generic/src/ipc/sysipc.c
+++ b/kernel/generic/src/ipc/sysipc.c
@@ -130,7 +130,7 @@ static inline bool method_is_immutable(sysarg_t imethod)
  */
 static inline bool answer_need_old(call_t *call)
 {
-	switch (IPC_GET_IMETHOD(&call->data)) {
+	switch (ipc_get_imethod(&call->data)) {
 	case IPC_M_CONNECT_TO_ME:
 	case IPC_M_CONNECT_ME_TO:
 	case IPC_M_PAGE_IN:
@@ -191,7 +191,7 @@ errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 	}
 	spinlock_unlock(&answer->forget_lock);
 
-	if ((errno_t) IPC_GET_RETVAL(&answer->data) == EHANGUP) {
+	if ((errno_t) ipc_get_retval(&answer->data) == EHANGUP) {
 		phone_t *phone = answer->caller_phone;
 		mutex_lock(&phone->lock);
 		if (phone->state == IPC_PHONE_CONNECTED) {
@@ -222,7 +222,7 @@ errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
  */
 static errno_t request_preprocess(call_t *call, phone_t *phone)
 {
-	call->request_method = IPC_GET_IMETHOD(&call->data);
+	call->request_method = ipc_get_imethod(&call->data);
 	return SYSIPC_OP(request_preprocess, call, phone);
 }
 
@@ -237,9 +237,9 @@ static errno_t request_preprocess(call_t *call, phone_t *phone)
  */
 static void process_answer(call_t *call)
 {
-	if (((errno_t) IPC_GET_RETVAL(&call->data) == EHANGUP) &&
+	if (((errno_t) ipc_get_retval(&call->data) == EHANGUP) &&
 	    (call->flags & IPC_CALL_FORWARDED))
-		IPC_SET_RETVAL(&call->data, EFORWARD);
+		ipc_set_retval(&call->data, EFORWARD);
 
 	SYSIPC_OP(answer_process, call);
 }
@@ -325,7 +325,7 @@ ipc_req_internal(cap_phone_handle_t handle, ipc_data_t *data, sysarg_t priv)
 
 		process_answer(call);
 	} else
-		IPC_SET_RETVAL(&call->data, rc);
+		ipc_set_retval(&call->data, rc);
 
 	memcpy(data->args, call->data.args, sizeof(data->args));
 	kobject_put(call->kobject);
@@ -384,16 +384,16 @@ sys_errno_t sys_ipc_call_async_fast(cap_phone_handle_t handle, sysarg_t imethod,
 		return ENOMEM;
 	}
 
-	IPC_SET_IMETHOD(&call->data, imethod);
-	IPC_SET_ARG1(&call->data, arg1);
-	IPC_SET_ARG2(&call->data, arg2);
-	IPC_SET_ARG3(&call->data, arg3);
+	ipc_set_imethod(&call->data, imethod);
+	ipc_set_arg1(&call->data, arg1);
+	ipc_set_arg2(&call->data, arg2);
+	ipc_set_arg3(&call->data, arg3);
 
 	/*
 	 * To achieve deterministic behavior, zero out arguments that are beyond
 	 * the limits of the fast version.
 	 */
-	IPC_SET_ARG5(&call->data, 0);
+	ipc_set_arg5(&call->data, 0);
 
 	/* Set the user-defined label */
 	call->data.answer_label = label;
@@ -504,7 +504,7 @@ static sys_errno_t sys_ipc_forward_common(cap_call_handle_t chandle,
 		goto error;
 	}
 
-	if (!method_is_forwardable(IPC_GET_IMETHOD(&call->data))) {
+	if (!method_is_forwardable(ipc_get_imethod(&call->data))) {
 		rc = EPERM;
 		goto error;
 	}
@@ -517,35 +517,35 @@ static sys_errno_t sys_ipc_forward_common(cap_call_handle_t chandle,
 	 * means of imethod, arg1, arg2 and arg3.
 	 * If the interface and method is immutable, don't change anything.
 	 */
-	if (!method_is_immutable(IPC_GET_IMETHOD(&call->data))) {
-		if (method_is_system(IPC_GET_IMETHOD(&call->data))) {
-			if (IPC_GET_IMETHOD(&call->data) ==
+	if (!method_is_immutable(ipc_get_imethod(&call->data))) {
+		if (method_is_system(ipc_get_imethod(&call->data))) {
+			if (ipc_get_imethod(&call->data) ==
 			    IPC_M_CONNECT_TO_ME) {
 				kobject_put((kobject_t *) call->priv);
 				call->priv = 0;
 				cap_free(TASK,
-				    (cap_handle_t) IPC_GET_ARG5(&call->data));
+				    (cap_handle_t) ipc_get_arg5(&call->data));
 			}
 
-			IPC_SET_ARG1(&call->data, imethod);
-			IPC_SET_ARG2(&call->data, arg1);
-			IPC_SET_ARG3(&call->data, arg2);
+			ipc_set_arg1(&call->data, imethod);
+			ipc_set_arg2(&call->data, arg1);
+			ipc_set_arg3(&call->data, arg2);
 
 			if (slow)
-				IPC_SET_ARG4(&call->data, arg3);
+				ipc_set_arg4(&call->data, arg3);
 
 			/*
 			 * For system methods we deliberately don't
 			 * overwrite ARG5.
 			 */
 		} else {
-			IPC_SET_IMETHOD(&call->data, imethod);
-			IPC_SET_ARG1(&call->data, arg1);
-			IPC_SET_ARG2(&call->data, arg2);
+			ipc_set_imethod(&call->data, imethod);
+			ipc_set_arg1(&call->data, arg1);
+			ipc_set_arg2(&call->data, arg2);
 			if (slow) {
-				IPC_SET_ARG3(&call->data, arg3);
-				IPC_SET_ARG4(&call->data, arg4);
-				IPC_SET_ARG5(&call->data, arg5);
+				ipc_set_arg3(&call->data, arg3);
+				ipc_set_arg4(&call->data, arg4);
+				ipc_set_arg5(&call->data, arg5);
 			}
 		}
 	}
@@ -562,7 +562,7 @@ static sys_errno_t sys_ipc_forward_common(cap_call_handle_t chandle,
 	return EOK;
 
 error:
-	IPC_SET_RETVAL(&call->data, EFORWARD);
+	ipc_set_retval(&call->data, EFORWARD);
 	(void) answer_preprocess(call, need_old ? &old : NULL);
 	if (after_forward)
 		_ipc_answer_free_call(call, false);
@@ -631,9 +631,9 @@ sys_errno_t sys_ipc_forward_slow(cap_call_handle_t chandle,
 		return (sys_errno_t) rc;
 
 	return sys_ipc_forward_common(chandle, phandle,
-	    IPC_GET_IMETHOD(&newdata), IPC_GET_ARG1(&newdata),
-	    IPC_GET_ARG2(&newdata), IPC_GET_ARG3(&newdata),
-	    IPC_GET_ARG4(&newdata), IPC_GET_ARG5(&newdata), mode, true);
+	    ipc_get_imethod(&newdata), ipc_get_arg1(&newdata),
+	    ipc_get_arg2(&newdata), ipc_get_arg3(&newdata),
+	    ipc_get_arg4(&newdata), ipc_get_arg5(&newdata), mode, true);
 }
 
 /** Answer an IPC call - fast version.
@@ -670,17 +670,17 @@ sys_errno_t sys_ipc_answer_fast(cap_call_handle_t chandle, sysarg_t retval,
 	} else
 		saved = false;
 
-	IPC_SET_RETVAL(&call->data, retval);
-	IPC_SET_ARG1(&call->data, arg1);
-	IPC_SET_ARG2(&call->data, arg2);
-	IPC_SET_ARG3(&call->data, arg3);
-	IPC_SET_ARG4(&call->data, arg4);
+	ipc_set_retval(&call->data, retval);
+	ipc_set_arg1(&call->data, arg1);
+	ipc_set_arg2(&call->data, arg2);
+	ipc_set_arg3(&call->data, arg3);
+	ipc_set_arg4(&call->data, arg4);
 
 	/*
 	 * To achieve deterministic behavior, zero out arguments that are beyond
 	 * the limits of the fast version.
 	 */
-	IPC_SET_ARG5(&call->data, 0);
+	ipc_set_arg5(&call->data, 0);
 	errno_t rc = answer_preprocess(call, saved ? &saved_data : NULL);
 
 	ipc_answer(&TASK->answerbox, call);
@@ -857,7 +857,7 @@ error:
 	} else
 		saved = false;
 
-	IPC_SET_RETVAL(&call->data, EPARTY);
+	ipc_set_retval(&call->data, EPARTY);
 	(void) answer_preprocess(call, saved ? &saved_data : NULL);
 	call->flags |= IPC_CALL_AUTO_REPLY;
 	ipc_answer(&TASK->answerbox, call);

--- a/kernel/generic/src/ipc/sysipc.c
+++ b/kernel/generic/src/ipc/sysipc.c
@@ -130,7 +130,7 @@ static inline bool method_is_immutable(sysarg_t imethod)
  */
 static inline bool answer_need_old(call_t *call)
 {
-	switch (IPC_GET_IMETHOD(call->data)) {
+	switch (IPC_GET_IMETHOD(&call->data)) {
 	case IPC_M_CONNECT_TO_ME:
 	case IPC_M_CONNECT_ME_TO:
 	case IPC_M_PAGE_IN:
@@ -191,7 +191,7 @@ errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 	}
 	spinlock_unlock(&answer->forget_lock);
 
-	if ((errno_t) IPC_GET_RETVAL(answer->data) == EHANGUP) {
+	if ((errno_t) IPC_GET_RETVAL(&answer->data) == EHANGUP) {
 		phone_t *phone = answer->caller_phone;
 		mutex_lock(&phone->lock);
 		if (phone->state == IPC_PHONE_CONNECTED) {
@@ -222,7 +222,7 @@ errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
  */
 static errno_t request_preprocess(call_t *call, phone_t *phone)
 {
-	call->request_method = IPC_GET_IMETHOD(call->data);
+	call->request_method = IPC_GET_IMETHOD(&call->data);
 	return SYSIPC_OP(request_preprocess, call, phone);
 }
 
@@ -237,9 +237,9 @@ static errno_t request_preprocess(call_t *call, phone_t *phone)
  */
 static void process_answer(call_t *call)
 {
-	if (((errno_t) IPC_GET_RETVAL(call->data) == EHANGUP) &&
+	if (((errno_t) IPC_GET_RETVAL(&call->data) == EHANGUP) &&
 	    (call->flags & IPC_CALL_FORWARDED))
-		IPC_SET_RETVAL(call->data, EFORWARD);
+		IPC_SET_RETVAL(&call->data, EFORWARD);
 
 	SYSIPC_OP(answer_process, call);
 }
@@ -325,7 +325,7 @@ ipc_req_internal(cap_phone_handle_t handle, ipc_data_t *data, sysarg_t priv)
 
 		process_answer(call);
 	} else
-		IPC_SET_RETVAL(call->data, rc);
+		IPC_SET_RETVAL(&call->data, rc);
 
 	memcpy(data->args, call->data.args, sizeof(data->args));
 	kobject_put(call->kobject);
@@ -384,16 +384,16 @@ sys_errno_t sys_ipc_call_async_fast(cap_phone_handle_t handle, sysarg_t imethod,
 		return ENOMEM;
 	}
 
-	IPC_SET_IMETHOD(call->data, imethod);
-	IPC_SET_ARG1(call->data, arg1);
-	IPC_SET_ARG2(call->data, arg2);
-	IPC_SET_ARG3(call->data, arg3);
+	IPC_SET_IMETHOD(&call->data, imethod);
+	IPC_SET_ARG1(&call->data, arg1);
+	IPC_SET_ARG2(&call->data, arg2);
+	IPC_SET_ARG3(&call->data, arg3);
 
 	/*
 	 * To achieve deterministic behavior, zero out arguments that are beyond
 	 * the limits of the fast version.
 	 */
-	IPC_SET_ARG5(call->data, 0);
+	IPC_SET_ARG5(&call->data, 0);
 
 	/* Set the user-defined label */
 	call->data.answer_label = label;
@@ -504,7 +504,7 @@ static sys_errno_t sys_ipc_forward_common(cap_call_handle_t chandle,
 		goto error;
 	}
 
-	if (!method_is_forwardable(IPC_GET_IMETHOD(call->data))) {
+	if (!method_is_forwardable(IPC_GET_IMETHOD(&call->data))) {
 		rc = EPERM;
 		goto error;
 	}
@@ -517,35 +517,35 @@ static sys_errno_t sys_ipc_forward_common(cap_call_handle_t chandle,
 	 * means of imethod, arg1, arg2 and arg3.
 	 * If the interface and method is immutable, don't change anything.
 	 */
-	if (!method_is_immutable(IPC_GET_IMETHOD(call->data))) {
-		if (method_is_system(IPC_GET_IMETHOD(call->data))) {
-			if (IPC_GET_IMETHOD(call->data) ==
+	if (!method_is_immutable(IPC_GET_IMETHOD(&call->data))) {
+		if (method_is_system(IPC_GET_IMETHOD(&call->data))) {
+			if (IPC_GET_IMETHOD(&call->data) ==
 			    IPC_M_CONNECT_TO_ME) {
 				kobject_put((kobject_t *) call->priv);
 				call->priv = 0;
 				cap_free(TASK,
-				    (cap_handle_t) IPC_GET_ARG5(call->data));
+				    (cap_handle_t) IPC_GET_ARG5(&call->data));
 			}
 
-			IPC_SET_ARG1(call->data, imethod);
-			IPC_SET_ARG2(call->data, arg1);
-			IPC_SET_ARG3(call->data, arg2);
+			IPC_SET_ARG1(&call->data, imethod);
+			IPC_SET_ARG2(&call->data, arg1);
+			IPC_SET_ARG3(&call->data, arg2);
 
 			if (slow)
-				IPC_SET_ARG4(call->data, arg3);
+				IPC_SET_ARG4(&call->data, arg3);
 
 			/*
 			 * For system methods we deliberately don't
 			 * overwrite ARG5.
 			 */
 		} else {
-			IPC_SET_IMETHOD(call->data, imethod);
-			IPC_SET_ARG1(call->data, arg1);
-			IPC_SET_ARG2(call->data, arg2);
+			IPC_SET_IMETHOD(&call->data, imethod);
+			IPC_SET_ARG1(&call->data, arg1);
+			IPC_SET_ARG2(&call->data, arg2);
 			if (slow) {
-				IPC_SET_ARG3(call->data, arg3);
-				IPC_SET_ARG4(call->data, arg4);
-				IPC_SET_ARG5(call->data, arg5);
+				IPC_SET_ARG3(&call->data, arg3);
+				IPC_SET_ARG4(&call->data, arg4);
+				IPC_SET_ARG5(&call->data, arg5);
 			}
 		}
 	}
@@ -562,7 +562,7 @@ static sys_errno_t sys_ipc_forward_common(cap_call_handle_t chandle,
 	return EOK;
 
 error:
-	IPC_SET_RETVAL(call->data, EFORWARD);
+	IPC_SET_RETVAL(&call->data, EFORWARD);
 	(void) answer_preprocess(call, need_old ? &old : NULL);
 	if (after_forward)
 		_ipc_answer_free_call(call, false);
@@ -631,9 +631,9 @@ sys_errno_t sys_ipc_forward_slow(cap_call_handle_t chandle,
 		return (sys_errno_t) rc;
 
 	return sys_ipc_forward_common(chandle, phandle,
-	    IPC_GET_IMETHOD(newdata), IPC_GET_ARG1(newdata),
-	    IPC_GET_ARG2(newdata), IPC_GET_ARG3(newdata),
-	    IPC_GET_ARG4(newdata), IPC_GET_ARG5(newdata), mode, true);
+	    IPC_GET_IMETHOD(&newdata), IPC_GET_ARG1(&newdata),
+	    IPC_GET_ARG2(&newdata), IPC_GET_ARG3(&newdata),
+	    IPC_GET_ARG4(&newdata), IPC_GET_ARG5(&newdata), mode, true);
 }
 
 /** Answer an IPC call - fast version.
@@ -670,17 +670,17 @@ sys_errno_t sys_ipc_answer_fast(cap_call_handle_t chandle, sysarg_t retval,
 	} else
 		saved = false;
 
-	IPC_SET_RETVAL(call->data, retval);
-	IPC_SET_ARG1(call->data, arg1);
-	IPC_SET_ARG2(call->data, arg2);
-	IPC_SET_ARG3(call->data, arg3);
-	IPC_SET_ARG4(call->data, arg4);
+	IPC_SET_RETVAL(&call->data, retval);
+	IPC_SET_ARG1(&call->data, arg1);
+	IPC_SET_ARG2(&call->data, arg2);
+	IPC_SET_ARG3(&call->data, arg3);
+	IPC_SET_ARG4(&call->data, arg4);
 
 	/*
 	 * To achieve deterministic behavior, zero out arguments that are beyond
 	 * the limits of the fast version.
 	 */
-	IPC_SET_ARG5(call->data, 0);
+	IPC_SET_ARG5(&call->data, 0);
 	errno_t rc = answer_preprocess(call, saved ? &saved_data : NULL);
 
 	ipc_answer(&TASK->answerbox, call);
@@ -857,7 +857,7 @@ error:
 	} else
 		saved = false;
 
-	IPC_SET_RETVAL(call->data, EPARTY);
+	IPC_SET_RETVAL(&call->data, EPARTY);
 	(void) answer_preprocess(call, saved ? &saved_data : NULL);
 	call->flags |= IPC_CALL_AUTO_REPLY;
 	ipc_answer(&TASK->answerbox, call);

--- a/kernel/generic/src/ipc/sysipc.c
+++ b/kernel/generic/src/ipc/sysipc.c
@@ -840,7 +840,7 @@ restart:
 	return EOK;
 
 error:
-	if (CAP_HANDLE_VALID(handle))
+	if (cap_handle_valid(handle))
 		cap_free(TASK, handle);
 
 	/*

--- a/kernel/generic/src/mm/backend_user.c
+++ b/kernel/generic/src/mm/backend_user.c
@@ -118,12 +118,12 @@ int user_page_fault(as_area_t *area, uintptr_t upage, pf_access_t access)
 	as_area_pager_info_t *pager_info = &area->backend_data.pager_info;
 
 	ipc_data_t data = { };
-	IPC_SET_IMETHOD(data, IPC_M_PAGE_IN);
-	IPC_SET_ARG1(data, upage - area->base);
-	IPC_SET_ARG2(data, PAGE_SIZE);
-	IPC_SET_ARG3(data, pager_info->id1);
-	IPC_SET_ARG4(data, pager_info->id2);
-	IPC_SET_ARG5(data, pager_info->id3);
+	IPC_SET_IMETHOD(&data, IPC_M_PAGE_IN);
+	IPC_SET_ARG1(&data, upage - area->base);
+	IPC_SET_ARG2(&data, PAGE_SIZE);
+	IPC_SET_ARG3(&data, pager_info->id1);
+	IPC_SET_ARG4(&data, pager_info->id2);
+	IPC_SET_ARG5(&data, pager_info->id3);
 
 	errno_t rc = ipc_req_internal(pager_info->pager, &data, (sysarg_t) true);
 
@@ -135,7 +135,7 @@ int user_page_fault(as_area_t *area, uintptr_t upage, pf_access_t access)
 		return AS_PF_FAULT;
 	}
 
-	if (IPC_GET_RETVAL(data) != EOK)
+	if (IPC_GET_RETVAL(&data) != EOK)
 		return AS_PF_FAULT;
 
 	/*
@@ -144,7 +144,7 @@ int user_page_fault(as_area_t *area, uintptr_t upage, pf_access_t access)
 	 * incremented (if applicable).
 	 */
 
-	uintptr_t frame = IPC_GET_ARG1(data);
+	uintptr_t frame = IPC_GET_ARG1(&data);
 	page_mapping_insert(AS, upage, frame, as_area_get_flags(area));
 	if (!used_space_insert(&area->used_space, upage, 1))
 		panic("Cannot insert used space.");

--- a/kernel/generic/src/mm/backend_user.c
+++ b/kernel/generic/src/mm/backend_user.c
@@ -118,12 +118,12 @@ int user_page_fault(as_area_t *area, uintptr_t upage, pf_access_t access)
 	as_area_pager_info_t *pager_info = &area->backend_data.pager_info;
 
 	ipc_data_t data = { };
-	IPC_SET_IMETHOD(&data, IPC_M_PAGE_IN);
-	IPC_SET_ARG1(&data, upage - area->base);
-	IPC_SET_ARG2(&data, PAGE_SIZE);
-	IPC_SET_ARG3(&data, pager_info->id1);
-	IPC_SET_ARG4(&data, pager_info->id2);
-	IPC_SET_ARG5(&data, pager_info->id3);
+	ipc_set_imethod(&data, IPC_M_PAGE_IN);
+	ipc_set_arg1(&data, upage - area->base);
+	ipc_set_arg2(&data, PAGE_SIZE);
+	ipc_set_arg3(&data, pager_info->id1);
+	ipc_set_arg4(&data, pager_info->id2);
+	ipc_set_arg5(&data, pager_info->id3);
 
 	errno_t rc = ipc_req_internal(pager_info->pager, &data, (sysarg_t) true);
 
@@ -135,7 +135,7 @@ int user_page_fault(as_area_t *area, uintptr_t upage, pf_access_t access)
 		return AS_PF_FAULT;
 	}
 
-	if (IPC_GET_RETVAL(&data) != EOK)
+	if (ipc_get_retval(&data) != EOK)
 		return AS_PF_FAULT;
 
 	/*
@@ -144,7 +144,7 @@ int user_page_fault(as_area_t *area, uintptr_t upage, pf_access_t access)
 	 * incremented (if applicable).
 	 */
 
-	uintptr_t frame = IPC_GET_ARG1(&data);
+	uintptr_t frame = ipc_get_arg1(&data);
 	page_mapping_insert(AS, upage, frame, as_area_get_flags(area));
 	if (!used_space_insert(&area->used_space, upage, 1))
 		panic("Cannot insert used space.");

--- a/kernel/generic/src/udebug/udebug.c
+++ b/kernel/generic/src/udebug/udebug.c
@@ -140,7 +140,7 @@ void udebug_stoppable_begin(void)
 		TASK->udebug.dt_state = UDEBUG_TS_ACTIVE;
 		TASK->udebug.begin_call = NULL;
 
-		IPC_SET_RETVAL(&db_call->data, 0);
+		ipc_set_retval(&db_call->data, 0);
 		ipc_answer(&TASK->answerbox, db_call);
 	} else if (TASK->udebug.dt_state == UDEBUG_TS_ACTIVE) {
 		/*
@@ -159,8 +159,8 @@ void udebug_stoppable_begin(void)
 			THREAD->udebug.go_call = NULL;
 			assert(go_call);
 
-			IPC_SET_RETVAL(&go_call->data, 0);
-			IPC_SET_ARG1(&go_call->data, UDEBUG_EVENT_STOP);
+			ipc_set_retval(&go_call->data, 0);
+			ipc_set_arg1(&go_call->data, UDEBUG_EVENT_STOP);
 
 			THREAD->udebug.cur_event = UDEBUG_EVENT_STOP;
 			ipc_answer(&TASK->answerbox, go_call);
@@ -242,10 +242,10 @@ void udebug_syscall_event(sysarg_t a1, sysarg_t a2, sysarg_t a3,
 	call_t *call = THREAD->udebug.go_call;
 	THREAD->udebug.go_call = NULL;
 
-	IPC_SET_RETVAL(&call->data, 0);
-	IPC_SET_ARG1(&call->data, etype);
-	IPC_SET_ARG2(&call->data, id);
-	IPC_SET_ARG3(&call->data, rc);
+	ipc_set_retval(&call->data, 0);
+	ipc_set_arg1(&call->data, etype);
+	ipc_set_arg2(&call->data, id);
+	ipc_set_arg3(&call->data, rc);
 
 	THREAD->udebug.syscall_args[0] = a1;
 	THREAD->udebug.syscall_args[1] = a2;
@@ -313,9 +313,9 @@ void udebug_thread_b_event_attach(struct thread *thread, struct task *task)
 	call_t *call = THREAD->udebug.go_call;
 
 	THREAD->udebug.go_call = NULL;
-	IPC_SET_RETVAL(&call->data, 0);
-	IPC_SET_ARG1(&call->data, UDEBUG_EVENT_THREAD_B);
-	IPC_SET_ARG2(&call->data, (sysarg_t) thread);
+	ipc_set_retval(&call->data, 0);
+	ipc_set_arg1(&call->data, UDEBUG_EVENT_THREAD_B);
+	ipc_set_arg2(&call->data, (sysarg_t) thread);
 
 	/*
 	 * Make sure udebug.go is false when going to sleep
@@ -364,8 +364,8 @@ void udebug_thread_e_event(void)
 	call_t *call = THREAD->udebug.go_call;
 
 	THREAD->udebug.go_call = NULL;
-	IPC_SET_RETVAL(&call->data, 0);
-	IPC_SET_ARG1(&call->data, UDEBUG_EVENT_THREAD_E);
+	ipc_set_retval(&call->data, 0);
+	ipc_set_arg1(&call->data, UDEBUG_EVENT_THREAD_E);
 
 	/* Prevent any further debug activity in thread. */
 	THREAD->udebug.active = false;
@@ -427,8 +427,8 @@ errno_t udebug_task_cleanup(struct task *task)
 				/* Answer GO call */
 				LOG("Answer GO call with EVENT_FINISHED.");
 
-				IPC_SET_RETVAL(&thread->udebug.go_call->data, 0);
-				IPC_SET_ARG1(&thread->udebug.go_call->data,
+				ipc_set_retval(&thread->udebug.go_call->data, 0);
+				ipc_set_arg1(&thread->udebug.go_call->data,
 				    UDEBUG_EVENT_FINISHED);
 
 				ipc_answer(&task->answerbox, thread->udebug.go_call);

--- a/kernel/generic/src/udebug/udebug.c
+++ b/kernel/generic/src/udebug/udebug.c
@@ -140,7 +140,7 @@ void udebug_stoppable_begin(void)
 		TASK->udebug.dt_state = UDEBUG_TS_ACTIVE;
 		TASK->udebug.begin_call = NULL;
 
-		IPC_SET_RETVAL(db_call->data, 0);
+		IPC_SET_RETVAL(&db_call->data, 0);
 		ipc_answer(&TASK->answerbox, db_call);
 	} else if (TASK->udebug.dt_state == UDEBUG_TS_ACTIVE) {
 		/*
@@ -159,8 +159,8 @@ void udebug_stoppable_begin(void)
 			THREAD->udebug.go_call = NULL;
 			assert(go_call);
 
-			IPC_SET_RETVAL(go_call->data, 0);
-			IPC_SET_ARG1(go_call->data, UDEBUG_EVENT_STOP);
+			IPC_SET_RETVAL(&go_call->data, 0);
+			IPC_SET_ARG1(&go_call->data, UDEBUG_EVENT_STOP);
 
 			THREAD->udebug.cur_event = UDEBUG_EVENT_STOP;
 			ipc_answer(&TASK->answerbox, go_call);
@@ -242,10 +242,10 @@ void udebug_syscall_event(sysarg_t a1, sysarg_t a2, sysarg_t a3,
 	call_t *call = THREAD->udebug.go_call;
 	THREAD->udebug.go_call = NULL;
 
-	IPC_SET_RETVAL(call->data, 0);
-	IPC_SET_ARG1(call->data, etype);
-	IPC_SET_ARG2(call->data, id);
-	IPC_SET_ARG3(call->data, rc);
+	IPC_SET_RETVAL(&call->data, 0);
+	IPC_SET_ARG1(&call->data, etype);
+	IPC_SET_ARG2(&call->data, id);
+	IPC_SET_ARG3(&call->data, rc);
 
 	THREAD->udebug.syscall_args[0] = a1;
 	THREAD->udebug.syscall_args[1] = a2;
@@ -313,9 +313,9 @@ void udebug_thread_b_event_attach(struct thread *thread, struct task *task)
 	call_t *call = THREAD->udebug.go_call;
 
 	THREAD->udebug.go_call = NULL;
-	IPC_SET_RETVAL(call->data, 0);
-	IPC_SET_ARG1(call->data, UDEBUG_EVENT_THREAD_B);
-	IPC_SET_ARG2(call->data, (sysarg_t) thread);
+	IPC_SET_RETVAL(&call->data, 0);
+	IPC_SET_ARG1(&call->data, UDEBUG_EVENT_THREAD_B);
+	IPC_SET_ARG2(&call->data, (sysarg_t) thread);
 
 	/*
 	 * Make sure udebug.go is false when going to sleep
@@ -364,8 +364,8 @@ void udebug_thread_e_event(void)
 	call_t *call = THREAD->udebug.go_call;
 
 	THREAD->udebug.go_call = NULL;
-	IPC_SET_RETVAL(call->data, 0);
-	IPC_SET_ARG1(call->data, UDEBUG_EVENT_THREAD_E);
+	IPC_SET_RETVAL(&call->data, 0);
+	IPC_SET_ARG1(&call->data, UDEBUG_EVENT_THREAD_E);
 
 	/* Prevent any further debug activity in thread. */
 	THREAD->udebug.active = false;
@@ -427,8 +427,8 @@ errno_t udebug_task_cleanup(struct task *task)
 				/* Answer GO call */
 				LOG("Answer GO call with EVENT_FINISHED.");
 
-				IPC_SET_RETVAL(thread->udebug.go_call->data, 0);
-				IPC_SET_ARG1(thread->udebug.go_call->data,
+				IPC_SET_RETVAL(&thread->udebug.go_call->data, 0);
+				IPC_SET_ARG1(&thread->udebug.go_call->data,
 				    UDEBUG_EVENT_FINISHED);
 
 				ipc_answer(&task->answerbox, thread->udebug.go_call);

--- a/kernel/generic/src/udebug/udebug_ipc.c
+++ b/kernel/generic/src/udebug/udebug_ipc.c
@@ -52,7 +52,7 @@
 
 errno_t udebug_request_preprocess(call_t *call, phone_t *phone)
 {
-	switch (IPC_GET_ARG1(&call->data)) {
+	switch (ipc_get_arg1(&call->data)) {
 		/* future UDEBUG_M_REGS_WRITE, UDEBUG_M_MEM_WRITE: */
 	default:
 		break;
@@ -75,7 +75,7 @@ static void udebug_receive_begin(call_t *call)
 
 	rc = udebug_begin(call, &active);
 	if (rc != EOK) {
-		IPC_SET_RETVAL(&call->data, rc);
+		ipc_set_retval(&call->data, rc);
 		ipc_answer(&TASK->kb.box, call);
 		return;
 	}
@@ -85,7 +85,7 @@ static void udebug_receive_begin(call_t *call)
 	 * send a reply.
 	 */
 	if (active) {
-		IPC_SET_RETVAL(&call->data, EOK);
+		ipc_set_retval(&call->data, EOK);
 		ipc_answer(&TASK->kb.box, call);
 	}
 }
@@ -101,7 +101,7 @@ static void udebug_receive_end(call_t *call)
 
 	rc = udebug_end();
 
-	IPC_SET_RETVAL(&call->data, rc);
+	ipc_set_retval(&call->data, rc);
 	ipc_answer(&TASK->kb.box, call);
 }
 
@@ -115,10 +115,10 @@ static void udebug_receive_set_evmask(call_t *call)
 	errno_t rc;
 	udebug_evmask_t mask;
 
-	mask = IPC_GET_ARG2(&call->data);
+	mask = ipc_get_arg2(&call->data);
 	rc = udebug_set_evmask(mask);
 
-	IPC_SET_RETVAL(&call->data, rc);
+	ipc_set_retval(&call->data, rc);
 	ipc_answer(&TASK->kb.box, call);
 }
 
@@ -132,11 +132,11 @@ static void udebug_receive_go(call_t *call)
 	thread_t *t;
 	errno_t rc;
 
-	t = (thread_t *)IPC_GET_ARG2(&call->data);
+	t = (thread_t *)ipc_get_arg2(&call->data);
 
 	rc = udebug_go(t, call);
 	if (rc != EOK) {
-		IPC_SET_RETVAL(&call->data, rc);
+		ipc_set_retval(&call->data, rc);
 		ipc_answer(&TASK->kb.box, call);
 		return;
 	}
@@ -152,10 +152,10 @@ static void udebug_receive_stop(call_t *call)
 	thread_t *t;
 	errno_t rc;
 
-	t = (thread_t *)IPC_GET_ARG2(&call->data);
+	t = (thread_t *)ipc_get_arg2(&call->data);
 
 	rc = udebug_stop(t, call);
-	IPC_SET_RETVAL(&call->data, rc);
+	ipc_set_retval(&call->data, rc);
 	ipc_answer(&TASK->kb.box, call);
 }
 
@@ -172,8 +172,8 @@ static void udebug_receive_thread_read(call_t *call)
 	size_t copied, needed;
 	errno_t rc;
 
-	uspace_addr = IPC_GET_ARG2(&call->data);	/* Destination address */
-	buf_size = IPC_GET_ARG3(&call->data);	/* Dest. buffer size */
+	uspace_addr = ipc_get_arg2(&call->data);	/* Destination address */
+	buf_size = ipc_get_arg3(&call->data);	/* Dest. buffer size */
 
 	/*
 	 * Read thread list. Variable n will be filled with actual number
@@ -181,7 +181,7 @@ static void udebug_receive_thread_read(call_t *call)
 	 */
 	rc = udebug_thread_read(&buffer, buf_size, &copied, &needed);
 	if (rc != EOK) {
-		IPC_SET_RETVAL(&call->data, rc);
+		ipc_set_retval(&call->data, rc);
 		ipc_answer(&TASK->kb.box, call);
 		return;
 	}
@@ -190,15 +190,15 @@ static void udebug_receive_thread_read(call_t *call)
 	 * Make use of call->buffer to transfer data to caller's userspace
 	 */
 
-	IPC_SET_RETVAL(&call->data, 0);
+	ipc_set_retval(&call->data, 0);
 	/*
 	 * ARG1=dest, ARG2=size as in IPC_M_DATA_READ so that
 	 * same code in process_answer() can be used
 	 * (no way to distinguish method in answer)
 	 */
-	IPC_SET_ARG1(&call->data, uspace_addr);
-	IPC_SET_ARG2(&call->data, copied);
-	IPC_SET_ARG3(&call->data, needed);
+	ipc_set_arg1(&call->data, uspace_addr);
+	ipc_set_arg2(&call->data, copied);
+	ipc_set_arg3(&call->data, needed);
 	call->buffer = buffer;
 
 	ipc_answer(&TASK->kb.box, call);
@@ -218,8 +218,8 @@ static void udebug_receive_name_read(call_t *call)
 	size_t buf_size;
 	void *data;
 
-	uspace_addr = IPC_GET_ARG2(&call->data);	/* Destination address */
-	buf_size = IPC_GET_ARG3(&call->data);	/* Dest. buffer size */
+	uspace_addr = ipc_get_arg2(&call->data);	/* Destination address */
+	buf_size = ipc_get_arg3(&call->data);	/* Dest. buffer size */
 
 	/*
 	 * Read task name.
@@ -237,16 +237,16 @@ static void udebug_receive_name_read(call_t *call)
 	 * Make use of call->buffer to transfer data to caller's userspace
 	 */
 
-	IPC_SET_RETVAL(&call->data, 0);
+	ipc_set_retval(&call->data, 0);
 	/*
 	 * ARG1=dest, ARG2=size as in IPC_M_DATA_READ so that
 	 * same code in process_answer() can be used
 	 * (no way to distinguish method in answer)
 	 */
-	IPC_SET_ARG1(&call->data, uspace_addr);
-	IPC_SET_ARG2(&call->data, to_copy);
+	ipc_set_arg1(&call->data, uspace_addr);
+	ipc_set_arg2(&call->data, to_copy);
 
-	IPC_SET_ARG3(&call->data, data_size);
+	ipc_set_arg3(&call->data, data_size);
 	call->buffer = data;
 
 	ipc_answer(&TASK->kb.box, call);
@@ -267,15 +267,15 @@ static void udebug_receive_areas_read(call_t *call)
 	size_t buf_size;
 	as_area_info_t *data;
 
-	uspace_addr = IPC_GET_ARG2(&call->data);	/* Destination address */
-	buf_size = IPC_GET_ARG3(&call->data);	/* Dest. buffer size */
+	uspace_addr = ipc_get_arg2(&call->data);	/* Destination address */
+	buf_size = ipc_get_arg3(&call->data);	/* Dest. buffer size */
 
 	/*
 	 * Read area list.
 	 */
 	data = as_get_area_info(AS, &data_size);
 	if (!data) {
-		IPC_SET_RETVAL(&call->data, ENOMEM);
+		ipc_set_retval(&call->data, ENOMEM);
 		ipc_answer(&TASK->kb.box, call);
 		return;
 	}
@@ -291,16 +291,16 @@ static void udebug_receive_areas_read(call_t *call)
 	 * Make use of call->buffer to transfer data to caller's userspace
 	 */
 
-	IPC_SET_RETVAL(&call->data, 0);
+	ipc_set_retval(&call->data, 0);
 	/*
 	 * ARG1=dest, ARG2=size as in IPC_M_DATA_READ so that
 	 * same code in process_answer() can be used
 	 * (no way to distinguish method in answer)
 	 */
-	IPC_SET_ARG1(&call->data, uspace_addr);
-	IPC_SET_ARG2(&call->data, to_copy);
+	ipc_set_arg1(&call->data, uspace_addr);
+	ipc_set_arg2(&call->data, to_copy);
 
-	IPC_SET_ARG3(&call->data, data_size);
+	ipc_set_arg3(&call->data, data_size);
 	call->buffer = (uint8_t *) data;
 
 	ipc_answer(&TASK->kb.box, call);
@@ -318,11 +318,11 @@ static void udebug_receive_args_read(call_t *call)
 	errno_t rc;
 	void *buffer;
 
-	t = (thread_t *)IPC_GET_ARG2(&call->data);
+	t = (thread_t *)ipc_get_arg2(&call->data);
 
 	rc = udebug_args_read(t, &buffer);
 	if (rc != EOK) {
-		IPC_SET_RETVAL(&call->data, rc);
+		ipc_set_retval(&call->data, rc);
 		ipc_answer(&TASK->kb.box, call);
 		return;
 	}
@@ -331,16 +331,16 @@ static void udebug_receive_args_read(call_t *call)
 	 * Make use of call->buffer to transfer data to caller's userspace
 	 */
 
-	uspace_addr = IPC_GET_ARG3(&call->data);
+	uspace_addr = ipc_get_arg3(&call->data);
 
-	IPC_SET_RETVAL(&call->data, 0);
+	ipc_set_retval(&call->data, 0);
 	/*
 	 * ARG1=dest, ARG2=size as in IPC_M_DATA_READ so that
 	 * same code in process_answer() can be used
 	 * (no way to distinguish method in answer)
 	 */
-	IPC_SET_ARG1(&call->data, uspace_addr);
-	IPC_SET_ARG2(&call->data, 6 * sizeof(sysarg_t));
+	ipc_set_arg1(&call->data, uspace_addr);
+	ipc_set_arg2(&call->data, 6 * sizeof(sysarg_t));
 	call->buffer = buffer;
 
 	ipc_answer(&TASK->kb.box, call);
@@ -358,11 +358,11 @@ static void udebug_receive_regs_read(call_t *call)
 	void *buffer = NULL;
 	errno_t rc;
 
-	t = (thread_t *) IPC_GET_ARG2(&call->data);
+	t = (thread_t *) ipc_get_arg2(&call->data);
 
 	rc = udebug_regs_read(t, &buffer);
 	if (rc != EOK) {
-		IPC_SET_RETVAL(&call->data, rc);
+		ipc_set_retval(&call->data, rc);
 		ipc_answer(&TASK->kb.box, call);
 		return;
 	}
@@ -373,17 +373,17 @@ static void udebug_receive_regs_read(call_t *call)
 	 * Make use of call->buffer to transfer data to caller's userspace
 	 */
 
-	uspace_addr = IPC_GET_ARG3(&call->data);
+	uspace_addr = ipc_get_arg3(&call->data);
 	to_copy = sizeof(istate_t);
 
-	IPC_SET_RETVAL(&call->data, 0);
+	ipc_set_retval(&call->data, 0);
 	/*
 	 * ARG1=dest, ARG2=size as in IPC_M_DATA_READ so that
 	 * same code in process_answer() can be used
 	 * (no way to distinguish method in answer)
 	 */
-	IPC_SET_ARG1(&call->data, uspace_addr);
-	IPC_SET_ARG2(&call->data, to_copy);
+	ipc_set_arg1(&call->data, uspace_addr);
+	ipc_set_arg2(&call->data, to_copy);
 
 	call->buffer = buffer;
 
@@ -403,27 +403,27 @@ static void udebug_receive_mem_read(call_t *call)
 	void *buffer = NULL;
 	errno_t rc;
 
-	uspace_dst = IPC_GET_ARG2(&call->data);
-	uspace_src = IPC_GET_ARG3(&call->data);
-	size = IPC_GET_ARG4(&call->data);
+	uspace_dst = ipc_get_arg2(&call->data);
+	uspace_src = ipc_get_arg3(&call->data);
+	size = ipc_get_arg4(&call->data);
 
 	rc = udebug_mem_read(uspace_src, size, &buffer);
 	if (rc != EOK) {
-		IPC_SET_RETVAL(&call->data, rc);
+		ipc_set_retval(&call->data, rc);
 		ipc_answer(&TASK->kb.box, call);
 		return;
 	}
 
 	assert(buffer != NULL);
 
-	IPC_SET_RETVAL(&call->data, 0);
+	ipc_set_retval(&call->data, 0);
 	/*
 	 * ARG1=dest, ARG2=size as in IPC_M_DATA_READ so that
 	 * same code in process_answer() can be used
 	 * (no way to distinguish method in answer)
 	 */
-	IPC_SET_ARG1(&call->data, uspace_dst);
-	IPC_SET_ARG2(&call->data, size);
+	ipc_set_arg1(&call->data, uspace_dst);
+	ipc_set_arg2(&call->data, size);
 	call->buffer = buffer;
 
 	ipc_answer(&TASK->kb.box, call);
@@ -438,7 +438,7 @@ void udebug_call_receive(call_t *call)
 {
 	int debug_method;
 
-	debug_method = IPC_GET_ARG1(&call->data);
+	debug_method = ipc_get_arg1(&call->data);
 
 	if (debug_method != UDEBUG_M_BEGIN) {
 		/*
@@ -449,7 +449,7 @@ void udebug_call_receive(call_t *call)
 		 * control exits this function.
 		 */
 		if (TASK->udebug.debugger != call->sender) {
-			IPC_SET_RETVAL(&call->data, EINVAL);
+			ipc_set_retval(&call->data, EINVAL);
 			ipc_answer(&TASK->kb.box, call);
 			return;
 		}

--- a/kernel/generic/src/udebug/udebug_ipc.c
+++ b/kernel/generic/src/udebug/udebug_ipc.c
@@ -52,7 +52,7 @@
 
 errno_t udebug_request_preprocess(call_t *call, phone_t *phone)
 {
-	switch (IPC_GET_ARG1(call->data)) {
+	switch (IPC_GET_ARG1(&call->data)) {
 		/* future UDEBUG_M_REGS_WRITE, UDEBUG_M_MEM_WRITE: */
 	default:
 		break;
@@ -75,7 +75,7 @@ static void udebug_receive_begin(call_t *call)
 
 	rc = udebug_begin(call, &active);
 	if (rc != EOK) {
-		IPC_SET_RETVAL(call->data, rc);
+		IPC_SET_RETVAL(&call->data, rc);
 		ipc_answer(&TASK->kb.box, call);
 		return;
 	}
@@ -85,7 +85,7 @@ static void udebug_receive_begin(call_t *call)
 	 * send a reply.
 	 */
 	if (active) {
-		IPC_SET_RETVAL(call->data, EOK);
+		IPC_SET_RETVAL(&call->data, EOK);
 		ipc_answer(&TASK->kb.box, call);
 	}
 }
@@ -101,7 +101,7 @@ static void udebug_receive_end(call_t *call)
 
 	rc = udebug_end();
 
-	IPC_SET_RETVAL(call->data, rc);
+	IPC_SET_RETVAL(&call->data, rc);
 	ipc_answer(&TASK->kb.box, call);
 }
 
@@ -115,10 +115,10 @@ static void udebug_receive_set_evmask(call_t *call)
 	errno_t rc;
 	udebug_evmask_t mask;
 
-	mask = IPC_GET_ARG2(call->data);
+	mask = IPC_GET_ARG2(&call->data);
 	rc = udebug_set_evmask(mask);
 
-	IPC_SET_RETVAL(call->data, rc);
+	IPC_SET_RETVAL(&call->data, rc);
 	ipc_answer(&TASK->kb.box, call);
 }
 
@@ -132,11 +132,11 @@ static void udebug_receive_go(call_t *call)
 	thread_t *t;
 	errno_t rc;
 
-	t = (thread_t *)IPC_GET_ARG2(call->data);
+	t = (thread_t *)IPC_GET_ARG2(&call->data);
 
 	rc = udebug_go(t, call);
 	if (rc != EOK) {
-		IPC_SET_RETVAL(call->data, rc);
+		IPC_SET_RETVAL(&call->data, rc);
 		ipc_answer(&TASK->kb.box, call);
 		return;
 	}
@@ -152,10 +152,10 @@ static void udebug_receive_stop(call_t *call)
 	thread_t *t;
 	errno_t rc;
 
-	t = (thread_t *)IPC_GET_ARG2(call->data);
+	t = (thread_t *)IPC_GET_ARG2(&call->data);
 
 	rc = udebug_stop(t, call);
-	IPC_SET_RETVAL(call->data, rc);
+	IPC_SET_RETVAL(&call->data, rc);
 	ipc_answer(&TASK->kb.box, call);
 }
 
@@ -172,8 +172,8 @@ static void udebug_receive_thread_read(call_t *call)
 	size_t copied, needed;
 	errno_t rc;
 
-	uspace_addr = IPC_GET_ARG2(call->data);	/* Destination address */
-	buf_size = IPC_GET_ARG3(call->data);	/* Dest. buffer size */
+	uspace_addr = IPC_GET_ARG2(&call->data);	/* Destination address */
+	buf_size = IPC_GET_ARG3(&call->data);	/* Dest. buffer size */
 
 	/*
 	 * Read thread list. Variable n will be filled with actual number
@@ -181,7 +181,7 @@ static void udebug_receive_thread_read(call_t *call)
 	 */
 	rc = udebug_thread_read(&buffer, buf_size, &copied, &needed);
 	if (rc != EOK) {
-		IPC_SET_RETVAL(call->data, rc);
+		IPC_SET_RETVAL(&call->data, rc);
 		ipc_answer(&TASK->kb.box, call);
 		return;
 	}
@@ -190,15 +190,15 @@ static void udebug_receive_thread_read(call_t *call)
 	 * Make use of call->buffer to transfer data to caller's userspace
 	 */
 
-	IPC_SET_RETVAL(call->data, 0);
+	IPC_SET_RETVAL(&call->data, 0);
 	/*
 	 * ARG1=dest, ARG2=size as in IPC_M_DATA_READ so that
 	 * same code in process_answer() can be used
 	 * (no way to distinguish method in answer)
 	 */
-	IPC_SET_ARG1(call->data, uspace_addr);
-	IPC_SET_ARG2(call->data, copied);
-	IPC_SET_ARG3(call->data, needed);
+	IPC_SET_ARG1(&call->data, uspace_addr);
+	IPC_SET_ARG2(&call->data, copied);
+	IPC_SET_ARG3(&call->data, needed);
 	call->buffer = buffer;
 
 	ipc_answer(&TASK->kb.box, call);
@@ -218,8 +218,8 @@ static void udebug_receive_name_read(call_t *call)
 	size_t buf_size;
 	void *data;
 
-	uspace_addr = IPC_GET_ARG2(call->data);	/* Destination address */
-	buf_size = IPC_GET_ARG3(call->data);	/* Dest. buffer size */
+	uspace_addr = IPC_GET_ARG2(&call->data);	/* Destination address */
+	buf_size = IPC_GET_ARG3(&call->data);	/* Dest. buffer size */
 
 	/*
 	 * Read task name.
@@ -237,16 +237,16 @@ static void udebug_receive_name_read(call_t *call)
 	 * Make use of call->buffer to transfer data to caller's userspace
 	 */
 
-	IPC_SET_RETVAL(call->data, 0);
+	IPC_SET_RETVAL(&call->data, 0);
 	/*
 	 * ARG1=dest, ARG2=size as in IPC_M_DATA_READ so that
 	 * same code in process_answer() can be used
 	 * (no way to distinguish method in answer)
 	 */
-	IPC_SET_ARG1(call->data, uspace_addr);
-	IPC_SET_ARG2(call->data, to_copy);
+	IPC_SET_ARG1(&call->data, uspace_addr);
+	IPC_SET_ARG2(&call->data, to_copy);
 
-	IPC_SET_ARG3(call->data, data_size);
+	IPC_SET_ARG3(&call->data, data_size);
 	call->buffer = data;
 
 	ipc_answer(&TASK->kb.box, call);
@@ -267,15 +267,15 @@ static void udebug_receive_areas_read(call_t *call)
 	size_t buf_size;
 	as_area_info_t *data;
 
-	uspace_addr = IPC_GET_ARG2(call->data);	/* Destination address */
-	buf_size = IPC_GET_ARG3(call->data);	/* Dest. buffer size */
+	uspace_addr = IPC_GET_ARG2(&call->data);	/* Destination address */
+	buf_size = IPC_GET_ARG3(&call->data);	/* Dest. buffer size */
 
 	/*
 	 * Read area list.
 	 */
 	data = as_get_area_info(AS, &data_size);
 	if (!data) {
-		IPC_SET_RETVAL(call->data, ENOMEM);
+		IPC_SET_RETVAL(&call->data, ENOMEM);
 		ipc_answer(&TASK->kb.box, call);
 		return;
 	}
@@ -291,16 +291,16 @@ static void udebug_receive_areas_read(call_t *call)
 	 * Make use of call->buffer to transfer data to caller's userspace
 	 */
 
-	IPC_SET_RETVAL(call->data, 0);
+	IPC_SET_RETVAL(&call->data, 0);
 	/*
 	 * ARG1=dest, ARG2=size as in IPC_M_DATA_READ so that
 	 * same code in process_answer() can be used
 	 * (no way to distinguish method in answer)
 	 */
-	IPC_SET_ARG1(call->data, uspace_addr);
-	IPC_SET_ARG2(call->data, to_copy);
+	IPC_SET_ARG1(&call->data, uspace_addr);
+	IPC_SET_ARG2(&call->data, to_copy);
 
-	IPC_SET_ARG3(call->data, data_size);
+	IPC_SET_ARG3(&call->data, data_size);
 	call->buffer = (uint8_t *) data;
 
 	ipc_answer(&TASK->kb.box, call);
@@ -318,11 +318,11 @@ static void udebug_receive_args_read(call_t *call)
 	errno_t rc;
 	void *buffer;
 
-	t = (thread_t *)IPC_GET_ARG2(call->data);
+	t = (thread_t *)IPC_GET_ARG2(&call->data);
 
 	rc = udebug_args_read(t, &buffer);
 	if (rc != EOK) {
-		IPC_SET_RETVAL(call->data, rc);
+		IPC_SET_RETVAL(&call->data, rc);
 		ipc_answer(&TASK->kb.box, call);
 		return;
 	}
@@ -331,16 +331,16 @@ static void udebug_receive_args_read(call_t *call)
 	 * Make use of call->buffer to transfer data to caller's userspace
 	 */
 
-	uspace_addr = IPC_GET_ARG3(call->data);
+	uspace_addr = IPC_GET_ARG3(&call->data);
 
-	IPC_SET_RETVAL(call->data, 0);
+	IPC_SET_RETVAL(&call->data, 0);
 	/*
 	 * ARG1=dest, ARG2=size as in IPC_M_DATA_READ so that
 	 * same code in process_answer() can be used
 	 * (no way to distinguish method in answer)
 	 */
-	IPC_SET_ARG1(call->data, uspace_addr);
-	IPC_SET_ARG2(call->data, 6 * sizeof(sysarg_t));
+	IPC_SET_ARG1(&call->data, uspace_addr);
+	IPC_SET_ARG2(&call->data, 6 * sizeof(sysarg_t));
 	call->buffer = buffer;
 
 	ipc_answer(&TASK->kb.box, call);
@@ -358,11 +358,11 @@ static void udebug_receive_regs_read(call_t *call)
 	void *buffer = NULL;
 	errno_t rc;
 
-	t = (thread_t *) IPC_GET_ARG2(call->data);
+	t = (thread_t *) IPC_GET_ARG2(&call->data);
 
 	rc = udebug_regs_read(t, &buffer);
 	if (rc != EOK) {
-		IPC_SET_RETVAL(call->data, rc);
+		IPC_SET_RETVAL(&call->data, rc);
 		ipc_answer(&TASK->kb.box, call);
 		return;
 	}
@@ -373,17 +373,17 @@ static void udebug_receive_regs_read(call_t *call)
 	 * Make use of call->buffer to transfer data to caller's userspace
 	 */
 
-	uspace_addr = IPC_GET_ARG3(call->data);
+	uspace_addr = IPC_GET_ARG3(&call->data);
 	to_copy = sizeof(istate_t);
 
-	IPC_SET_RETVAL(call->data, 0);
+	IPC_SET_RETVAL(&call->data, 0);
 	/*
 	 * ARG1=dest, ARG2=size as in IPC_M_DATA_READ so that
 	 * same code in process_answer() can be used
 	 * (no way to distinguish method in answer)
 	 */
-	IPC_SET_ARG1(call->data, uspace_addr);
-	IPC_SET_ARG2(call->data, to_copy);
+	IPC_SET_ARG1(&call->data, uspace_addr);
+	IPC_SET_ARG2(&call->data, to_copy);
 
 	call->buffer = buffer;
 
@@ -403,27 +403,27 @@ static void udebug_receive_mem_read(call_t *call)
 	void *buffer = NULL;
 	errno_t rc;
 
-	uspace_dst = IPC_GET_ARG2(call->data);
-	uspace_src = IPC_GET_ARG3(call->data);
-	size = IPC_GET_ARG4(call->data);
+	uspace_dst = IPC_GET_ARG2(&call->data);
+	uspace_src = IPC_GET_ARG3(&call->data);
+	size = IPC_GET_ARG4(&call->data);
 
 	rc = udebug_mem_read(uspace_src, size, &buffer);
 	if (rc != EOK) {
-		IPC_SET_RETVAL(call->data, rc);
+		IPC_SET_RETVAL(&call->data, rc);
 		ipc_answer(&TASK->kb.box, call);
 		return;
 	}
 
 	assert(buffer != NULL);
 
-	IPC_SET_RETVAL(call->data, 0);
+	IPC_SET_RETVAL(&call->data, 0);
 	/*
 	 * ARG1=dest, ARG2=size as in IPC_M_DATA_READ so that
 	 * same code in process_answer() can be used
 	 * (no way to distinguish method in answer)
 	 */
-	IPC_SET_ARG1(call->data, uspace_dst);
-	IPC_SET_ARG2(call->data, size);
+	IPC_SET_ARG1(&call->data, uspace_dst);
+	IPC_SET_ARG2(&call->data, size);
 	call->buffer = buffer;
 
 	ipc_answer(&TASK->kb.box, call);
@@ -438,7 +438,7 @@ void udebug_call_receive(call_t *call)
 {
 	int debug_method;
 
-	debug_method = IPC_GET_ARG1(call->data);
+	debug_method = IPC_GET_ARG1(&call->data);
 
 	if (debug_method != UDEBUG_M_BEGIN) {
 		/*
@@ -449,7 +449,7 @@ void udebug_call_receive(call_t *call)
 		 * control exits this function.
 		 */
 		if (TASK->udebug.debugger != call->sender) {
-			IPC_SET_RETVAL(call->data, EINVAL);
+			IPC_SET_RETVAL(&call->data, EINVAL);
 			ipc_answer(&TASK->kb.box, call);
 			return;
 		}

--- a/kernel/generic/src/udebug/udebug_ops.c
+++ b/kernel/generic/src/udebug/udebug_ops.c
@@ -327,8 +327,8 @@ errno_t udebug_stop(thread_t *thread, call_t *call)
 	call = thread->udebug.go_call;
 	thread->udebug.go_call = NULL;
 
-	IPC_SET_RETVAL(call->data, 0);
-	IPC_SET_ARG1(call->data, UDEBUG_EVENT_STOP);
+	IPC_SET_RETVAL(&call->data, 0);
+	IPC_SET_ARG1(&call->data, UDEBUG_EVENT_STOP);
 
 	THREAD->udebug.cur_event = UDEBUG_EVENT_STOP;
 

--- a/kernel/generic/src/udebug/udebug_ops.c
+++ b/kernel/generic/src/udebug/udebug_ops.c
@@ -327,8 +327,8 @@ errno_t udebug_stop(thread_t *thread, call_t *call)
 	call = thread->udebug.go_call;
 	thread->udebug.go_call = NULL;
 
-	IPC_SET_RETVAL(&call->data, 0);
-	IPC_SET_ARG1(&call->data, UDEBUG_EVENT_STOP);
+	ipc_set_retval(&call->data, 0);
+	ipc_set_arg1(&call->data, UDEBUG_EVENT_STOP);
 
 	THREAD->udebug.cur_event = UDEBUG_EVENT_STOP;
 

--- a/uspace/app/kio/kio.c
+++ b/uspace/app/kio/kio.c
@@ -163,9 +163,9 @@ static void kio_notification_handler(ipc_call_t *call, void *arg)
 
 	fibril_mutex_lock(&mtx);
 
-	size_t kio_start = (size_t) IPC_GET_ARG1(*call);
-	size_t kio_len = (size_t) IPC_GET_ARG2(*call);
-	size_t kio_stored = (size_t) IPC_GET_ARG3(*call);
+	size_t kio_start = (size_t) IPC_GET_ARG1(call);
+	size_t kio_len = (size_t) IPC_GET_ARG2(call);
+	size_t kio_stored = (size_t) IPC_GET_ARG3(call);
 
 	size_t offset = (kio_start + kio_len - kio_stored) % kio_length;
 

--- a/uspace/app/kio/kio.c
+++ b/uspace/app/kio/kio.c
@@ -163,9 +163,9 @@ static void kio_notification_handler(ipc_call_t *call, void *arg)
 
 	fibril_mutex_lock(&mtx);
 
-	size_t kio_start = (size_t) IPC_GET_ARG1(call);
-	size_t kio_len = (size_t) IPC_GET_ARG2(call);
-	size_t kio_stored = (size_t) IPC_GET_ARG3(call);
+	size_t kio_start = (size_t) ipc_get_arg1(call);
+	size_t kio_len = (size_t) ipc_get_arg2(call);
+	size_t kio_stored = (size_t) ipc_get_arg3(call);
 
 	size_t offset = (kio_start + kio_len - kio_stored) % kio_length;
 

--- a/uspace/app/trace/ipcp.c
+++ b/uspace/app/trace/ipcp.c
@@ -193,7 +193,7 @@ void ipcp_call_out(cap_phone_handle_t phandle, ipc_call_t *call,
 	if ((display_mask & DM_IPC) != 0) {
 		printf("Call handle: %p, phone: %p, proto: %s, method: ",
 		    chandle, phandle, (proto ? proto->name : "n/a"));
-		ipc_m_print(proto, IPC_GET_IMETHOD(call));
+		ipc_m_print(proto, ipc_get_imethod(call));
 		printf(" args: (%" PRIun ", %" PRIun ", %" PRIun ", "
 		    "%" PRIun ", %" PRIun ")\n",
 		    args[1], args[2], args[3], args[4], args[5]);
@@ -202,7 +202,7 @@ void ipcp_call_out(cap_phone_handle_t phandle, ipc_call_t *call,
 	if ((display_mask & DM_USER) != 0) {
 
 		if (proto != NULL) {
-			oper = proto_get_oper(proto, IPC_GET_IMETHOD(call));
+			oper = proto_get_oper(proto, ipc_get_imethod(call));
 		} else {
 			oper = NULL;
 		}
@@ -261,17 +261,17 @@ static void parse_answer(cap_call_handle_t call_handle, pending_call_t *pcall,
 	int i;
 
 	phone = pcall->phone_handle;
-	method = IPC_GET_IMETHOD(&pcall->question);
-	retval = IPC_GET_RETVAL(answer);
+	method = ipc_get_imethod(&pcall->question);
+	retval = ipc_get_retval(answer);
 
 	resp = answer->args;
 
 	if ((display_mask & DM_IPC) != 0) {
 		printf("Response to %p: retval=%s, args = (%" PRIun ", "
 		    "%" PRIun ", %" PRIun ", %" PRIun ", %" PRIun ")\n",
-		    call_handle, str_error_name(retval), IPC_GET_ARG1(answer),
-		    IPC_GET_ARG2(answer), IPC_GET_ARG3(answer),
-		    IPC_GET_ARG4(answer), IPC_GET_ARG5(answer));
+		    call_handle, str_error_name(retval), ipc_get_arg1(answer),
+		    ipc_get_arg2(answer), ipc_get_arg3(answer),
+		    ipc_get_arg4(answer), ipc_get_arg5(answer));
 	}
 
 	if ((display_mask & DM_USER) != 0) {
@@ -304,12 +304,12 @@ static void parse_answer(cap_call_handle_t call_handle, pending_call_t *pcall,
 	if ((phone == PHONE_NS) && (method == IPC_M_CONNECT_ME_TO) &&
 	    (retval == 0)) {
 		/* Connected to a service (through NS) */
-		service = IPC_GET_ARG2(&pcall->question);
+		service = ipc_get_arg2(&pcall->question);
 		proto = proto_get_by_srv(service);
 		if (proto == NULL)
 			proto = proto_unknown;
 
-		cphone = (cap_phone_handle_t) IPC_GET_ARG5(answer);
+		cphone = (cap_phone_handle_t) ipc_get_arg5(answer);
 		if ((display_mask & DM_SYSTEM) != 0) {
 			printf("Registering connection (phone %p, protocol: %s)\n", cphone,
 			    proto->name);

--- a/uspace/app/trace/ipcp.c
+++ b/uspace/app/trace/ipcp.c
@@ -193,7 +193,7 @@ void ipcp_call_out(cap_phone_handle_t phandle, ipc_call_t *call,
 	if ((display_mask & DM_IPC) != 0) {
 		printf("Call handle: %p, phone: %p, proto: %s, method: ",
 		    chandle, phandle, (proto ? proto->name : "n/a"));
-		ipc_m_print(proto, IPC_GET_IMETHOD(*call));
+		ipc_m_print(proto, IPC_GET_IMETHOD(call));
 		printf(" args: (%" PRIun ", %" PRIun ", %" PRIun ", "
 		    "%" PRIun ", %" PRIun ")\n",
 		    args[1], args[2], args[3], args[4], args[5]);
@@ -202,7 +202,7 @@ void ipcp_call_out(cap_phone_handle_t phandle, ipc_call_t *call,
 	if ((display_mask & DM_USER) != 0) {
 
 		if (proto != NULL) {
-			oper = proto_get_oper(proto, IPC_GET_IMETHOD(*call));
+			oper = proto_get_oper(proto, IPC_GET_IMETHOD(call));
 		} else {
 			oper = NULL;
 		}
@@ -261,17 +261,17 @@ static void parse_answer(cap_call_handle_t call_handle, pending_call_t *pcall,
 	int i;
 
 	phone = pcall->phone_handle;
-	method = IPC_GET_IMETHOD(pcall->question);
-	retval = IPC_GET_RETVAL(*answer);
+	method = IPC_GET_IMETHOD(&pcall->question);
+	retval = IPC_GET_RETVAL(answer);
 
 	resp = answer->args;
 
 	if ((display_mask & DM_IPC) != 0) {
 		printf("Response to %p: retval=%s, args = (%" PRIun ", "
 		    "%" PRIun ", %" PRIun ", %" PRIun ", %" PRIun ")\n",
-		    call_handle, str_error_name(retval), IPC_GET_ARG1(*answer),
-		    IPC_GET_ARG2(*answer), IPC_GET_ARG3(*answer),
-		    IPC_GET_ARG4(*answer), IPC_GET_ARG5(*answer));
+		    call_handle, str_error_name(retval), IPC_GET_ARG1(answer),
+		    IPC_GET_ARG2(answer), IPC_GET_ARG3(answer),
+		    IPC_GET_ARG4(answer), IPC_GET_ARG5(answer));
 	}
 
 	if ((display_mask & DM_USER) != 0) {
@@ -304,12 +304,12 @@ static void parse_answer(cap_call_handle_t call_handle, pending_call_t *pcall,
 	if ((phone == PHONE_NS) && (method == IPC_M_CONNECT_ME_TO) &&
 	    (retval == 0)) {
 		/* Connected to a service (through NS) */
-		service = IPC_GET_ARG2(pcall->question);
+		service = IPC_GET_ARG2(&pcall->question);
 		proto = proto_get_by_srv(service);
 		if (proto == NULL)
 			proto = proto_unknown;
 
-		cphone = (cap_phone_handle_t) IPC_GET_ARG5(*answer);
+		cphone = (cap_phone_handle_t) IPC_GET_ARG5(answer);
 		if ((display_mask & DM_SYSTEM) != 0) {
 			printf("Registering connection (phone %p, protocol: %s)\n", cphone,
 			    proto->name);

--- a/uspace/app/trace/ipcp.c
+++ b/uspace/app/trace/ipcp.c
@@ -74,13 +74,13 @@ proto_t	*proto_unknown;		/**< Protocol with no known methods. */
 static size_t pending_call_key_hash(void *key)
 {
 	cap_call_handle_t *chandle = (cap_call_handle_t *) key;
-	return CAP_HANDLE_RAW(*chandle);
+	return cap_handle_raw(*chandle);
 }
 
 static size_t pending_call_hash(const ht_link_t *item)
 {
 	pending_call_t *hs = hash_table_get_inst(item, pending_call_t, link);
-	return CAP_HANDLE_RAW(hs->call_handle);
+	return cap_handle_raw(hs->call_handle);
 }
 
 static bool pending_call_key_equal(void *key, const ht_link_t *item)
@@ -103,18 +103,18 @@ void ipcp_connection_set(cap_phone_handle_t phone, int server, proto_t *proto)
 {
 	// XXX: there is no longer a limit on the number of phones as phones are
 	// now handled using capabilities
-	if (CAP_HANDLE_RAW(phone) < 0 || CAP_HANDLE_RAW(phone) >= MAX_PHONE)
+	if (cap_handle_raw(phone) < 0 || cap_handle_raw(phone) >= MAX_PHONE)
 		return;
-	connections[CAP_HANDLE_RAW(phone)].server = server;
-	connections[CAP_HANDLE_RAW(phone)].proto = proto;
-	have_conn[CAP_HANDLE_RAW(phone)] = 1;
+	connections[cap_handle_raw(phone)].server = server;
+	connections[cap_handle_raw(phone)].proto = proto;
+	have_conn[cap_handle_raw(phone)] = 1;
 }
 
 void ipcp_connection_clear(cap_phone_handle_t phone)
 {
-	have_conn[CAP_HANDLE_RAW(phone)] = 0;
-	connections[CAP_HANDLE_RAW(phone)].server = 0;
-	connections[CAP_HANDLE_RAW(phone)].proto = NULL;
+	have_conn[cap_handle_raw(phone)] = 0;
+	connections[cap_handle_raw(phone)].server = 0;
+	connections[cap_handle_raw(phone)].proto = NULL;
 }
 
 static void ipc_m_print(proto_t *proto, sysarg_t method)
@@ -183,8 +183,8 @@ void ipcp_call_out(cap_phone_handle_t phandle, ipc_call_t *call,
 	sysarg_t *args;
 	int i;
 
-	if (have_conn[CAP_HANDLE_RAW(phandle)])
-		proto = connections[CAP_HANDLE_RAW(phandle)].proto;
+	if (have_conn[cap_handle_raw(phandle)])
+		proto = connections[cap_handle_raw(phandle)].proto;
 	else
 		proto = NULL;
 

--- a/uspace/app/trace/trace.c
+++ b/uspace/app/trace/trace.c
@@ -301,12 +301,12 @@ static void sc_ipc_call_async_fast(sysarg_t *sc_args, errno_t sc_rc)
 
 	phandle = (cap_phone_handle_t) sc_args[0];
 
-	IPC_SET_IMETHOD(&call, sc_args[1]);
-	IPC_SET_ARG1(&call, sc_args[2]);
-	IPC_SET_ARG2(&call, sc_args[3]);
-	IPC_SET_ARG3(&call, sc_args[4]);
-	IPC_SET_ARG4(&call, sc_args[5]);
-	IPC_SET_ARG5(&call, 0);
+	ipc_set_imethod(&call, sc_args[1]);
+	ipc_set_arg1(&call, sc_args[2]);
+	ipc_set_arg2(&call, sc_args[3]);
+	ipc_set_arg3(&call, sc_args[4]);
+	ipc_set_arg4(&call, sc_args[5]);
+	ipc_set_arg5(&call, 0);
 
 	ipcp_call_out(phandle, &call, 0);
 }

--- a/uspace/app/trace/trace.c
+++ b/uspace/app/trace/trace.c
@@ -301,12 +301,12 @@ static void sc_ipc_call_async_fast(sysarg_t *sc_args, errno_t sc_rc)
 
 	phandle = (cap_phone_handle_t) sc_args[0];
 
-	IPC_SET_IMETHOD(call, sc_args[1]);
-	IPC_SET_ARG1(call, sc_args[2]);
-	IPC_SET_ARG2(call, sc_args[3]);
-	IPC_SET_ARG3(call, sc_args[4]);
-	IPC_SET_ARG4(call, sc_args[5]);
-	IPC_SET_ARG5(call, 0);
+	IPC_SET_IMETHOD(&call, sc_args[1]);
+	IPC_SET_ARG1(&call, sc_args[2]);
+	IPC_SET_ARG2(&call, sc_args[3]);
+	IPC_SET_ARG3(&call, sc_args[4]);
+	IPC_SET_ARG4(&call, sc_args[5]);
+	IPC_SET_ARG5(&call, 0);
 
 	ipcp_call_out(phandle, &call, 0);
 }

--- a/uspace/app/wavplay/dplay.c
+++ b/uspace/app/wavplay/dplay.c
@@ -102,10 +102,10 @@ static void device_event_callback(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case PCM_EVENT_PLAYBACK_STARTED:
 		case PCM_EVENT_FRAMES_PLAYED:
-			printf("%" PRIun " frames: ", IPC_GET_ARG1(&call));
+			printf("%" PRIun " frames: ", ipc_get_arg1(&call));
 			async_answer_0(&call, EOK);
 			break;
 		case PCM_EVENT_PLAYBACK_TERMINATED:
@@ -117,7 +117,7 @@ static void device_event_callback(ipc_call_t *icall, void *arg)
 			fibril_mutex_unlock(&pb->mutex);
 			return;
 		default:
-			printf("Unknown event %" PRIun ".\n", IPC_GET_IMETHOD(&call));
+			printf("Unknown event %" PRIun ".\n", ipc_get_imethod(&call));
 			async_answer_0(&call, ENOTSUP);
 			continue;
 

--- a/uspace/app/wavplay/dplay.c
+++ b/uspace/app/wavplay/dplay.c
@@ -102,10 +102,10 @@ static void device_event_callback(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case PCM_EVENT_PLAYBACK_STARTED:
 		case PCM_EVENT_FRAMES_PLAYED:
-			printf("%" PRIun " frames: ", IPC_GET_ARG1(call));
+			printf("%" PRIun " frames: ", IPC_GET_ARG1(&call));
 			async_answer_0(&call, EOK);
 			break;
 		case PCM_EVENT_PLAYBACK_TERMINATED:
@@ -117,7 +117,7 @@ static void device_event_callback(ipc_call_t *icall, void *arg)
 			fibril_mutex_unlock(&pb->mutex);
 			return;
 		default:
-			printf("Unknown event %" PRIun ".\n", IPC_GET_IMETHOD(call));
+			printf("Unknown event %" PRIun ".\n", IPC_GET_IMETHOD(&call));
 			async_answer_0(&call, ENOTSUP);
 			continue;
 

--- a/uspace/app/wavplay/drec.c
+++ b/uspace/app/wavplay/drec.c
@@ -102,16 +102,16 @@ static void device_event_callback(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case PCM_EVENT_CAPTURE_TERMINATED:
 			printf("Recording terminated\n");
 			record = false;
 			break;
 		case PCM_EVENT_FRAMES_CAPTURED:
-			printf("%" PRIun " frames\n", IPC_GET_ARG1(&call));
+			printf("%" PRIun " frames\n", ipc_get_arg1(&call));
 			break;
 		default:
-			printf("Unknown event %" PRIun ".\n", IPC_GET_IMETHOD(&call));
+			printf("Unknown event %" PRIun ".\n", ipc_get_imethod(&call));
 			async_answer_0(&call, ENOTSUP);
 			continue;
 		}

--- a/uspace/app/wavplay/drec.c
+++ b/uspace/app/wavplay/drec.c
@@ -102,16 +102,16 @@ static void device_event_callback(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case PCM_EVENT_CAPTURE_TERMINATED:
 			printf("Recording terminated\n");
 			record = false;
 			break;
 		case PCM_EVENT_FRAMES_CAPTURED:
-			printf("%" PRIun " frames\n", IPC_GET_ARG1(call));
+			printf("%" PRIun " frames\n", IPC_GET_ARG1(&call));
 			break;
 		default:
-			printf("Unknown event %" PRIun ".\n", IPC_GET_IMETHOD(call));
+			printf("Unknown event %" PRIun ".\n", IPC_GET_IMETHOD(&call));
 			async_answer_0(&call, ENOTSUP);
 			continue;
 		}

--- a/uspace/drv/audio/hdaudio/hdaudio.c
+++ b/uspace/drv/audio/hdaudio/hdaudio.c
@@ -384,7 +384,7 @@ static void hdaudio_interrupt(ipc_call_t *icall, ddf_dev_t *dev)
 		ddf_msg(LVL_NOTE, "## interrupt ##");
 	hda_ctl_interrupt(hda->ctl);
 
-	if (IPC_GET_ARG3(*icall) != 0) {
+	if (IPC_GET_ARG3(icall) != 0) {
 		/* Buffer completed */
 		hda_lock(hda);
 		if (hda->playing) {

--- a/uspace/drv/audio/hdaudio/hdaudio.c
+++ b/uspace/drv/audio/hdaudio/hdaudio.c
@@ -384,7 +384,7 @@ static void hdaudio_interrupt(ipc_call_t *icall, ddf_dev_t *dev)
 		ddf_msg(LVL_NOTE, "## interrupt ##");
 	hda_ctl_interrupt(hda->ctl);
 
-	if (IPC_GET_ARG3(icall) != 0) {
+	if (ipc_get_arg3(icall) != 0) {
 		/* Buffer completed */
 		hda_lock(hda);
 		if (hda->playing) {

--- a/uspace/drv/block/ahci/ahci.c
+++ b/uspace/drv/block/ahci/ahci.c
@@ -896,8 +896,8 @@ static irq_cmd_t ahci_cmds[] = {
 static void ahci_interrupt(ipc_call_t *icall, ddf_dev_t *dev)
 {
 	ahci_dev_t *ahci = dev_ahci_dev(dev);
-	unsigned int port = IPC_GET_ARG1(icall);
-	ahci_port_is_t pxis = IPC_GET_ARG2(icall);
+	unsigned int port = ipc_get_arg1(icall);
+	ahci_port_is_t pxis = ipc_get_arg2(icall);
 
 	if (port >= AHCI_MAX_PORTS)
 		return;

--- a/uspace/drv/block/ahci/ahci.c
+++ b/uspace/drv/block/ahci/ahci.c
@@ -896,8 +896,8 @@ static irq_cmd_t ahci_cmds[] = {
 static void ahci_interrupt(ipc_call_t *icall, ddf_dev_t *dev)
 {
 	ahci_dev_t *ahci = dev_ahci_dev(dev);
-	unsigned int port = IPC_GET_ARG1(*icall);
-	ahci_port_is_t pxis = IPC_GET_ARG2(*icall);
+	unsigned int port = IPC_GET_ARG1(icall);
+	ahci_port_is_t pxis = IPC_GET_ARG2(icall);
 
 	if (port >= AHCI_MAX_PORTS)
 		return;

--- a/uspace/drv/block/ddisk/ddisk.c
+++ b/uspace/drv/block/ddisk/ddisk.c
@@ -178,7 +178,7 @@ irq_code_t ddisk_irq_code = {
 void ddisk_irq_handler(ipc_call_t *icall, ddf_dev_t *dev)
 {
 	ddf_msg(LVL_DEBUG, "ddisk_irq_handler(), status=%" PRIx32,
-	    (uint32_t) IPC_GET_ARG1(icall));
+	    (uint32_t) ipc_get_arg1(icall));
 
 	ddisk_t *ddisk = (ddisk_t *) ddf_dev_data_get(dev);
 

--- a/uspace/drv/block/ddisk/ddisk.c
+++ b/uspace/drv/block/ddisk/ddisk.c
@@ -178,7 +178,7 @@ irq_code_t ddisk_irq_code = {
 void ddisk_irq_handler(ipc_call_t *icall, ddf_dev_t *dev)
 {
 	ddf_msg(LVL_DEBUG, "ddisk_irq_handler(), status=%" PRIx32,
-	    (uint32_t) IPC_GET_ARG1(*icall));
+	    (uint32_t) IPC_GET_ARG1(icall));
 
 	ddisk_t *ddisk = (ddisk_t *) ddf_dev_data_get(dev);
 

--- a/uspace/drv/bus/adb/cuda_adb/cuda_adb.c
+++ b/uspace/drv/bus/adb/cuda_adb/cuda_adb.c
@@ -207,7 +207,7 @@ static void cuda_dev_connection(ipc_call_t *icall, void *arg)
 
 	while (true) {
 		async_get_call(&call);
-		method = IPC_GET_IMETHOD(call);
+		method = IPC_GET_IMETHOD(&call);
 
 		if (!method) {
 			/* The other side has hung up. */

--- a/uspace/drv/bus/adb/cuda_adb/cuda_adb.c
+++ b/uspace/drv/bus/adb/cuda_adb/cuda_adb.c
@@ -207,7 +207,7 @@ static void cuda_dev_connection(ipc_call_t *icall, void *arg)
 
 	while (true) {
 		async_get_call(&call);
-		method = IPC_GET_IMETHOD(&call);
+		method = ipc_get_imethod(&call);
 
 		if (!method) {
 			/* The other side has hung up. */

--- a/uspace/drv/bus/pci/pciintel/ctl.c
+++ b/uspace/drv/bus/pci/pciintel/ctl.c
@@ -64,10 +64,10 @@ void pci_ctl_connection(ipc_call_t *icall, void *arg)
 	while (true) {
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call))
+		if (!ipc_get_imethod(&call))
 			break;
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case PCI_GET_DEVICES:
 			pci_ctl_get_devices_srv(bus, &call);
 			break;
@@ -139,7 +139,7 @@ static void pci_ctl_dev_get_info_srv(pci_bus_t *bus, ipc_call_t *icall)
 	pci_dev_info_t info;
 	errno_t rc;
 
-	dev_handle = IPC_GET_ARG1(icall);
+	dev_handle = ipc_get_arg1(icall);
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "pci_dev_get_info_srv(%zu)",
 	    dev_handle);
 	fun = pci_fun_first(bus);

--- a/uspace/drv/bus/pci/pciintel/ctl.c
+++ b/uspace/drv/bus/pci/pciintel/ctl.c
@@ -64,10 +64,10 @@ void pci_ctl_connection(ipc_call_t *icall, void *arg)
 	while (true) {
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call))
+		if (!IPC_GET_IMETHOD(&call))
 			break;
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case PCI_GET_DEVICES:
 			pci_ctl_get_devices_srv(bus, &call);
 			break;
@@ -139,7 +139,7 @@ static void pci_ctl_dev_get_info_srv(pci_bus_t *bus, ipc_call_t *icall)
 	pci_dev_info_t info;
 	errno_t rc;
 
-	dev_handle = IPC_GET_ARG1(*icall);
+	dev_handle = IPC_GET_ARG1(icall);
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "pci_dev_get_info_srv(%zu)",
 	    dev_handle);
 	fun = pci_fun_first(bus);

--- a/uspace/drv/bus/usb/ohci/hc.c
+++ b/uspace/drv/bus/usb/ohci/hc.c
@@ -513,7 +513,7 @@ int hc_start(hc_device_t *hcd)
 	    OHCI_RD(instance->registers->control));
 
 	/* Enable interrupts */
-	if (CAP_HANDLE_VALID(instance->base.irq_handle)) {
+	if (cap_handle_valid(instance->base.irq_handle)) {
 		OHCI_WR(instance->registers->interrupt_enable,
 		    OHCI_USED_INTERRUPTS);
 		usb_log_debug("Enabled interrupts: %x.",

--- a/uspace/drv/bus/usb/uhci/hc.c
+++ b/uspace/drv/bus/usb/uhci/hc.c
@@ -294,7 +294,7 @@ void hc_init_hw(const hc_t *instance)
 	const uint32_t pa = addr_to_phys(instance->frame_list);
 	pio_write_32(&registers->flbaseadd, pa);
 
-	if (CAP_HANDLE_VALID(instance->base.irq_handle)) {
+	if (cap_handle_valid(instance->base.irq_handle)) {
 		/* Enable all interrupts, but resume interrupt */
 		pio_write_16(&instance->registers->usbintr,
 		    UHCI_INTR_ALLOW_INTERRUPTS);

--- a/uspace/drv/bus/usb/vhc/conndev.c
+++ b/uspace/drv/bus/usb/vhc/conndev.c
@@ -82,7 +82,7 @@ static void receive_device_name(async_sess_t *sess)
 	if ((data_request_rc != EOK) || (opening_request_rc != EOK))
 		return;
 
-	size_t len = IPC_GET_ARG2(data_request_call);
+	size_t len = IPC_GET_ARG2(&data_request_call);
 	plugged_device_name[len] = 0;
 }
 

--- a/uspace/drv/bus/usb/vhc/conndev.c
+++ b/uspace/drv/bus/usb/vhc/conndev.c
@@ -82,7 +82,7 @@ static void receive_device_name(async_sess_t *sess)
 	if ((data_request_rc != EOK) || (opening_request_rc != EOK))
 		return;
 
-	size_t len = IPC_GET_ARG2(&data_request_call);
+	size_t len = ipc_get_arg2(&data_request_call);
 	plugged_device_name[len] = 0;
 }
 

--- a/uspace/drv/bus/usb/xhci/hc.c
+++ b/uspace/drv/bus/usb/xhci/hc.c
@@ -493,7 +493,7 @@ errno_t hc_start(xhci_hc_t *hc)
 	const uintptr_t erstba_phys = dma_buffer_phys_base(&hc->event_ring.erst);
 	XHCI_REG_WR(intr0, XHCI_INTR_ERSTBA, erstba_phys);
 
-	if (CAP_HANDLE_VALID(hc->base.irq_handle)) {
+	if (cap_handle_valid(hc->base.irq_handle)) {
 		XHCI_REG_SET(intr0, XHCI_INTR_IE, 1);
 		XHCI_REG_SET(hc->op_regs, XHCI_OP_INTE, 1);
 	}

--- a/uspace/drv/char/i8042/i8042.c
+++ b/uspace/drv/char/i8042/i8042.c
@@ -131,8 +131,8 @@ static void i8042_irq_handler(ipc_call_t *call, ddf_dev_t *dev)
 	i8042_t *controller = ddf_dev_data_get(dev);
 	errno_t rc;
 
-	const uint8_t status = IPC_GET_ARG1(*call);
-	const uint8_t data = IPC_GET_ARG2(*call);
+	const uint8_t status = IPC_GET_ARG1(call);
+	const uint8_t data = IPC_GET_ARG2(call);
 
 	i8042_port_t *port = (status & i8042_AUX_DATA) ?
 	    controller->aux : controller->kbd;

--- a/uspace/drv/char/i8042/i8042.c
+++ b/uspace/drv/char/i8042/i8042.c
@@ -131,8 +131,8 @@ static void i8042_irq_handler(ipc_call_t *call, ddf_dev_t *dev)
 	i8042_t *controller = ddf_dev_data_get(dev);
 	errno_t rc;
 
-	const uint8_t status = IPC_GET_ARG1(call);
-	const uint8_t data = IPC_GET_ARG2(call);
+	const uint8_t status = ipc_get_arg1(call);
+	const uint8_t data = ipc_get_arg2(call);
 
 	i8042_port_t *port = (status & i8042_AUX_DATA) ?
 	    controller->aux : controller->kbd;

--- a/uspace/drv/char/msim-con/msim-con.c
+++ b/uspace/drv/char/msim-con/msim-con.c
@@ -155,7 +155,7 @@ errno_t msim_con_add(msim_con_t *con, msim_con_res_t *res)
 
 	return EOK;
 error:
-	if (CAP_HANDLE_VALID(con->irq_handle))
+	if (cap_handle_valid(con->irq_handle))
 		async_irq_unsubscribe(con->irq_handle);
 	if (bound)
 		ddf_fun_unbind(fun);

--- a/uspace/drv/char/msim-con/msim-con.c
+++ b/uspace/drv/char/msim-con/msim-con.c
@@ -70,7 +70,7 @@ static void msim_irq_handler(ipc_call_t *call, void *arg)
 
 	fibril_mutex_lock(&con->buf_lock);
 
-	c = IPC_GET_ARG2(call);
+	c = ipc_get_arg2(call);
 	rc = circ_buf_push(&con->cbuf, &c);
 	if (rc != EOK)
 		ddf_msg(LVL_ERROR, "Buffer overrun");

--- a/uspace/drv/char/msim-con/msim-con.c
+++ b/uspace/drv/char/msim-con/msim-con.c
@@ -70,7 +70,7 @@ static void msim_irq_handler(ipc_call_t *call, void *arg)
 
 	fibril_mutex_lock(&con->buf_lock);
 
-	c = IPC_GET_ARG2(*call);
+	c = IPC_GET_ARG2(call);
 	rc = circ_buf_push(&con->cbuf, &c);
 	if (rc != EOK)
 		ddf_msg(LVL_ERROR, "Buffer overrun");

--- a/uspace/drv/char/ns8250/ns8250.c
+++ b/uspace/drv/char/ns8250/ns8250.c
@@ -1079,7 +1079,7 @@ static errno_t ns8250_set_props(ddf_dev_t *dev, unsigned int baud_rate,
 static void ns8250_default_handler(chardev_srv_t *srv, ipc_call_t *call)
 {
 	ns8250_t *ns8250 = srv_ns8250(srv);
-	sysarg_t method = IPC_GET_IMETHOD(*call);
+	sysarg_t method = IPC_GET_IMETHOD(call);
 	errno_t ret;
 	unsigned int baud_rate, parity, word_length, stop_bits;
 
@@ -1092,10 +1092,10 @@ static void ns8250_default_handler(chardev_srv_t *srv, ipc_call_t *call)
 		break;
 
 	case SERIAL_SET_COM_PROPS:
-		baud_rate = IPC_GET_ARG1(*call);
-		parity = IPC_GET_ARG2(*call);
-		word_length = IPC_GET_ARG3(*call);
-		stop_bits = IPC_GET_ARG4(*call);
+		baud_rate = IPC_GET_ARG1(call);
+		parity = IPC_GET_ARG2(call);
+		word_length = IPC_GET_ARG3(call);
+		stop_bits = IPC_GET_ARG4(call);
 		ret = ns8250_set_props(ns8250->dev, baud_rate, parity, word_length,
 		    stop_bits);
 		async_answer_0(call, ret);

--- a/uspace/drv/char/ns8250/ns8250.c
+++ b/uspace/drv/char/ns8250/ns8250.c
@@ -1079,7 +1079,7 @@ static errno_t ns8250_set_props(ddf_dev_t *dev, unsigned int baud_rate,
 static void ns8250_default_handler(chardev_srv_t *srv, ipc_call_t *call)
 {
 	ns8250_t *ns8250 = srv_ns8250(srv);
-	sysarg_t method = IPC_GET_IMETHOD(call);
+	sysarg_t method = ipc_get_imethod(call);
 	errno_t ret;
 	unsigned int baud_rate, parity, word_length, stop_bits;
 
@@ -1092,10 +1092,10 @@ static void ns8250_default_handler(chardev_srv_t *srv, ipc_call_t *call)
 		break;
 
 	case SERIAL_SET_COM_PROPS:
-		baud_rate = IPC_GET_ARG1(call);
-		parity = IPC_GET_ARG2(call);
-		word_length = IPC_GET_ARG3(call);
-		stop_bits = IPC_GET_ARG4(call);
+		baud_rate = ipc_get_arg1(call);
+		parity = ipc_get_arg2(call);
+		word_length = ipc_get_arg3(call);
+		stop_bits = ipc_get_arg4(call);
 		ret = ns8250_set_props(ns8250->dev, baud_rate, parity, word_length,
 		    stop_bits);
 		async_answer_0(call, ret);

--- a/uspace/drv/char/pc-lpt/pc-lpt.c
+++ b/uspace/drv/char/pc-lpt/pc-lpt.c
@@ -172,7 +172,7 @@ errno_t pc_lpt_add(pc_lpt_t *lpt, pc_lpt_res_t *res)
 
 	return EOK;
 error:
-	if (CAP_HANDLE_VALID(lpt->irq_handle))
+	if (cap_handle_valid(lpt->irq_handle))
 		async_irq_unsubscribe(lpt->irq_handle);
 	if (bound)
 		ddf_fun_unbind(fun);

--- a/uspace/drv/char/pl050/pl050.c
+++ b/uspace/drv/char/pl050/pl050.c
@@ -156,7 +156,7 @@ static void pl050_interrupt(ipc_call_t *call, ddf_dev_t *dev)
 		return;
 	}
 
-	pl050->buffer[pl050->buf_wp] = IPC_GET_ARG2(call);
+	pl050->buffer[pl050->buf_wp] = ipc_get_arg2(call);
 	pl050->buf_wp = nidx;
 	fibril_condvar_broadcast(&pl050->buf_cv);
 	fibril_mutex_unlock(&pl050->buf_lock);

--- a/uspace/drv/char/pl050/pl050.c
+++ b/uspace/drv/char/pl050/pl050.c
@@ -156,7 +156,7 @@ static void pl050_interrupt(ipc_call_t *call, ddf_dev_t *dev)
 		return;
 	}
 
-	pl050->buffer[pl050->buf_wp] = IPC_GET_ARG2(*call);
+	pl050->buffer[pl050->buf_wp] = IPC_GET_ARG2(call);
 	pl050->buf_wp = nidx;
 	fibril_condvar_broadcast(&pl050->buf_cv);
 	fibril_mutex_unlock(&pl050->buf_lock);

--- a/uspace/drv/hid/adb-kbd/adb-kbd.c
+++ b/uspace/drv/hid/adb-kbd/adb-kbd.c
@@ -140,14 +140,14 @@ static void adb_kbd_events(ipc_call_t *icall, void *arg)
 
 		errno_t retval = EOK;
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case ADB_REG_NOTIF:
-			adb_kbd_reg0_data(kbd, IPC_GET_ARG1(&call));
+			adb_kbd_reg0_data(kbd, ipc_get_arg1(&call));
 			break;
 		default:
 			retval = ENOENT;
@@ -204,7 +204,7 @@ static void adb_kbd_conn(ipc_call_t *icall, void *arg)
 
 	while (true) {
 		async_get_call(&call);
-		method = IPC_GET_IMETHOD(&call);
+		method = ipc_get_imethod(&call);
 
 		if (!method) {
 			/* The other side has hung up. */

--- a/uspace/drv/hid/adb-kbd/adb-kbd.c
+++ b/uspace/drv/hid/adb-kbd/adb-kbd.c
@@ -140,14 +140,14 @@ static void adb_kbd_events(ipc_call_t *icall, void *arg)
 
 		errno_t retval = EOK;
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case ADB_REG_NOTIF:
-			adb_kbd_reg0_data(kbd, IPC_GET_ARG1(call));
+			adb_kbd_reg0_data(kbd, IPC_GET_ARG1(&call));
 			break;
 		default:
 			retval = ENOENT;
@@ -204,7 +204,7 @@ static void adb_kbd_conn(ipc_call_t *icall, void *arg)
 
 	while (true) {
 		async_get_call(&call);
-		method = IPC_GET_IMETHOD(call);
+		method = IPC_GET_IMETHOD(&call);
 
 		if (!method) {
 			/* The other side has hung up. */

--- a/uspace/drv/hid/adb-mouse/adb-mouse.c
+++ b/uspace/drv/hid/adb-mouse/adb-mouse.c
@@ -98,14 +98,14 @@ static void adb_mouse_events(ipc_call_t *icall, void *arg)
 
 		errno_t retval = EOK;
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			/* TODO: Handle hangup */
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case ADB_REG_NOTIF:
-			adb_mouse_data(mouse, IPC_GET_ARG1(call));
+			adb_mouse_data(mouse, IPC_GET_ARG1(&call));
 			break;
 		default:
 			retval = ENOENT;
@@ -214,7 +214,7 @@ static void adb_mouse_conn(ipc_call_t *icall, void *arg)
 
 	while (true) {
 		async_get_call(&call);
-		method = IPC_GET_IMETHOD(call);
+		method = IPC_GET_IMETHOD(&call);
 
 		if (!method) {
 			/* The other side has hung up. */

--- a/uspace/drv/hid/adb-mouse/adb-mouse.c
+++ b/uspace/drv/hid/adb-mouse/adb-mouse.c
@@ -98,14 +98,14 @@ static void adb_mouse_events(ipc_call_t *icall, void *arg)
 
 		errno_t retval = EOK;
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			/* TODO: Handle hangup */
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case ADB_REG_NOTIF:
-			adb_mouse_data(mouse, IPC_GET_ARG1(&call));
+			adb_mouse_data(mouse, ipc_get_arg1(&call));
 			break;
 		default:
 			retval = ENOENT;
@@ -214,7 +214,7 @@ static void adb_mouse_conn(ipc_call_t *icall, void *arg)
 
 	while (true) {
 		async_get_call(&call);
-		method = IPC_GET_IMETHOD(&call);
+		method = ipc_get_imethod(&call);
 
 		if (!method) {
 			/* The other side has hung up. */

--- a/uspace/drv/hid/atkbd/atkbd.c
+++ b/uspace/drv/hid/atkbd/atkbd.c
@@ -309,7 +309,7 @@ static errno_t polling(void *arg)
  */
 static void default_connection_handler(ddf_fun_t *fun, ipc_call_t *icall)
 {
-	const sysarg_t method = IPC_GET_IMETHOD(icall);
+	const sysarg_t method = ipc_get_imethod(icall);
 	at_kbd_t *kbd = ddf_dev_data_get(ddf_fun_get_dev(fun));
 	async_sess_t *sess;
 

--- a/uspace/drv/hid/atkbd/atkbd.c
+++ b/uspace/drv/hid/atkbd/atkbd.c
@@ -309,7 +309,7 @@ static errno_t polling(void *arg)
  */
 static void default_connection_handler(ddf_fun_t *fun, ipc_call_t *icall)
 {
-	const sysarg_t method = IPC_GET_IMETHOD(*icall);
+	const sysarg_t method = IPC_GET_IMETHOD(icall);
 	at_kbd_t *kbd = ddf_dev_data_get(ddf_fun_get_dev(fun));
 	async_sess_t *sess;
 

--- a/uspace/drv/hid/ps2mouse/ps2mouse.c
+++ b/uspace/drv/hid/ps2mouse/ps2mouse.c
@@ -428,7 +428,7 @@ static errno_t probe_intellimouse(ps2_mouse_t *mouse, bool buttons)
  */
 void default_connection_handler(ddf_fun_t *fun, ipc_call_t *icall)
 {
-	const sysarg_t method = IPC_GET_IMETHOD(*icall);
+	const sysarg_t method = IPC_GET_IMETHOD(icall);
 	ps2_mouse_t *mouse = ddf_dev_data_get(ddf_fun_get_dev(fun));
 	async_sess_t *sess;
 

--- a/uspace/drv/hid/ps2mouse/ps2mouse.c
+++ b/uspace/drv/hid/ps2mouse/ps2mouse.c
@@ -428,7 +428,7 @@ static errno_t probe_intellimouse(ps2_mouse_t *mouse, bool buttons)
  */
 void default_connection_handler(ddf_fun_t *fun, ipc_call_t *icall)
 {
-	const sysarg_t method = IPC_GET_IMETHOD(icall);
+	const sysarg_t method = ipc_get_imethod(icall);
 	ps2_mouse_t *mouse = ddf_dev_data_get(ddf_fun_get_dev(fun));
 	async_sess_t *sess;
 

--- a/uspace/drv/hid/usbhid/kbd/kbddev.c
+++ b/uspace/drv/hid/usbhid/kbd/kbddev.c
@@ -158,13 +158,13 @@ typedef enum usb_kbd_flags {
  */
 static void default_connection_handler(ddf_fun_t *fun, ipc_call_t *icall)
 {
-	const sysarg_t method = IPC_GET_IMETHOD(*icall);
+	const sysarg_t method = IPC_GET_IMETHOD(icall);
 	usb_kbd_t *kbd_dev = ddf_fun_data_get(fun);
 	async_sess_t *sess;
 
 	switch (method) {
 	case KBDEV_SET_IND:
-		kbd_dev->mods = IPC_GET_ARG1(*icall);
+		kbd_dev->mods = IPC_GET_ARG1(icall);
 		usb_kbd_set_led(kbd_dev->hid_dev, kbd_dev);
 		async_answer_0(icall, EOK);
 		break;

--- a/uspace/drv/hid/usbhid/kbd/kbddev.c
+++ b/uspace/drv/hid/usbhid/kbd/kbddev.c
@@ -158,13 +158,13 @@ typedef enum usb_kbd_flags {
  */
 static void default_connection_handler(ddf_fun_t *fun, ipc_call_t *icall)
 {
-	const sysarg_t method = IPC_GET_IMETHOD(icall);
+	const sysarg_t method = ipc_get_imethod(icall);
 	usb_kbd_t *kbd_dev = ddf_fun_data_get(fun);
 	async_sess_t *sess;
 
 	switch (method) {
 	case KBDEV_SET_IND:
-		kbd_dev->mods = IPC_GET_ARG1(icall);
+		kbd_dev->mods = ipc_get_arg1(icall);
 		usb_kbd_set_led(kbd_dev->hid_dev, kbd_dev);
 		async_answer_0(icall, EOK);
 		break;

--- a/uspace/drv/hid/xtkbd/xtkbd.c
+++ b/uspace/drv/hid/xtkbd/xtkbd.c
@@ -343,7 +343,7 @@ static errno_t polling(void *arg)
  */
 static void default_connection_handler(ddf_fun_t *fun, ipc_call_t *icall)
 {
-	const sysarg_t method = IPC_GET_IMETHOD(*icall);
+	const sysarg_t method = IPC_GET_IMETHOD(icall);
 	xt_kbd_t *kbd = ddf_dev_data_get(ddf_fun_get_dev(fun));
 	unsigned mods;
 	async_sess_t *sess;
@@ -354,7 +354,7 @@ static void default_connection_handler(ddf_fun_t *fun, ipc_call_t *icall)
 		 * XT keyboards do not support setting mods,
 		 * assume AT keyboard with Scan Code Set 1.
 		 */
-		mods = IPC_GET_ARG1(*icall);
+		mods = IPC_GET_ARG1(icall);
 		const uint8_t status = 0 |
 		    ((mods & KM_CAPS_LOCK) ? LI_CAPS : 0) |
 		    ((mods & KM_NUM_LOCK) ? LI_NUM : 0) |

--- a/uspace/drv/hid/xtkbd/xtkbd.c
+++ b/uspace/drv/hid/xtkbd/xtkbd.c
@@ -343,7 +343,7 @@ static errno_t polling(void *arg)
  */
 static void default_connection_handler(ddf_fun_t *fun, ipc_call_t *icall)
 {
-	const sysarg_t method = IPC_GET_IMETHOD(icall);
+	const sysarg_t method = ipc_get_imethod(icall);
 	xt_kbd_t *kbd = ddf_dev_data_get(ddf_fun_get_dev(fun));
 	unsigned mods;
 	async_sess_t *sess;
@@ -354,7 +354,7 @@ static void default_connection_handler(ddf_fun_t *fun, ipc_call_t *icall)
 		 * XT keyboards do not support setting mods,
 		 * assume AT keyboard with Scan Code Set 1.
 		 */
-		mods = IPC_GET_ARG1(icall);
+		mods = ipc_get_arg1(icall);
 		const uint8_t status = 0 |
 		    ((mods & KM_CAPS_LOCK) ? LI_CAPS : 0) |
 		    ((mods & KM_NUM_LOCK) ? LI_NUM : 0) |

--- a/uspace/drv/intctl/apic/apic.c
+++ b/uspace/drv/intctl/apic/apic.c
@@ -178,16 +178,16 @@ static void apic_connection(ipc_call_t *icall, void *arg)
 	while (true) {
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			/* The other side has hung up. */
 			async_answer_0(&call, EOK);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case IRC_ENABLE_INTERRUPT:
 			async_answer_0(&call, apic_enable_irq(apic,
-			    IPC_GET_ARG1(call)));
+			    IPC_GET_ARG1(&call)));
 			break;
 		case IRC_DISABLE_INTERRUPT:
 			/* XXX TODO */

--- a/uspace/drv/intctl/apic/apic.c
+++ b/uspace/drv/intctl/apic/apic.c
@@ -178,16 +178,16 @@ static void apic_connection(ipc_call_t *icall, void *arg)
 	while (true) {
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			/* The other side has hung up. */
 			async_answer_0(&call, EOK);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case IRC_ENABLE_INTERRUPT:
 			async_answer_0(&call, apic_enable_irq(apic,
-			    IPC_GET_ARG1(&call)));
+			    ipc_get_arg1(&call)));
 			break;
 		case IRC_DISABLE_INTERRUPT:
 			/* XXX TODO */

--- a/uspace/drv/intctl/i8259/i8259.c
+++ b/uspace/drv/intctl/i8259/i8259.c
@@ -107,16 +107,16 @@ static void i8259_connection(ipc_call_t *icall, void *arg)
 	while (true) {
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			/* The other side has hung up. */
 			async_answer_0(&call, EOK);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case IRC_ENABLE_INTERRUPT:
 			async_answer_0(&call, pic_enable_irq(i8259,
-			    IPC_GET_ARG1(call)));
+			    IPC_GET_ARG1(&call)));
 			break;
 		case IRC_DISABLE_INTERRUPT:
 			/* XXX TODO */

--- a/uspace/drv/intctl/i8259/i8259.c
+++ b/uspace/drv/intctl/i8259/i8259.c
@@ -107,16 +107,16 @@ static void i8259_connection(ipc_call_t *icall, void *arg)
 	while (true) {
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			/* The other side has hung up. */
 			async_answer_0(&call, EOK);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case IRC_ENABLE_INTERRUPT:
 			async_answer_0(&call, pic_enable_irq(i8259,
-			    IPC_GET_ARG1(&call)));
+			    ipc_get_arg1(&call)));
 			break;
 		case IRC_DISABLE_INTERRUPT:
 			/* XXX TODO */

--- a/uspace/drv/intctl/icp-ic/icp-ic.c
+++ b/uspace/drv/intctl/icp-ic/icp-ic.c
@@ -83,16 +83,16 @@ static void icpic_connection(ipc_call_t *icall, void *arg)
 	while (true) {
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			/* The other side has hung up. */
 			async_answer_0(&call, EOK);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case IRC_ENABLE_INTERRUPT:
 			async_answer_0(&call,
-			    icpic_enable_irq(icpic, IPC_GET_ARG1(call)));
+			    icpic_enable_irq(icpic, IPC_GET_ARG1(&call)));
 			break;
 		case IRC_DISABLE_INTERRUPT:
 			/* XXX TODO */

--- a/uspace/drv/intctl/icp-ic/icp-ic.c
+++ b/uspace/drv/intctl/icp-ic/icp-ic.c
@@ -83,16 +83,16 @@ static void icpic_connection(ipc_call_t *icall, void *arg)
 	while (true) {
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			/* The other side has hung up. */
 			async_answer_0(&call, EOK);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case IRC_ENABLE_INTERRUPT:
 			async_answer_0(&call,
-			    icpic_enable_irq(icpic, IPC_GET_ARG1(&call)));
+			    icpic_enable_irq(icpic, ipc_get_arg1(&call)));
 			break;
 		case IRC_DISABLE_INTERRUPT:
 			/* XXX TODO */

--- a/uspace/drv/intctl/obio/obio.c
+++ b/uspace/drv/intctl/obio/obio.c
@@ -89,9 +89,9 @@ static void obio_connection(ipc_call_t *icall, void *arg)
 
 		async_get_call(&call);
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case IRC_ENABLE_INTERRUPT:
-			inr = IPC_GET_ARG1(&call);
+			inr = ipc_get_arg1(&call);
 			pio_set_64(&obio->regs[OBIO_IMR(inr & INO_MASK)],
 			    1UL << 31, 0);
 			async_answer_0(&call, EOK);
@@ -101,7 +101,7 @@ static void obio_connection(ipc_call_t *icall, void *arg)
 			async_answer_0(&call, EOK);
 			break;
 		case IRC_CLEAR_INTERRUPT:
-			inr = IPC_GET_ARG1(&call);
+			inr = ipc_get_arg1(&call);
 			pio_write_64(&obio->regs[OBIO_CIR(inr & INO_MASK)], 0);
 			async_answer_0(&call, EOK);
 			break;

--- a/uspace/drv/intctl/obio/obio.c
+++ b/uspace/drv/intctl/obio/obio.c
@@ -89,9 +89,9 @@ static void obio_connection(ipc_call_t *icall, void *arg)
 
 		async_get_call(&call);
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case IRC_ENABLE_INTERRUPT:
-			inr = IPC_GET_ARG1(call);
+			inr = IPC_GET_ARG1(&call);
 			pio_set_64(&obio->regs[OBIO_IMR(inr & INO_MASK)],
 			    1UL << 31, 0);
 			async_answer_0(&call, EOK);
@@ -101,7 +101,7 @@ static void obio_connection(ipc_call_t *icall, void *arg)
 			async_answer_0(&call, EOK);
 			break;
 		case IRC_CLEAR_INTERRUPT:
-			inr = IPC_GET_ARG1(call);
+			inr = IPC_GET_ARG1(&call);
 			pio_write_64(&obio->regs[OBIO_CIR(inr & INO_MASK)], 0);
 			async_answer_0(&call, EOK);
 			break;

--- a/uspace/drv/nic/e1k/e1k.c
+++ b/uspace/drv/nic/e1k/e1k.c
@@ -1243,7 +1243,7 @@ static void e1000_interrupt_handler_impl(nic_t *nic, uint32_t icr)
 static void e1000_interrupt_handler(ipc_call_t *icall,
     ddf_dev_t *dev)
 {
-	uint32_t icr = (uint32_t) IPC_GET_ARG2(*icall);
+	uint32_t icr = (uint32_t) IPC_GET_ARG2(icall);
 	nic_t *nic = NIC_DATA_DEV(dev);
 	e1000_t *e1000 = DRIVER_DATA_NIC(nic);
 

--- a/uspace/drv/nic/e1k/e1k.c
+++ b/uspace/drv/nic/e1k/e1k.c
@@ -1243,7 +1243,7 @@ static void e1000_interrupt_handler_impl(nic_t *nic, uint32_t icr)
 static void e1000_interrupt_handler(ipc_call_t *icall,
     ddf_dev_t *dev)
 {
-	uint32_t icr = (uint32_t) IPC_GET_ARG2(icall);
+	uint32_t icr = (uint32_t) ipc_get_arg2(icall);
 	nic_t *nic = NIC_DATA_DEV(dev);
 	e1000_t *e1000 = DRIVER_DATA_NIC(nic);
 

--- a/uspace/drv/nic/ne2k/ne2k.c
+++ b/uspace/drv/nic/ne2k/ne2k.c
@@ -51,14 +51,14 @@
  * @param[in] call The interrupt call.
  *
  */
-#define IRQ_GET_ISR(call)  ((int) IPC_GET_ARG2(call))
+#define IRQ_GET_ISR(call)  ((int) IPC_GET_ARG2(&call))
 
 /** Return the TSR from the interrupt call.
  *
  * @param[in] call The interrupt call.
  *
  */
-#define IRQ_GET_TSR(call)  ((int) IPC_GET_ARG3(call))
+#define IRQ_GET_TSR(call)  ((int) IPC_GET_ARG3(&call))
 
 #define DRIVER_DATA(dev) ((nic_t *) ddf_dev_data_get(dev))
 #define NE2K(device) ((ne2k_t *) nic_get_specific(DRIVER_DATA(device)))

--- a/uspace/drv/nic/ne2k/ne2k.c
+++ b/uspace/drv/nic/ne2k/ne2k.c
@@ -51,14 +51,14 @@
  * @param[in] call The interrupt call.
  *
  */
-#define IRQ_GET_ISR(call)  ((int) IPC_GET_ARG2(&call))
+#define IRQ_GET_ISR(call)  ((int) ipc_get_arg2(&call))
 
 /** Return the TSR from the interrupt call.
  *
  * @param[in] call The interrupt call.
  *
  */
-#define IRQ_GET_TSR(call)  ((int) IPC_GET_ARG3(&call))
+#define IRQ_GET_TSR(call)  ((int) ipc_get_arg3(&call))
 
 #define DRIVER_DATA(dev) ((nic_t *) ddf_dev_data_get(dev))
 #define NE2K(device) ((ne2k_t *) nic_get_specific(DRIVER_DATA(device)))

--- a/uspace/drv/nic/rtl8139/driver.c
+++ b/uspace/drv/nic/rtl8139/driver.c
@@ -826,7 +826,7 @@ static void rtl8139_interrupt_handler(ipc_call_t *icall, ddf_dev_t *dev)
 	assert(dev);
 	assert(icall);
 
-	uint16_t isr = (uint16_t) IPC_GET_ARG2(icall);
+	uint16_t isr = (uint16_t) ipc_get_arg2(icall);
 	nic_t *nic_data = nic_get_from_ddf_dev(dev);
 	rtl8139_t *rtl8139 = nic_get_specific(nic_data);
 

--- a/uspace/drv/nic/rtl8139/driver.c
+++ b/uspace/drv/nic/rtl8139/driver.c
@@ -826,7 +826,7 @@ static void rtl8139_interrupt_handler(ipc_call_t *icall, ddf_dev_t *dev)
 	assert(dev);
 	assert(icall);
 
-	uint16_t isr = (uint16_t) IPC_GET_ARG2(*icall);
+	uint16_t isr = (uint16_t) IPC_GET_ARG2(icall);
 	nic_t *nic_data = nic_get_from_ddf_dev(dev);
 	rtl8139_t *rtl8139 = nic_get_specific(nic_data);
 

--- a/uspace/drv/nic/rtl8169/driver.c
+++ b/uspace/drv/nic/rtl8169/driver.c
@@ -1037,7 +1037,7 @@ static void rtl8169_irq_handler(ipc_call_t *icall, ddf_dev_t *dev)
 	assert(dev);
 	assert(icall);
 
-	uint16_t isr = (uint16_t) IPC_GET_ARG2(icall) & INT_KNOWN;
+	uint16_t isr = (uint16_t) ipc_get_arg2(icall) & INT_KNOWN;
 	nic_t *nic_data = nic_get_from_ddf_dev(dev);
 	rtl8169_t *rtl8169 = nic_get_specific(nic_data);
 

--- a/uspace/drv/nic/rtl8169/driver.c
+++ b/uspace/drv/nic/rtl8169/driver.c
@@ -1037,7 +1037,7 @@ static void rtl8169_irq_handler(ipc_call_t *icall, ddf_dev_t *dev)
 	assert(dev);
 	assert(icall);
 
-	uint16_t isr = (uint16_t) IPC_GET_ARG2(*icall) & INT_KNOWN;
+	uint16_t isr = (uint16_t) IPC_GET_ARG2(icall) & INT_KNOWN;
 	nic_t *nic_data = nic_get_from_ddf_dev(dev);
 	rtl8169_t *rtl8169 = nic_get_specific(nic_data);
 

--- a/uspace/lib/c/generic/async/client.c
+++ b/uspace/lib/c/generic/async/client.c
@@ -215,7 +215,7 @@ void async_reply_received(ipc_call_t *data)
 
 	fibril_rmutex_lock(&message_mutex);
 
-	msg->retval = IPC_GET_RETVAL(data);
+	msg->retval = ipc_get_retval(data);
 
 	/* Copy data inside lock, just in case the call was detached */
 	if ((msg->dataptr) && (data))
@@ -485,19 +485,19 @@ static errno_t async_req_fast(async_exch_t *exch, sysarg_t imethod,
 	async_wait_for(aid, &rc);
 
 	if (r1)
-		*r1 = IPC_GET_ARG1(&result);
+		*r1 = ipc_get_arg1(&result);
 
 	if (r2)
-		*r2 = IPC_GET_ARG2(&result);
+		*r2 = ipc_get_arg2(&result);
 
 	if (r3)
-		*r3 = IPC_GET_ARG3(&result);
+		*r3 = ipc_get_arg3(&result);
 
 	if (r4)
-		*r4 = IPC_GET_ARG4(&result);
+		*r4 = ipc_get_arg4(&result);
 
 	if (r5)
-		*r5 = IPC_GET_ARG5(&result);
+		*r5 = ipc_get_arg5(&result);
 
 	return rc;
 }
@@ -537,19 +537,19 @@ static errno_t async_req_slow(async_exch_t *exch, sysarg_t imethod,
 	async_wait_for(aid, &rc);
 
 	if (r1)
-		*r1 = IPC_GET_ARG1(&result);
+		*r1 = ipc_get_arg1(&result);
 
 	if (r2)
-		*r2 = IPC_GET_ARG2(&result);
+		*r2 = ipc_get_arg2(&result);
 
 	if (r3)
-		*r3 = IPC_GET_ARG3(&result);
+		*r3 = ipc_get_arg3(&result);
 
 	if (r4)
-		*r4 = IPC_GET_ARG4(&result);
+		*r4 = ipc_get_arg4(&result);
 
 	if (r5)
-		*r5 = IPC_GET_ARG5(&result);
+		*r5 = ipc_get_arg5(&result);
 
 	return rc;
 }
@@ -804,7 +804,7 @@ static errno_t async_connect_me_to_internal(cap_phone_handle_t phone,
 	if (rc != EOK)
 		return rc;
 
-	*out_phone = (cap_phone_handle_t) IPC_GET_ARG5(&result);
+	*out_phone = (cap_phone_handle_t) ipc_get_arg5(&result);
 	return EOK;
 }
 

--- a/uspace/lib/c/generic/async/client.c
+++ b/uspace/lib/c/generic/async/client.c
@@ -1259,7 +1259,7 @@ errno_t async_state_change_start(async_exch_t *exch, sysarg_t arg1, sysarg_t arg
     sysarg_t arg3, async_exch_t *other_exch)
 {
 	return async_req_5_0(exch, IPC_M_STATE_CHANGE_AUTHORIZE,
-	    arg1, arg2, arg3, 0, CAP_HANDLE_RAW(other_exch->phone));
+	    arg1, arg2, arg3, 0, cap_handle_raw(other_exch->phone));
 }
 
 /** Lock and get session remote state

--- a/uspace/lib/c/generic/async/client.c
+++ b/uspace/lib/c/generic/async/client.c
@@ -215,7 +215,7 @@ void async_reply_received(ipc_call_t *data)
 
 	fibril_rmutex_lock(&message_mutex);
 
-	msg->retval = IPC_GET_RETVAL(*data);
+	msg->retval = IPC_GET_RETVAL(data);
 
 	/* Copy data inside lock, just in case the call was detached */
 	if ((msg->dataptr) && (data))
@@ -485,19 +485,19 @@ static errno_t async_req_fast(async_exch_t *exch, sysarg_t imethod,
 	async_wait_for(aid, &rc);
 
 	if (r1)
-		*r1 = IPC_GET_ARG1(result);
+		*r1 = IPC_GET_ARG1(&result);
 
 	if (r2)
-		*r2 = IPC_GET_ARG2(result);
+		*r2 = IPC_GET_ARG2(&result);
 
 	if (r3)
-		*r3 = IPC_GET_ARG3(result);
+		*r3 = IPC_GET_ARG3(&result);
 
 	if (r4)
-		*r4 = IPC_GET_ARG4(result);
+		*r4 = IPC_GET_ARG4(&result);
 
 	if (r5)
-		*r5 = IPC_GET_ARG5(result);
+		*r5 = IPC_GET_ARG5(&result);
 
 	return rc;
 }
@@ -537,19 +537,19 @@ static errno_t async_req_slow(async_exch_t *exch, sysarg_t imethod,
 	async_wait_for(aid, &rc);
 
 	if (r1)
-		*r1 = IPC_GET_ARG1(result);
+		*r1 = IPC_GET_ARG1(&result);
 
 	if (r2)
-		*r2 = IPC_GET_ARG2(result);
+		*r2 = IPC_GET_ARG2(&result);
 
 	if (r3)
-		*r3 = IPC_GET_ARG3(result);
+		*r3 = IPC_GET_ARG3(&result);
 
 	if (r4)
-		*r4 = IPC_GET_ARG4(result);
+		*r4 = IPC_GET_ARG4(&result);
 
 	if (r5)
-		*r5 = IPC_GET_ARG5(result);
+		*r5 = IPC_GET_ARG5(&result);
 
 	return rc;
 }
@@ -804,7 +804,7 @@ static errno_t async_connect_me_to_internal(cap_phone_handle_t phone,
 	if (rc != EOK)
 		return rc;
 
-	*out_phone = (cap_phone_handle_t) IPC_GET_ARG5(result);
+	*out_phone = (cap_phone_handle_t) IPC_GET_ARG5(&result);
 	return EOK;
 }
 

--- a/uspace/lib/c/generic/async/server.c
+++ b/uspace/lib/c/generic/async/server.c
@@ -545,7 +545,7 @@ static errno_t route_call(ipc_call_t *call)
 
 	errno_t rc = mpsc_send(conn->msg_channel, call);
 
-	if (IPC_GET_IMETHOD(*call) == IPC_M_PHONE_HUNGUP) {
+	if (IPC_GET_IMETHOD(call) == IPC_M_PHONE_HUNGUP) {
 		/* Close the channel, but let the connection fibril answer. */
 		mpsc_close(conn->msg_channel);
 		// FIXME: Ideally, we should be able to discard/answer the
@@ -656,7 +656,7 @@ static void queue_notification(ipc_call_t *call)
 	}
 
 	ht_link_t *link = hash_table_find(&notification_hash_table,
-	    &IPC_GET_IMETHOD(*call));
+	    &IPC_GET_IMETHOD(call));
 	if (!link) {
 		/* Invalid notification. */
 		// TODO: Make sure this can't happen and turn it into assert.
@@ -870,7 +870,7 @@ bool async_get_call_timeout(ipc_call_t *call, usec_t usecs)
 		 */
 
 		memset(call, 0, sizeof(ipc_call_t));
-		IPC_SET_IMETHOD(*call, IPC_M_PHONE_HUNGUP);
+		IPC_SET_IMETHOD(call, IPC_M_PHONE_HUNGUP);
 		call->cap_handle = CAP_NIL;
 	}
 
@@ -943,14 +943,14 @@ static void handle_call(ipc_call_t *call)
 	}
 
 	/* New connection */
-	if (IPC_GET_IMETHOD(*call) == IPC_M_CONNECT_ME_TO) {
+	if (IPC_GET_IMETHOD(call) == IPC_M_CONNECT_ME_TO) {
 		connection_t *conn = calloc(1, sizeof(*conn));
 		if (!conn) {
 			ipc_answer_0(call->cap_handle, ENOMEM);
 			return;
 		}
 
-		iface_t iface = (iface_t) IPC_GET_ARG1(*call);
+		iface_t iface = (iface_t) IPC_GET_ARG1(call);
 
 		// TODO: Currently ignores all ports but the first one.
 		void *data;
@@ -1220,10 +1220,10 @@ bool async_share_in_receive(ipc_call_t *call, size_t *size)
 
 	async_get_call(call);
 
-	if (IPC_GET_IMETHOD(*call) != IPC_M_SHARE_IN)
+	if (IPC_GET_IMETHOD(call) != IPC_M_SHARE_IN)
 		return false;
 
-	*size = (size_t) IPC_GET_ARG1(*call);
+	*size = (size_t) IPC_GET_ARG1(call);
 	return true;
 }
 
@@ -1275,11 +1275,11 @@ bool async_share_out_receive(ipc_call_t *call, size_t *size,
 
 	async_get_call(call);
 
-	if (IPC_GET_IMETHOD(*call) != IPC_M_SHARE_OUT)
+	if (IPC_GET_IMETHOD(call) != IPC_M_SHARE_OUT)
 		return false;
 
-	*size = (size_t) IPC_GET_ARG2(*call);
-	*flags = (unsigned int) IPC_GET_ARG3(*call);
+	*size = (size_t) IPC_GET_ARG2(call);
+	*flags = (unsigned int) IPC_GET_ARG3(call);
 	return true;
 }
 
@@ -1328,11 +1328,11 @@ bool async_data_read_receive(ipc_call_t *call, size_t *size)
 
 	async_get_call(call);
 
-	if (IPC_GET_IMETHOD(*call) != IPC_M_DATA_READ)
+	if (IPC_GET_IMETHOD(call) != IPC_M_DATA_READ)
 		return false;
 
 	if (size)
-		*size = (size_t) IPC_GET_ARG2(*call);
+		*size = (size_t) IPC_GET_ARG2(call);
 
 	return true;
 }
@@ -1487,11 +1487,11 @@ bool async_data_write_receive(ipc_call_t *call, size_t *size)
 
 	async_get_call(call);
 
-	if (IPC_GET_IMETHOD(*call) != IPC_M_DATA_WRITE)
+	if (IPC_GET_IMETHOD(call) != IPC_M_DATA_WRITE)
 		return false;
 
 	if (size)
-		*size = (size_t) IPC_GET_ARG2(*call);
+		*size = (size_t) IPC_GET_ARG2(call);
 
 	return true;
 }
@@ -1731,9 +1731,9 @@ async_sess_t *async_callback_receive(exch_mgmt_t mgmt)
 	ipc_call_t call;
 	async_get_call(&call);
 
-	cap_phone_handle_t phandle = (cap_handle_t) IPC_GET_ARG5(call);
+	cap_phone_handle_t phandle = (cap_handle_t) IPC_GET_ARG5(&call);
 
-	if ((IPC_GET_IMETHOD(call) != IPC_M_CONNECT_TO_ME) ||
+	if ((IPC_GET_IMETHOD(&call) != IPC_M_CONNECT_TO_ME) ||
 	    !cap_handle_valid((phandle))) {
 		async_answer_0(&call, EINVAL);
 		return NULL;
@@ -1775,9 +1775,9 @@ async_sess_t *async_callback_receive(exch_mgmt_t mgmt)
  */
 async_sess_t *async_callback_receive_start(exch_mgmt_t mgmt, ipc_call_t *call)
 {
-	cap_phone_handle_t phandle = (cap_handle_t) IPC_GET_ARG5(*call);
+	cap_phone_handle_t phandle = (cap_handle_t) IPC_GET_ARG5(call);
 
-	if ((IPC_GET_IMETHOD(*call) != IPC_M_CONNECT_TO_ME) ||
+	if ((IPC_GET_IMETHOD(call) != IPC_M_CONNECT_TO_ME) ||
 	    !cap_handle_valid((phandle)))
 		return NULL;
 
@@ -1802,7 +1802,7 @@ bool async_state_change_receive(ipc_call_t *call)
 
 	async_get_call(call);
 
-	if (IPC_GET_IMETHOD(*call) != IPC_M_STATE_CHANGE_AUTHORIZE)
+	if (IPC_GET_IMETHOD(call) != IPC_M_STATE_CHANGE_AUTHORIZE)
 		return false;
 
 	return true;

--- a/uspace/lib/c/generic/async/server.c
+++ b/uspace/lib/c/generic/async/server.c
@@ -1734,7 +1734,7 @@ async_sess_t *async_callback_receive(exch_mgmt_t mgmt)
 	cap_phone_handle_t phandle = (cap_handle_t) IPC_GET_ARG5(call);
 
 	if ((IPC_GET_IMETHOD(call) != IPC_M_CONNECT_TO_ME) ||
-	    !CAP_HANDLE_VALID((phandle))) {
+	    !cap_handle_valid((phandle))) {
 		async_answer_0(&call, EINVAL);
 		return NULL;
 	}
@@ -1778,7 +1778,7 @@ async_sess_t *async_callback_receive_start(exch_mgmt_t mgmt, ipc_call_t *call)
 	cap_phone_handle_t phandle = (cap_handle_t) IPC_GET_ARG5(*call);
 
 	if ((IPC_GET_IMETHOD(*call) != IPC_M_CONNECT_TO_ME) ||
-	    !CAP_HANDLE_VALID((phandle)))
+	    !cap_handle_valid((phandle)))
 		return NULL;
 
 	async_sess_t *sess = calloc(1, sizeof(async_sess_t));
@@ -1812,7 +1812,7 @@ errno_t async_state_change_finalize(ipc_call_t *call, async_exch_t *other_exch)
 {
 	assert(call);
 
-	return async_answer_1(call, EOK, CAP_HANDLE_RAW(other_exch->phone));
+	return async_answer_1(call, EOK, cap_handle_raw(other_exch->phone));
 }
 
 __noreturn void async_manager(void)

--- a/uspace/lib/c/generic/async/server.c
+++ b/uspace/lib/c/generic/async/server.c
@@ -545,7 +545,7 @@ static errno_t route_call(ipc_call_t *call)
 
 	errno_t rc = mpsc_send(conn->msg_channel, call);
 
-	if (IPC_GET_IMETHOD(call) == IPC_M_PHONE_HUNGUP) {
+	if (ipc_get_imethod(call) == IPC_M_PHONE_HUNGUP) {
 		/* Close the channel, but let the connection fibril answer. */
 		mpsc_close(conn->msg_channel);
 		// FIXME: Ideally, we should be able to discard/answer the
@@ -656,7 +656,7 @@ static void queue_notification(ipc_call_t *call)
 	}
 
 	ht_link_t *link = hash_table_find(&notification_hash_table,
-	    &IPC_GET_IMETHOD(call));
+	    &ipc_get_imethod(call));
 	if (!link) {
 		/* Invalid notification. */
 		// TODO: Make sure this can't happen and turn it into assert.
@@ -870,7 +870,7 @@ bool async_get_call_timeout(ipc_call_t *call, usec_t usecs)
 		 */
 
 		memset(call, 0, sizeof(ipc_call_t));
-		IPC_SET_IMETHOD(call, IPC_M_PHONE_HUNGUP);
+		ipc_set_imethod(call, IPC_M_PHONE_HUNGUP);
 		call->cap_handle = CAP_NIL;
 	}
 
@@ -943,14 +943,14 @@ static void handle_call(ipc_call_t *call)
 	}
 
 	/* New connection */
-	if (IPC_GET_IMETHOD(call) == IPC_M_CONNECT_ME_TO) {
+	if (ipc_get_imethod(call) == IPC_M_CONNECT_ME_TO) {
 		connection_t *conn = calloc(1, sizeof(*conn));
 		if (!conn) {
 			ipc_answer_0(call->cap_handle, ENOMEM);
 			return;
 		}
 
-		iface_t iface = (iface_t) IPC_GET_ARG1(call);
+		iface_t iface = (iface_t) ipc_get_arg1(call);
 
 		// TODO: Currently ignores all ports but the first one.
 		void *data;
@@ -1220,10 +1220,10 @@ bool async_share_in_receive(ipc_call_t *call, size_t *size)
 
 	async_get_call(call);
 
-	if (IPC_GET_IMETHOD(call) != IPC_M_SHARE_IN)
+	if (ipc_get_imethod(call) != IPC_M_SHARE_IN)
 		return false;
 
-	*size = (size_t) IPC_GET_ARG1(call);
+	*size = (size_t) ipc_get_arg1(call);
 	return true;
 }
 
@@ -1275,11 +1275,11 @@ bool async_share_out_receive(ipc_call_t *call, size_t *size,
 
 	async_get_call(call);
 
-	if (IPC_GET_IMETHOD(call) != IPC_M_SHARE_OUT)
+	if (ipc_get_imethod(call) != IPC_M_SHARE_OUT)
 		return false;
 
-	*size = (size_t) IPC_GET_ARG2(call);
-	*flags = (unsigned int) IPC_GET_ARG3(call);
+	*size = (size_t) ipc_get_arg2(call);
+	*flags = (unsigned int) ipc_get_arg3(call);
 	return true;
 }
 
@@ -1328,11 +1328,11 @@ bool async_data_read_receive(ipc_call_t *call, size_t *size)
 
 	async_get_call(call);
 
-	if (IPC_GET_IMETHOD(call) != IPC_M_DATA_READ)
+	if (ipc_get_imethod(call) != IPC_M_DATA_READ)
 		return false;
 
 	if (size)
-		*size = (size_t) IPC_GET_ARG2(call);
+		*size = (size_t) ipc_get_arg2(call);
 
 	return true;
 }
@@ -1487,11 +1487,11 @@ bool async_data_write_receive(ipc_call_t *call, size_t *size)
 
 	async_get_call(call);
 
-	if (IPC_GET_IMETHOD(call) != IPC_M_DATA_WRITE)
+	if (ipc_get_imethod(call) != IPC_M_DATA_WRITE)
 		return false;
 
 	if (size)
-		*size = (size_t) IPC_GET_ARG2(call);
+		*size = (size_t) ipc_get_arg2(call);
 
 	return true;
 }
@@ -1731,9 +1731,9 @@ async_sess_t *async_callback_receive(exch_mgmt_t mgmt)
 	ipc_call_t call;
 	async_get_call(&call);
 
-	cap_phone_handle_t phandle = (cap_handle_t) IPC_GET_ARG5(&call);
+	cap_phone_handle_t phandle = (cap_handle_t) ipc_get_arg5(&call);
 
-	if ((IPC_GET_IMETHOD(&call) != IPC_M_CONNECT_TO_ME) ||
+	if ((ipc_get_imethod(&call) != IPC_M_CONNECT_TO_ME) ||
 	    !cap_handle_valid((phandle))) {
 		async_answer_0(&call, EINVAL);
 		return NULL;
@@ -1775,9 +1775,9 @@ async_sess_t *async_callback_receive(exch_mgmt_t mgmt)
  */
 async_sess_t *async_callback_receive_start(exch_mgmt_t mgmt, ipc_call_t *call)
 {
-	cap_phone_handle_t phandle = (cap_handle_t) IPC_GET_ARG5(call);
+	cap_phone_handle_t phandle = (cap_handle_t) ipc_get_arg5(call);
 
-	if ((IPC_GET_IMETHOD(call) != IPC_M_CONNECT_TO_ME) ||
+	if ((ipc_get_imethod(call) != IPC_M_CONNECT_TO_ME) ||
 	    !cap_handle_valid((phandle)))
 		return NULL;
 
@@ -1802,7 +1802,7 @@ bool async_state_change_receive(ipc_call_t *call)
 
 	async_get_call(call);
 
-	if (IPC_GET_IMETHOD(call) != IPC_M_STATE_CHANGE_AUTHORIZE)
+	if (ipc_get_imethod(call) != IPC_M_STATE_CHANGE_AUTHORIZE)
 		return false;
 
 	return true;

--- a/uspace/lib/c/generic/async/server.c
+++ b/uspace/lib/c/generic/async/server.c
@@ -655,8 +655,8 @@ static void queue_notification(ipc_call_t *call)
 		notification_freelist_total++;
 	}
 
-	ht_link_t *link = hash_table_find(&notification_hash_table,
-	    &ipc_get_imethod(call));
+	sysarg_t imethod = ipc_get_imethod(call);
+	ht_link_t *link = hash_table_find(&notification_hash_table, &imethod);
 	if (!link) {
 		/* Invalid notification. */
 		// TODO: Make sure this can't happen and turn it into assert.

--- a/uspace/lib/c/generic/bd.c
+++ b/uspace/lib/c/generic/bd.c
@@ -205,12 +205,12 @@ static void bd_cb_conn(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		default:
 			async_answer_0(&call, ENOTSUP);
 		}

--- a/uspace/lib/c/generic/bd.c
+++ b/uspace/lib/c/generic/bd.c
@@ -205,12 +205,12 @@ static void bd_cb_conn(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		default:
 			async_answer_0(&call, ENOTSUP);
 		}

--- a/uspace/lib/c/generic/bd_srv.c
+++ b/uspace/lib/c/generic/bd_srv.c
@@ -50,8 +50,8 @@ static void bd_read_blocks_srv(bd_srv_t *srv, ipc_call_t *call)
 	size_t size;
 	errno_t rc;
 
-	ba = MERGE_LOUP32(IPC_GET_ARG1(*call), IPC_GET_ARG2(*call));
-	cnt = IPC_GET_ARG3(*call);
+	ba = MERGE_LOUP32(IPC_GET_ARG1(call), IPC_GET_ARG2(call));
+	cnt = IPC_GET_ARG3(call);
 
 	ipc_call_t rcall;
 	if (!async_data_read_receive(&rcall, &size)) {
@@ -94,7 +94,7 @@ static void bd_read_toc_srv(bd_srv_t *srv, ipc_call_t *call)
 	size_t size;
 	errno_t rc;
 
-	session = IPC_GET_ARG1(*call);
+	session = IPC_GET_ARG1(call);
 
 	ipc_call_t rcall;
 	if (!async_data_read_receive(&rcall, &size)) {
@@ -136,8 +136,8 @@ static void bd_sync_cache_srv(bd_srv_t *srv, ipc_call_t *call)
 	size_t cnt;
 	errno_t rc;
 
-	ba = MERGE_LOUP32(IPC_GET_ARG1(*call), IPC_GET_ARG2(*call));
-	cnt = IPC_GET_ARG3(*call);
+	ba = MERGE_LOUP32(IPC_GET_ARG1(call), IPC_GET_ARG2(call));
+	cnt = IPC_GET_ARG3(call);
 
 	if (srv->srvs->ops->sync_cache == NULL) {
 		async_answer_0(call, ENOTSUP);
@@ -156,8 +156,8 @@ static void bd_write_blocks_srv(bd_srv_t *srv, ipc_call_t *call)
 	size_t size;
 	errno_t rc;
 
-	ba = MERGE_LOUP32(IPC_GET_ARG1(*call), IPC_GET_ARG2(*call));
-	cnt = IPC_GET_ARG3(*call);
+	ba = MERGE_LOUP32(IPC_GET_ARG1(call), IPC_GET_ARG2(call));
+	cnt = IPC_GET_ARG3(call);
 
 	rc = async_data_write_accept(&data, false, 0, 0, 0, &size);
 	if (rc != EOK) {
@@ -246,7 +246,7 @@ errno_t bd_conn(ipc_call_t *icall, bd_srvs_t *srvs)
 	while (true) {
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(call);
+		sysarg_t method = IPC_GET_IMETHOD(&call);
 
 		if (!method) {
 			/* The other side has hung up */

--- a/uspace/lib/c/generic/bd_srv.c
+++ b/uspace/lib/c/generic/bd_srv.c
@@ -50,8 +50,8 @@ static void bd_read_blocks_srv(bd_srv_t *srv, ipc_call_t *call)
 	size_t size;
 	errno_t rc;
 
-	ba = MERGE_LOUP32(IPC_GET_ARG1(call), IPC_GET_ARG2(call));
-	cnt = IPC_GET_ARG3(call);
+	ba = MERGE_LOUP32(ipc_get_arg1(call), ipc_get_arg2(call));
+	cnt = ipc_get_arg3(call);
 
 	ipc_call_t rcall;
 	if (!async_data_read_receive(&rcall, &size)) {
@@ -94,7 +94,7 @@ static void bd_read_toc_srv(bd_srv_t *srv, ipc_call_t *call)
 	size_t size;
 	errno_t rc;
 
-	session = IPC_GET_ARG1(call);
+	session = ipc_get_arg1(call);
 
 	ipc_call_t rcall;
 	if (!async_data_read_receive(&rcall, &size)) {
@@ -136,8 +136,8 @@ static void bd_sync_cache_srv(bd_srv_t *srv, ipc_call_t *call)
 	size_t cnt;
 	errno_t rc;
 
-	ba = MERGE_LOUP32(IPC_GET_ARG1(call), IPC_GET_ARG2(call));
-	cnt = IPC_GET_ARG3(call);
+	ba = MERGE_LOUP32(ipc_get_arg1(call), ipc_get_arg2(call));
+	cnt = ipc_get_arg3(call);
 
 	if (srv->srvs->ops->sync_cache == NULL) {
 		async_answer_0(call, ENOTSUP);
@@ -156,8 +156,8 @@ static void bd_write_blocks_srv(bd_srv_t *srv, ipc_call_t *call)
 	size_t size;
 	errno_t rc;
 
-	ba = MERGE_LOUP32(IPC_GET_ARG1(call), IPC_GET_ARG2(call));
-	cnt = IPC_GET_ARG3(call);
+	ba = MERGE_LOUP32(ipc_get_arg1(call), ipc_get_arg2(call));
+	cnt = ipc_get_arg3(call);
 
 	rc = async_data_write_accept(&data, false, 0, 0, 0, &size);
 	if (rc != EOK) {
@@ -246,7 +246,7 @@ errno_t bd_conn(ipc_call_t *icall, bd_srvs_t *srvs)
 	while (true) {
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(&call);
+		sysarg_t method = ipc_get_imethod(&call);
 
 		if (!method) {
 			/* The other side has hung up */

--- a/uspace/lib/c/generic/devman.c
+++ b/uspace/lib/c/generic/devman.c
@@ -254,7 +254,7 @@ errno_t devman_add_function(const char *name, fun_type_t ftype,
 	async_wait_for(req, &retval);
 	if (retval == EOK) {
 		if (funh != NULL)
-			*funh = (int) IPC_GET_ARG1(&answer);
+			*funh = (int) ipc_get_arg1(&answer);
 	} else {
 		if (funh != NULL)
 			*funh = -1;
@@ -393,7 +393,7 @@ errno_t devman_fun_get_handle(const char *pathname, devman_handle_t *handle,
 	}
 
 	if (handle != NULL)
-		*handle = (devman_handle_t) IPC_GET_ARG1(&answer);
+		*handle = (devman_handle_t) ipc_get_arg1(&answer);
 
 	return retval;
 }
@@ -428,8 +428,8 @@ static errno_t devman_get_str_internal(sysarg_t method, sysarg_t arg1,
 	}
 
 	if (r1 != NULL)
-		*r1 = IPC_GET_ARG1(&answer);
-	act_size = IPC_GET_ARG2(&dreply);
+		*r1 = ipc_get_arg1(&answer);
+	act_size = ipc_get_arg2(&dreply);
 	assert(act_size <= buf_size - 1);
 	buf[act_size] = '\0';
 
@@ -516,7 +516,7 @@ static errno_t devman_get_handles_once(sysarg_t method, sysarg_t arg1,
 		return retval;
 	}
 
-	*act_size = IPC_GET_ARG1(&answer);
+	*act_size = ipc_get_arg1(&answer);
 	return EOK;
 }
 
@@ -662,7 +662,7 @@ errno_t devman_driver_get_handle(const char *drvname, devman_handle_t *handle)
 	}
 
 	if (handle != NULL)
-		*handle = (devman_handle_t) IPC_GET_ARG1(&answer);
+		*handle = (devman_handle_t) ipc_get_arg1(&answer);
 
 	return retval;
 }

--- a/uspace/lib/c/generic/devman.c
+++ b/uspace/lib/c/generic/devman.c
@@ -254,7 +254,7 @@ errno_t devman_add_function(const char *name, fun_type_t ftype,
 	async_wait_for(req, &retval);
 	if (retval == EOK) {
 		if (funh != NULL)
-			*funh = (int) IPC_GET_ARG1(answer);
+			*funh = (int) IPC_GET_ARG1(&answer);
 	} else {
 		if (funh != NULL)
 			*funh = -1;
@@ -393,7 +393,7 @@ errno_t devman_fun_get_handle(const char *pathname, devman_handle_t *handle,
 	}
 
 	if (handle != NULL)
-		*handle = (devman_handle_t) IPC_GET_ARG1(answer);
+		*handle = (devman_handle_t) IPC_GET_ARG1(&answer);
 
 	return retval;
 }
@@ -428,8 +428,8 @@ static errno_t devman_get_str_internal(sysarg_t method, sysarg_t arg1,
 	}
 
 	if (r1 != NULL)
-		*r1 = IPC_GET_ARG1(answer);
-	act_size = IPC_GET_ARG2(dreply);
+		*r1 = IPC_GET_ARG1(&answer);
+	act_size = IPC_GET_ARG2(&dreply);
 	assert(act_size <= buf_size - 1);
 	buf[act_size] = '\0';
 
@@ -516,7 +516,7 @@ static errno_t devman_get_handles_once(sysarg_t method, sysarg_t arg1,
 		return retval;
 	}
 
-	*act_size = IPC_GET_ARG1(answer);
+	*act_size = IPC_GET_ARG1(&answer);
 	return EOK;
 }
 
@@ -662,7 +662,7 @@ errno_t devman_driver_get_handle(const char *drvname, devman_handle_t *handle)
 	}
 
 	if (handle != NULL)
-		*handle = (devman_handle_t) IPC_GET_ARG1(answer);
+		*handle = (devman_handle_t) IPC_GET_ARG1(&answer);
 
 	return retval;
 }

--- a/uspace/lib/c/generic/dnsr.c
+++ b/uspace/lib/c/generic/dnsr.c
@@ -124,7 +124,7 @@ errno_t dnsr_name2host(const char *name, dnsr_hostinfo_t **rinfo, ip_ver_t ver)
 		return retval;
 	}
 
-	size_t act_size = IPC_GET_ARG2(&answer_cname);
+	size_t act_size = ipc_get_arg2(&answer_cname);
 	assert(act_size <= DNSR_NAME_MAX_SIZE);
 
 	cname_buf[act_size] = '\0';

--- a/uspace/lib/c/generic/dnsr.c
+++ b/uspace/lib/c/generic/dnsr.c
@@ -124,7 +124,7 @@ errno_t dnsr_name2host(const char *name, dnsr_hostinfo_t **rinfo, ip_ver_t ver)
 		return retval;
 	}
 
-	size_t act_size = IPC_GET_ARG2(answer_cname);
+	size_t act_size = IPC_GET_ARG2(&answer_cname);
 	assert(act_size <= DNSR_NAME_MAX_SIZE);
 
 	cname_buf[act_size] = '\0';

--- a/uspace/lib/c/generic/inet.c
+++ b/uspace/lib/c/generic/inet.c
@@ -179,8 +179,8 @@ static void inet_ev_recv(ipc_call_t *icall)
 {
 	inet_dgram_t dgram;
 
-	dgram.tos = IPC_GET_ARG1(*icall);
-	dgram.iplink = IPC_GET_ARG2(*icall);
+	dgram.tos = IPC_GET_ARG1(icall);
+	dgram.iplink = IPC_GET_ARG2(icall);
 
 	ipc_call_t call;
 	size_t size;
@@ -239,12 +239,12 @@ static void inet_cb_conn(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case INET_EV_RECV:
 			inet_ev_recv(&call);
 			break;

--- a/uspace/lib/c/generic/inet.c
+++ b/uspace/lib/c/generic/inet.c
@@ -179,8 +179,8 @@ static void inet_ev_recv(ipc_call_t *icall)
 {
 	inet_dgram_t dgram;
 
-	dgram.tos = IPC_GET_ARG1(icall);
-	dgram.iplink = IPC_GET_ARG2(icall);
+	dgram.tos = ipc_get_arg1(icall);
+	dgram.iplink = ipc_get_arg2(icall);
 
 	ipc_call_t call;
 	size_t size;
@@ -239,12 +239,12 @@ static void inet_cb_conn(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case INET_EV_RECV:
 			inet_ev_recv(&call);
 			break;

--- a/uspace/lib/c/generic/inet/tcp.c
+++ b/uspace/lib/c/generic/inet/tcp.c
@@ -231,7 +231,7 @@ errno_t tcp_conn_create(tcp_t *tcp, inet_ep2_t *epp, tcp_cb_t *cb, void *arg,
 	if (rc != EOK)
 		goto error;
 
-	conn_id = IPC_GET_ARG1(&answer);
+	conn_id = ipc_get_arg1(&answer);
 
 	rc = tcp_conn_new(tcp, conn_id, cb, arg, rconn);
 	if (rc != EOK)
@@ -347,7 +347,7 @@ errno_t tcp_listener_create(tcp_t *tcp, inet_ep_t *ep, tcp_listen_cb_t *lcb,
 		goto error;
 
 	lst->tcp = tcp;
-	lst->id = IPC_GET_ARG1(&answer);
+	lst->id = ipc_get_arg1(&answer);
 	lst->lcb = lcb;
 	lst->lcb_arg = larg;
 	lst->cb = cb;
@@ -568,7 +568,7 @@ errno_t tcp_conn_recv(tcp_conn_t *conn, void *buf, size_t bsize, size_t *nrecv)
 		return retval;
 	}
 
-	*nrecv = IPC_GET_ARG1(&answer);
+	*nrecv = ipc_get_arg1(&answer);
 	fibril_mutex_unlock(&conn->lock);
 	return EOK;
 }
@@ -625,7 +625,7 @@ again:
 		return retval;
 	}
 
-	*nrecv = IPC_GET_ARG1(&answer);
+	*nrecv = ipc_get_arg1(&answer);
 	fibril_mutex_unlock(&conn->lock);
 	return EOK;
 }
@@ -642,7 +642,7 @@ static void tcp_ev_connected(tcp_t *tcp, ipc_call_t *icall)
 	sysarg_t conn_id;
 	errno_t rc;
 
-	conn_id = IPC_GET_ARG1(icall);
+	conn_id = ipc_get_arg1(icall);
 
 	rc = tcp_conn_get(tcp, conn_id, &conn);
 	if (rc != EOK) {
@@ -670,7 +670,7 @@ static void tcp_ev_conn_failed(tcp_t *tcp, ipc_call_t *icall)
 	sysarg_t conn_id;
 	errno_t rc;
 
-	conn_id = IPC_GET_ARG1(icall);
+	conn_id = ipc_get_arg1(icall);
 
 	rc = tcp_conn_get(tcp, conn_id, &conn);
 	if (rc != EOK) {
@@ -698,7 +698,7 @@ static void tcp_ev_conn_reset(tcp_t *tcp, ipc_call_t *icall)
 	sysarg_t conn_id;
 	errno_t rc;
 
-	conn_id = IPC_GET_ARG1(icall);
+	conn_id = ipc_get_arg1(icall);
 
 	rc = tcp_conn_get(tcp, conn_id, &conn);
 	if (rc != EOK) {
@@ -726,7 +726,7 @@ static void tcp_ev_data(tcp_t *tcp, ipc_call_t *icall)
 	sysarg_t conn_id;
 	errno_t rc;
 
-	conn_id = IPC_GET_ARG1(icall);
+	conn_id = ipc_get_arg1(icall);
 
 	rc = tcp_conn_get(tcp, conn_id, &conn);
 	if (rc != EOK) {
@@ -770,8 +770,8 @@ static void tcp_ev_new_conn(tcp_t *tcp, ipc_call_t *icall)
 	tcp_in_conn_t *cinfo;
 	errno_t rc;
 
-	lst_id = IPC_GET_ARG1(icall);
-	conn_id = IPC_GET_ARG2(icall);
+	lst_id = ipc_get_arg1(icall);
+	conn_id = ipc_get_arg2(icall);
 
 	rc = tcp_listener_get(tcp, lst_id, &lst);
 	if (rc != EOK) {
@@ -820,13 +820,13 @@ static void tcp_cb_conn(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			/* Hangup*/
 			async_answer_0(&call, EOK);
 			goto out;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case TCP_EV_CONNECTED:
 			tcp_ev_connected(tcp, &call);
 			break;

--- a/uspace/lib/c/generic/inet/tcp.c
+++ b/uspace/lib/c/generic/inet/tcp.c
@@ -231,7 +231,7 @@ errno_t tcp_conn_create(tcp_t *tcp, inet_ep2_t *epp, tcp_cb_t *cb, void *arg,
 	if (rc != EOK)
 		goto error;
 
-	conn_id = IPC_GET_ARG1(answer);
+	conn_id = IPC_GET_ARG1(&answer);
 
 	rc = tcp_conn_new(tcp, conn_id, cb, arg, rconn);
 	if (rc != EOK)
@@ -347,7 +347,7 @@ errno_t tcp_listener_create(tcp_t *tcp, inet_ep_t *ep, tcp_listen_cb_t *lcb,
 		goto error;
 
 	lst->tcp = tcp;
-	lst->id = IPC_GET_ARG1(answer);
+	lst->id = IPC_GET_ARG1(&answer);
 	lst->lcb = lcb;
 	lst->lcb_arg = larg;
 	lst->cb = cb;
@@ -568,7 +568,7 @@ errno_t tcp_conn_recv(tcp_conn_t *conn, void *buf, size_t bsize, size_t *nrecv)
 		return retval;
 	}
 
-	*nrecv = IPC_GET_ARG1(answer);
+	*nrecv = IPC_GET_ARG1(&answer);
 	fibril_mutex_unlock(&conn->lock);
 	return EOK;
 }
@@ -625,7 +625,7 @@ again:
 		return retval;
 	}
 
-	*nrecv = IPC_GET_ARG1(answer);
+	*nrecv = IPC_GET_ARG1(&answer);
 	fibril_mutex_unlock(&conn->lock);
 	return EOK;
 }
@@ -642,7 +642,7 @@ static void tcp_ev_connected(tcp_t *tcp, ipc_call_t *icall)
 	sysarg_t conn_id;
 	errno_t rc;
 
-	conn_id = IPC_GET_ARG1(*icall);
+	conn_id = IPC_GET_ARG1(icall);
 
 	rc = tcp_conn_get(tcp, conn_id, &conn);
 	if (rc != EOK) {
@@ -670,7 +670,7 @@ static void tcp_ev_conn_failed(tcp_t *tcp, ipc_call_t *icall)
 	sysarg_t conn_id;
 	errno_t rc;
 
-	conn_id = IPC_GET_ARG1(*icall);
+	conn_id = IPC_GET_ARG1(icall);
 
 	rc = tcp_conn_get(tcp, conn_id, &conn);
 	if (rc != EOK) {
@@ -698,7 +698,7 @@ static void tcp_ev_conn_reset(tcp_t *tcp, ipc_call_t *icall)
 	sysarg_t conn_id;
 	errno_t rc;
 
-	conn_id = IPC_GET_ARG1(*icall);
+	conn_id = IPC_GET_ARG1(icall);
 
 	rc = tcp_conn_get(tcp, conn_id, &conn);
 	if (rc != EOK) {
@@ -726,7 +726,7 @@ static void tcp_ev_data(tcp_t *tcp, ipc_call_t *icall)
 	sysarg_t conn_id;
 	errno_t rc;
 
-	conn_id = IPC_GET_ARG1(*icall);
+	conn_id = IPC_GET_ARG1(icall);
 
 	rc = tcp_conn_get(tcp, conn_id, &conn);
 	if (rc != EOK) {
@@ -770,8 +770,8 @@ static void tcp_ev_new_conn(tcp_t *tcp, ipc_call_t *icall)
 	tcp_in_conn_t *cinfo;
 	errno_t rc;
 
-	lst_id = IPC_GET_ARG1(*icall);
-	conn_id = IPC_GET_ARG2(*icall);
+	lst_id = IPC_GET_ARG1(icall);
+	conn_id = IPC_GET_ARG2(icall);
 
 	rc = tcp_listener_get(tcp, lst_id, &lst);
 	if (rc != EOK) {
@@ -820,13 +820,13 @@ static void tcp_cb_conn(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			/* Hangup*/
 			async_answer_0(&call, EOK);
 			goto out;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case TCP_EV_CONNECTED:
 			tcp_ev_connected(tcp, &call);
 			break;

--- a/uspace/lib/c/generic/inet/udp.c
+++ b/uspace/lib/c/generic/inet/udp.c
@@ -189,7 +189,7 @@ errno_t udp_assoc_create(udp_t *udp, inet_ep2_t *epp, udp_cb_t *cb, void *arg,
 		goto error;
 
 	assoc->udp = udp;
-	assoc->id = IPC_GET_ARG1(&answer);
+	assoc->id = ipc_get_arg1(&answer);
 	assoc->cb = cb;
 	assoc->cb_arg = arg;
 
@@ -403,8 +403,8 @@ static errno_t udp_rmsg_info(udp_t *udp, udp_rmsg_t *rmsg)
 		return retval;
 
 	rmsg->udp = udp;
-	rmsg->assoc_id = IPC_GET_ARG1(&answer);
-	rmsg->size = IPC_GET_ARG2(&answer);
+	rmsg->assoc_id = ipc_get_arg1(&answer);
+	rmsg->size = ipc_get_arg2(&answer);
 	rmsg->remote_ep = ep;
 	return EOK;
 }
@@ -497,13 +497,13 @@ static void udp_cb_conn(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			/* Hangup */
 			async_answer_0(&call, EOK);
 			goto out;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case UDP_EV_DATA:
 			udp_ev_data(udp, &call);
 			break;

--- a/uspace/lib/c/generic/inet/udp.c
+++ b/uspace/lib/c/generic/inet/udp.c
@@ -189,7 +189,7 @@ errno_t udp_assoc_create(udp_t *udp, inet_ep2_t *epp, udp_cb_t *cb, void *arg,
 		goto error;
 
 	assoc->udp = udp;
-	assoc->id = IPC_GET_ARG1(answer);
+	assoc->id = IPC_GET_ARG1(&answer);
 	assoc->cb = cb;
 	assoc->cb_arg = arg;
 
@@ -403,8 +403,8 @@ static errno_t udp_rmsg_info(udp_t *udp, udp_rmsg_t *rmsg)
 		return retval;
 
 	rmsg->udp = udp;
-	rmsg->assoc_id = IPC_GET_ARG1(answer);
-	rmsg->size = IPC_GET_ARG2(answer);
+	rmsg->assoc_id = IPC_GET_ARG1(&answer);
+	rmsg->size = IPC_GET_ARG2(&answer);
 	rmsg->remote_ep = ep;
 	return EOK;
 }
@@ -497,13 +497,13 @@ static void udp_cb_conn(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			/* Hangup */
 			async_answer_0(&call, EOK);
 			goto out;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case UDP_EV_DATA:
 			udp_ev_data(udp, &call);
 			break;

--- a/uspace/lib/c/generic/inetcfg.c
+++ b/uspace/lib/c/generic/inetcfg.c
@@ -61,7 +61,7 @@ static errno_t inetcfg_get_ids_once(sysarg_t method, sysarg_t arg1,
 		return retval;
 	}
 
-	*act_size = IPC_GET_ARG1(answer);
+	*act_size = IPC_GET_ARG1(&answer);
 	return EOK;
 }
 
@@ -160,7 +160,7 @@ errno_t inetcfg_addr_create_static(const char *name, inet_naddr_t *naddr,
 	errno_t retval;
 	async_wait_for(req, &retval);
 
-	*addr_id = IPC_GET_ARG1(answer);
+	*addr_id = IPC_GET_ARG1(&answer);
 
 	return retval;
 }
@@ -216,12 +216,12 @@ errno_t inetcfg_addr_get(sysarg_t addr_id, inet_addr_info_t *ainfo)
 	if (retval != EOK)
 		return retval;
 
-	size_t act_size = IPC_GET_ARG2(answer_name);
+	size_t act_size = IPC_GET_ARG2(&answer_name);
 	assert(act_size <= LOC_NAME_MAXLEN);
 
 	name_buf[act_size] = '\0';
 
-	ainfo->ilink = IPC_GET_ARG1(answer);
+	ainfo->ilink = IPC_GET_ARG1(&answer);
 	ainfo->name = str_dup(name_buf);
 
 	return EOK;
@@ -243,7 +243,7 @@ errno_t inetcfg_addr_get_id(const char *name, sysarg_t link_id, sysarg_t *addr_i
 	}
 
 	async_wait_for(req, &retval);
-	*addr_id = IPC_GET_ARG1(answer);
+	*addr_id = IPC_GET_ARG1(&answer);
 
 	return retval;
 }
@@ -304,12 +304,12 @@ errno_t inetcfg_link_get(sysarg_t link_id, inet_link_info_t *linfo)
 	if (retval != EOK)
 		return retval;
 
-	act_size = IPC_GET_ARG2(dreply);
+	act_size = IPC_GET_ARG2(&dreply);
 	assert(act_size <= LOC_NAME_MAXLEN);
 	name_buf[act_size] = '\0';
 
 	linfo->name = str_dup(name_buf);
-	linfo->def_mtu = IPC_GET_ARG1(answer);
+	linfo->def_mtu = IPC_GET_ARG1(&answer);
 
 	return EOK;
 }
@@ -358,7 +358,7 @@ errno_t inetcfg_sroute_create(const char *name, inet_naddr_t *dest,
 	errno_t retval;
 	async_wait_for(req, &retval);
 
-	*sroute_id = IPC_GET_ARG1(answer);
+	*sroute_id = IPC_GET_ARG1(&answer);
 
 	return retval;
 }
@@ -427,7 +427,7 @@ errno_t inetcfg_sroute_get(sysarg_t sroute_id, inet_sroute_info_t *srinfo)
 	if (retval != EOK)
 		return retval;
 
-	size_t act_size = IPC_GET_ARG2(answer_name);
+	size_t act_size = IPC_GET_ARG2(&answer_name);
 	assert(act_size <= LOC_NAME_MAXLEN);
 
 	name_buf[act_size] = '\0';
@@ -453,7 +453,7 @@ errno_t inetcfg_sroute_get_id(const char *name, sysarg_t *sroute_id)
 	}
 
 	async_wait_for(req, &retval);
-	*sroute_id = IPC_GET_ARG1(answer);
+	*sroute_id = IPC_GET_ARG1(&answer);
 
 	return retval;
 }

--- a/uspace/lib/c/generic/inetcfg.c
+++ b/uspace/lib/c/generic/inetcfg.c
@@ -61,7 +61,7 @@ static errno_t inetcfg_get_ids_once(sysarg_t method, sysarg_t arg1,
 		return retval;
 	}
 
-	*act_size = IPC_GET_ARG1(&answer);
+	*act_size = ipc_get_arg1(&answer);
 	return EOK;
 }
 
@@ -160,7 +160,7 @@ errno_t inetcfg_addr_create_static(const char *name, inet_naddr_t *naddr,
 	errno_t retval;
 	async_wait_for(req, &retval);
 
-	*addr_id = IPC_GET_ARG1(&answer);
+	*addr_id = ipc_get_arg1(&answer);
 
 	return retval;
 }
@@ -216,12 +216,12 @@ errno_t inetcfg_addr_get(sysarg_t addr_id, inet_addr_info_t *ainfo)
 	if (retval != EOK)
 		return retval;
 
-	size_t act_size = IPC_GET_ARG2(&answer_name);
+	size_t act_size = ipc_get_arg2(&answer_name);
 	assert(act_size <= LOC_NAME_MAXLEN);
 
 	name_buf[act_size] = '\0';
 
-	ainfo->ilink = IPC_GET_ARG1(&answer);
+	ainfo->ilink = ipc_get_arg1(&answer);
 	ainfo->name = str_dup(name_buf);
 
 	return EOK;
@@ -243,7 +243,7 @@ errno_t inetcfg_addr_get_id(const char *name, sysarg_t link_id, sysarg_t *addr_i
 	}
 
 	async_wait_for(req, &retval);
-	*addr_id = IPC_GET_ARG1(&answer);
+	*addr_id = ipc_get_arg1(&answer);
 
 	return retval;
 }
@@ -304,12 +304,12 @@ errno_t inetcfg_link_get(sysarg_t link_id, inet_link_info_t *linfo)
 	if (retval != EOK)
 		return retval;
 
-	act_size = IPC_GET_ARG2(&dreply);
+	act_size = ipc_get_arg2(&dreply);
 	assert(act_size <= LOC_NAME_MAXLEN);
 	name_buf[act_size] = '\0';
 
 	linfo->name = str_dup(name_buf);
-	linfo->def_mtu = IPC_GET_ARG1(&answer);
+	linfo->def_mtu = ipc_get_arg1(&answer);
 
 	return EOK;
 }
@@ -358,7 +358,7 @@ errno_t inetcfg_sroute_create(const char *name, inet_naddr_t *dest,
 	errno_t retval;
 	async_wait_for(req, &retval);
 
-	*sroute_id = IPC_GET_ARG1(&answer);
+	*sroute_id = ipc_get_arg1(&answer);
 
 	return retval;
 }
@@ -427,7 +427,7 @@ errno_t inetcfg_sroute_get(sysarg_t sroute_id, inet_sroute_info_t *srinfo)
 	if (retval != EOK)
 		return retval;
 
-	size_t act_size = IPC_GET_ARG2(&answer_name);
+	size_t act_size = ipc_get_arg2(&answer_name);
 	assert(act_size <= LOC_NAME_MAXLEN);
 
 	name_buf[act_size] = '\0';
@@ -453,7 +453,7 @@ errno_t inetcfg_sroute_get_id(const char *name, sysarg_t *sroute_id)
 	}
 
 	async_wait_for(req, &retval);
-	*sroute_id = IPC_GET_ARG1(&answer);
+	*sroute_id = ipc_get_arg1(&answer);
 
 	return retval;
 }

--- a/uspace/lib/c/generic/inetping.c
+++ b/uspace/lib/c/generic/inetping.c
@@ -153,7 +153,7 @@ static void inetping_ev_recv(ipc_call_t *icall)
 {
 	inetping_sdu_t sdu;
 
-	sdu.seq_no = IPC_GET_ARG1(icall);
+	sdu.seq_no = ipc_get_arg1(icall);
 
 	ipc_call_t call;
 	size_t size;
@@ -212,12 +212,12 @@ static void inetping_cb_conn(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case INETPING_EV_RECV:
 			inetping_ev_recv(&call);
 			break;

--- a/uspace/lib/c/generic/inetping.c
+++ b/uspace/lib/c/generic/inetping.c
@@ -153,7 +153,7 @@ static void inetping_ev_recv(ipc_call_t *icall)
 {
 	inetping_sdu_t sdu;
 
-	sdu.seq_no = IPC_GET_ARG1(*icall);
+	sdu.seq_no = IPC_GET_ARG1(icall);
 
 	ipc_call_t call;
 	size_t size;
@@ -212,12 +212,12 @@ static void inetping_cb_conn(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case INETPING_EV_RECV:
 			inetping_ev_recv(&call);
 			break;

--- a/uspace/lib/c/generic/io/chardev.c
+++ b/uspace/lib/c/generic/io/chardev.c
@@ -124,9 +124,9 @@ errno_t chardev_read(chardev_t *chardev, void *buf, size_t size, size_t *nread,
 		return retval;
 	}
 
-	*nread = IPC_GET_ARG2(answer);
+	*nread = IPC_GET_ARG2(&answer);
 	/* In case of partial success, ARG1 contains the error code */
-	return (errno_t) IPC_GET_ARG1(answer);
+	return (errno_t) IPC_GET_ARG1(&answer);
 
 }
 
@@ -175,9 +175,9 @@ static errno_t chardev_write_once(chardev_t *chardev, const void *data,
 		return retval;
 	}
 
-	*nwritten = IPC_GET_ARG2(answer);
+	*nwritten = IPC_GET_ARG2(&answer);
 	/* In case of partial success, ARG1 contains the error code */
-	return (errno_t) IPC_GET_ARG1(answer);
+	return (errno_t) IPC_GET_ARG1(&answer);
 }
 
 /** Write to character device.

--- a/uspace/lib/c/generic/io/chardev.c
+++ b/uspace/lib/c/generic/io/chardev.c
@@ -124,9 +124,9 @@ errno_t chardev_read(chardev_t *chardev, void *buf, size_t size, size_t *nread,
 		return retval;
 	}
 
-	*nread = IPC_GET_ARG2(&answer);
+	*nread = ipc_get_arg2(&answer);
 	/* In case of partial success, ARG1 contains the error code */
-	return (errno_t) IPC_GET_ARG1(&answer);
+	return (errno_t) ipc_get_arg1(&answer);
 
 }
 
@@ -175,9 +175,9 @@ static errno_t chardev_write_once(chardev_t *chardev, const void *data,
 		return retval;
 	}
 
-	*nwritten = IPC_GET_ARG2(&answer);
+	*nwritten = ipc_get_arg2(&answer);
 	/* In case of partial success, ARG1 contains the error code */
-	return (errno_t) IPC_GET_ARG1(&answer);
+	return (errno_t) ipc_get_arg1(&answer);
 }
 
 /** Write to character device.

--- a/uspace/lib/c/generic/io/chardev_srv.c
+++ b/uspace/lib/c/generic/io/chardev_srv.c
@@ -50,7 +50,7 @@ static void chardev_read_srv(chardev_srv_t *srv, ipc_call_t *icall)
 	chardev_flags_t flags;
 	errno_t rc;
 
-	flags = IPC_GET_ARG1(icall);
+	flags = ipc_get_arg1(icall);
 
 	ipc_call_t call;
 	if (!async_data_read_receive(&call, &size)) {
@@ -153,7 +153,7 @@ errno_t chardev_conn(ipc_call_t *icall, chardev_srvs_t *srvs)
 	while (true) {
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(&call);
+		sysarg_t method = ipc_get_imethod(&call);
 
 		if (!method) {
 			/* The other side has hung up */

--- a/uspace/lib/c/generic/io/chardev_srv.c
+++ b/uspace/lib/c/generic/io/chardev_srv.c
@@ -50,7 +50,7 @@ static void chardev_read_srv(chardev_srv_t *srv, ipc_call_t *icall)
 	chardev_flags_t flags;
 	errno_t rc;
 
-	flags = IPC_GET_ARG1(*icall);
+	flags = IPC_GET_ARG1(icall);
 
 	ipc_call_t call;
 	if (!async_data_read_receive(&call, &size)) {
@@ -153,7 +153,7 @@ errno_t chardev_conn(ipc_call_t *icall, chardev_srvs_t *srvs)
 	while (true) {
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(call);
+		sysarg_t method = IPC_GET_IMETHOD(&call);
 
 		if (!method) {
 			/* The other side has hung up */

--- a/uspace/lib/c/generic/io/con_srv.c
+++ b/uspace/lib/c/generic/io/con_srv.c
@@ -43,20 +43,20 @@
 
 static errno_t console_ev_encode(cons_event_t *event, ipc_call_t *icall)
 {
-	IPC_SET_ARG1(*icall, event->type);
+	IPC_SET_ARG1(icall, event->type);
 
 	switch (event->type) {
 	case CEV_KEY:
-		IPC_SET_ARG2(*icall, event->ev.key.type);
-		IPC_SET_ARG3(*icall, event->ev.key.key);
-		IPC_SET_ARG4(*icall, event->ev.key.mods);
-		IPC_SET_ARG5(*icall, event->ev.key.c);
+		IPC_SET_ARG2(icall, event->ev.key.type);
+		IPC_SET_ARG3(icall, event->ev.key.key);
+		IPC_SET_ARG4(icall, event->ev.key.mods);
+		IPC_SET_ARG5(icall, event->ev.key.c);
 		break;
 	case CEV_POS:
-		IPC_SET_ARG2(*icall, (event->ev.pos.pos_id << 16) | (event->ev.pos.type & 0xffff));
-		IPC_SET_ARG3(*icall, event->ev.pos.btn_num);
-		IPC_SET_ARG4(*icall, event->ev.pos.hpos);
-		IPC_SET_ARG5(*icall, event->ev.pos.vpos);
+		IPC_SET_ARG2(icall, (event->ev.pos.pos_id << 16) | (event->ev.pos.type & 0xffff));
+		IPC_SET_ARG3(icall, event->ev.pos.btn_num);
+		IPC_SET_ARG4(icall, event->ev.pos.hpos);
+		IPC_SET_ARG5(icall, event->ev.pos.vpos);
 		break;
 	default:
 		return EIO;
@@ -157,8 +157,8 @@ static void con_set_pos_srv(con_srv_t *srv, ipc_call_t *icall)
 	sysarg_t col;
 	sysarg_t row;
 
-	col = IPC_GET_ARG1(*icall);
-	row = IPC_GET_ARG2(*icall);
+	col = IPC_GET_ARG1(icall);
+	row = IPC_GET_ARG2(icall);
 
 	if (srv->srvs->ops->set_pos == NULL) {
 		async_answer_0(icall, ENOTSUP);
@@ -217,7 +217,7 @@ static void con_set_style_srv(con_srv_t *srv, ipc_call_t *icall)
 {
 	console_style_t style;
 
-	style = IPC_GET_ARG1(*icall);
+	style = IPC_GET_ARG1(icall);
 
 	if (srv->srvs->ops->set_style == NULL) {
 		async_answer_0(icall, ENOTSUP);
@@ -234,9 +234,9 @@ static void con_set_color_srv(con_srv_t *srv, ipc_call_t *icall)
 	console_color_t fgcolor;
 	console_color_attr_t flags;
 
-	bgcolor = IPC_GET_ARG1(*icall);
-	fgcolor = IPC_GET_ARG2(*icall);
-	flags = IPC_GET_ARG3(*icall);
+	bgcolor = IPC_GET_ARG1(icall);
+	fgcolor = IPC_GET_ARG2(icall);
+	flags = IPC_GET_ARG3(icall);
 
 	if (srv->srvs->ops->set_color == NULL) {
 		async_answer_0(icall, ENOTSUP);
@@ -252,8 +252,8 @@ static void con_set_rgb_color_srv(con_srv_t *srv, ipc_call_t *icall)
 	pixel_t bgcolor;
 	pixel_t fgcolor;
 
-	bgcolor = IPC_GET_ARG1(*icall);
-	fgcolor = IPC_GET_ARG2(*icall);
+	bgcolor = IPC_GET_ARG1(icall);
+	fgcolor = IPC_GET_ARG2(icall);
 
 	if (srv->srvs->ops->set_rgb_color == NULL) {
 		async_answer_0(icall, ENOTSUP);
@@ -268,7 +268,7 @@ static void con_set_cursor_visibility_srv(con_srv_t *srv, ipc_call_t *icall)
 {
 	bool show;
 
-	show = IPC_GET_ARG1(*icall);
+	show = IPC_GET_ARG1(icall);
 
 	if (srv->srvs->ops->set_cursor_visibility == NULL) {
 		async_answer_0(icall, ENOTSUP);
@@ -302,8 +302,8 @@ static void con_get_event_srv(con_srv_t *srv, ipc_call_t *icall)
 		return;
 	}
 
-	async_answer_5(icall, rc, IPC_GET_ARG1(result), IPC_GET_ARG2(result),
-	    IPC_GET_ARG3(result), IPC_GET_ARG4(result), IPC_GET_ARG5(result));
+	async_answer_5(icall, rc, IPC_GET_ARG1(&result), IPC_GET_ARG2(&result),
+	    IPC_GET_ARG3(&result), IPC_GET_ARG4(&result), IPC_GET_ARG5(&result));
 }
 
 static con_srv_t *con_srv_create(con_srvs_t *srvs)
@@ -363,7 +363,7 @@ errno_t con_conn(ipc_call_t *icall, con_srvs_t *srvs)
 		if (!received)
 			break;
 
-		sysarg_t method = IPC_GET_IMETHOD(call);
+		sysarg_t method = IPC_GET_IMETHOD(&call);
 
 		if (!method) {
 			/* The other side has hung up */

--- a/uspace/lib/c/generic/io/con_srv.c
+++ b/uspace/lib/c/generic/io/con_srv.c
@@ -43,20 +43,20 @@
 
 static errno_t console_ev_encode(cons_event_t *event, ipc_call_t *icall)
 {
-	IPC_SET_ARG1(icall, event->type);
+	ipc_set_arg1(icall, event->type);
 
 	switch (event->type) {
 	case CEV_KEY:
-		IPC_SET_ARG2(icall, event->ev.key.type);
-		IPC_SET_ARG3(icall, event->ev.key.key);
-		IPC_SET_ARG4(icall, event->ev.key.mods);
-		IPC_SET_ARG5(icall, event->ev.key.c);
+		ipc_set_arg2(icall, event->ev.key.type);
+		ipc_set_arg3(icall, event->ev.key.key);
+		ipc_set_arg4(icall, event->ev.key.mods);
+		ipc_set_arg5(icall, event->ev.key.c);
 		break;
 	case CEV_POS:
-		IPC_SET_ARG2(icall, (event->ev.pos.pos_id << 16) | (event->ev.pos.type & 0xffff));
-		IPC_SET_ARG3(icall, event->ev.pos.btn_num);
-		IPC_SET_ARG4(icall, event->ev.pos.hpos);
-		IPC_SET_ARG5(icall, event->ev.pos.vpos);
+		ipc_set_arg2(icall, (event->ev.pos.pos_id << 16) | (event->ev.pos.type & 0xffff));
+		ipc_set_arg3(icall, event->ev.pos.btn_num);
+		ipc_set_arg4(icall, event->ev.pos.hpos);
+		ipc_set_arg5(icall, event->ev.pos.vpos);
 		break;
 	default:
 		return EIO;
@@ -157,8 +157,8 @@ static void con_set_pos_srv(con_srv_t *srv, ipc_call_t *icall)
 	sysarg_t col;
 	sysarg_t row;
 
-	col = IPC_GET_ARG1(icall);
-	row = IPC_GET_ARG2(icall);
+	col = ipc_get_arg1(icall);
+	row = ipc_get_arg2(icall);
 
 	if (srv->srvs->ops->set_pos == NULL) {
 		async_answer_0(icall, ENOTSUP);
@@ -217,7 +217,7 @@ static void con_set_style_srv(con_srv_t *srv, ipc_call_t *icall)
 {
 	console_style_t style;
 
-	style = IPC_GET_ARG1(icall);
+	style = ipc_get_arg1(icall);
 
 	if (srv->srvs->ops->set_style == NULL) {
 		async_answer_0(icall, ENOTSUP);
@@ -234,9 +234,9 @@ static void con_set_color_srv(con_srv_t *srv, ipc_call_t *icall)
 	console_color_t fgcolor;
 	console_color_attr_t flags;
 
-	bgcolor = IPC_GET_ARG1(icall);
-	fgcolor = IPC_GET_ARG2(icall);
-	flags = IPC_GET_ARG3(icall);
+	bgcolor = ipc_get_arg1(icall);
+	fgcolor = ipc_get_arg2(icall);
+	flags = ipc_get_arg3(icall);
 
 	if (srv->srvs->ops->set_color == NULL) {
 		async_answer_0(icall, ENOTSUP);
@@ -252,8 +252,8 @@ static void con_set_rgb_color_srv(con_srv_t *srv, ipc_call_t *icall)
 	pixel_t bgcolor;
 	pixel_t fgcolor;
 
-	bgcolor = IPC_GET_ARG1(icall);
-	fgcolor = IPC_GET_ARG2(icall);
+	bgcolor = ipc_get_arg1(icall);
+	fgcolor = ipc_get_arg2(icall);
 
 	if (srv->srvs->ops->set_rgb_color == NULL) {
 		async_answer_0(icall, ENOTSUP);
@@ -268,7 +268,7 @@ static void con_set_cursor_visibility_srv(con_srv_t *srv, ipc_call_t *icall)
 {
 	bool show;
 
-	show = IPC_GET_ARG1(icall);
+	show = ipc_get_arg1(icall);
 
 	if (srv->srvs->ops->set_cursor_visibility == NULL) {
 		async_answer_0(icall, ENOTSUP);
@@ -302,8 +302,8 @@ static void con_get_event_srv(con_srv_t *srv, ipc_call_t *icall)
 		return;
 	}
 
-	async_answer_5(icall, rc, IPC_GET_ARG1(&result), IPC_GET_ARG2(&result),
-	    IPC_GET_ARG3(&result), IPC_GET_ARG4(&result), IPC_GET_ARG5(&result));
+	async_answer_5(icall, rc, ipc_get_arg1(&result), ipc_get_arg2(&result),
+	    ipc_get_arg3(&result), ipc_get_arg4(&result), ipc_get_arg5(&result));
 }
 
 static con_srv_t *con_srv_create(con_srvs_t *srvs)
@@ -363,7 +363,7 @@ errno_t con_conn(ipc_call_t *icall, con_srvs_t *srvs)
 		if (!received)
 			break;
 
-		sysarg_t method = IPC_GET_IMETHOD(&call);
+		sysarg_t method = ipc_get_imethod(&call);
 
 		if (!method) {
 			/* The other side has hung up */

--- a/uspace/lib/c/generic/io/console.c
+++ b/uspace/lib/c/generic/io/console.c
@@ -155,21 +155,21 @@ void console_set_pos(console_ctrl_t *ctrl, sysarg_t col, sysarg_t row)
 
 static errno_t console_ev_decode(ipc_call_t *call, cons_event_t *event)
 {
-	event->type = IPC_GET_ARG1(call);
+	event->type = ipc_get_arg1(call);
 
 	switch (event->type) {
 	case CEV_KEY:
-		event->ev.key.type = IPC_GET_ARG2(call);
-		event->ev.key.key = IPC_GET_ARG3(call);
-		event->ev.key.mods = IPC_GET_ARG4(call);
-		event->ev.key.c = IPC_GET_ARG5(call);
+		event->ev.key.type = ipc_get_arg2(call);
+		event->ev.key.key = ipc_get_arg3(call);
+		event->ev.key.mods = ipc_get_arg4(call);
+		event->ev.key.c = ipc_get_arg5(call);
 		break;
 	case CEV_POS:
-		event->ev.pos.pos_id = IPC_GET_ARG2(call) >> 16;
-		event->ev.pos.type = IPC_GET_ARG2(call) & 0xffff;
-		event->ev.pos.btn_num = IPC_GET_ARG3(call);
-		event->ev.pos.hpos = IPC_GET_ARG4(call);
-		event->ev.pos.vpos = IPC_GET_ARG5(call);
+		event->ev.pos.pos_id = ipc_get_arg2(call) >> 16;
+		event->ev.pos.type = ipc_get_arg2(call) & 0xffff;
+		event->ev.pos.btn_num = ipc_get_arg3(call);
+		event->ev.pos.hpos = ipc_get_arg4(call);
+		event->ev.pos.vpos = ipc_get_arg5(call);
 		break;
 	default:
 		return EIO;

--- a/uspace/lib/c/generic/io/console.c
+++ b/uspace/lib/c/generic/io/console.c
@@ -155,21 +155,21 @@ void console_set_pos(console_ctrl_t *ctrl, sysarg_t col, sysarg_t row)
 
 static errno_t console_ev_decode(ipc_call_t *call, cons_event_t *event)
 {
-	event->type = IPC_GET_ARG1(*call);
+	event->type = IPC_GET_ARG1(call);
 
 	switch (event->type) {
 	case CEV_KEY:
-		event->ev.key.type = IPC_GET_ARG2(*call);
-		event->ev.key.key = IPC_GET_ARG3(*call);
-		event->ev.key.mods = IPC_GET_ARG4(*call);
-		event->ev.key.c = IPC_GET_ARG5(*call);
+		event->ev.key.type = IPC_GET_ARG2(call);
+		event->ev.key.key = IPC_GET_ARG3(call);
+		event->ev.key.mods = IPC_GET_ARG4(call);
+		event->ev.key.c = IPC_GET_ARG5(call);
 		break;
 	case CEV_POS:
-		event->ev.pos.pos_id = IPC_GET_ARG2(*call) >> 16;
-		event->ev.pos.type = IPC_GET_ARG2(*call) & 0xffff;
-		event->ev.pos.btn_num = IPC_GET_ARG3(*call);
-		event->ev.pos.hpos = IPC_GET_ARG4(*call);
-		event->ev.pos.vpos = IPC_GET_ARG5(*call);
+		event->ev.pos.pos_id = IPC_GET_ARG2(call) >> 16;
+		event->ev.pos.type = IPC_GET_ARG2(call) & 0xffff;
+		event->ev.pos.btn_num = IPC_GET_ARG3(call);
+		event->ev.pos.hpos = IPC_GET_ARG4(call);
+		event->ev.pos.vpos = IPC_GET_ARG5(call);
 		break;
 	default:
 		return EIO;

--- a/uspace/lib/c/generic/io/input.c
+++ b/uspace/lib/c/generic/io/input.c
@@ -111,10 +111,10 @@ static void input_ev_key(input_t *input, ipc_call_t *call)
 	wchar_t c;
 	errno_t rc;
 
-	type = IPC_GET_ARG1(call);
-	key = IPC_GET_ARG2(call);
-	mods = IPC_GET_ARG3(call);
-	c = IPC_GET_ARG4(call);
+	type = ipc_get_arg1(call);
+	key = ipc_get_arg2(call);
+	mods = ipc_get_arg3(call);
+	c = ipc_get_arg4(call);
 
 	rc = input->ev_ops->key(input, type, key, mods, c);
 	async_answer_0(call, rc);
@@ -126,8 +126,8 @@ static void input_ev_move(input_t *input, ipc_call_t *call)
 	int dy;
 	errno_t rc;
 
-	dx = IPC_GET_ARG1(call);
-	dy = IPC_GET_ARG2(call);
+	dx = ipc_get_arg1(call);
+	dy = ipc_get_arg2(call);
 
 	rc = input->ev_ops->move(input, dx, dy);
 	async_answer_0(call, rc);
@@ -141,10 +141,10 @@ static void input_ev_abs_move(input_t *input, ipc_call_t *call)
 	unsigned max_y;
 	errno_t rc;
 
-	x = IPC_GET_ARG1(call);
-	y = IPC_GET_ARG2(call);
-	max_x = IPC_GET_ARG3(call);
-	max_y = IPC_GET_ARG4(call);
+	x = ipc_get_arg1(call);
+	y = ipc_get_arg2(call);
+	max_x = ipc_get_arg3(call);
+	max_y = ipc_get_arg4(call);
 
 	rc = input->ev_ops->abs_move(input, x, y, max_x, max_y);
 	async_answer_0(call, rc);
@@ -156,8 +156,8 @@ static void input_ev_button(input_t *input, ipc_call_t *call)
 	int press;
 	errno_t rc;
 
-	bnum = IPC_GET_ARG1(call);
-	press = IPC_GET_ARG2(call);
+	bnum = ipc_get_arg1(call);
+	press = ipc_get_arg2(call);
 
 	rc = input->ev_ops->button(input, bnum, press);
 	async_answer_0(call, rc);
@@ -171,12 +171,12 @@ static void input_cb_conn(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case INPUT_EVENT_ACTIVE:
 			input_ev_active(input, &call);
 			break;

--- a/uspace/lib/c/generic/io/input.c
+++ b/uspace/lib/c/generic/io/input.c
@@ -111,10 +111,10 @@ static void input_ev_key(input_t *input, ipc_call_t *call)
 	wchar_t c;
 	errno_t rc;
 
-	type = IPC_GET_ARG1(*call);
-	key = IPC_GET_ARG2(*call);
-	mods = IPC_GET_ARG3(*call);
-	c = IPC_GET_ARG4(*call);
+	type = IPC_GET_ARG1(call);
+	key = IPC_GET_ARG2(call);
+	mods = IPC_GET_ARG3(call);
+	c = IPC_GET_ARG4(call);
 
 	rc = input->ev_ops->key(input, type, key, mods, c);
 	async_answer_0(call, rc);
@@ -126,8 +126,8 @@ static void input_ev_move(input_t *input, ipc_call_t *call)
 	int dy;
 	errno_t rc;
 
-	dx = IPC_GET_ARG1(*call);
-	dy = IPC_GET_ARG2(*call);
+	dx = IPC_GET_ARG1(call);
+	dy = IPC_GET_ARG2(call);
 
 	rc = input->ev_ops->move(input, dx, dy);
 	async_answer_0(call, rc);
@@ -141,10 +141,10 @@ static void input_ev_abs_move(input_t *input, ipc_call_t *call)
 	unsigned max_y;
 	errno_t rc;
 
-	x = IPC_GET_ARG1(*call);
-	y = IPC_GET_ARG2(*call);
-	max_x = IPC_GET_ARG3(*call);
-	max_y = IPC_GET_ARG4(*call);
+	x = IPC_GET_ARG1(call);
+	y = IPC_GET_ARG2(call);
+	max_x = IPC_GET_ARG3(call);
+	max_y = IPC_GET_ARG4(call);
 
 	rc = input->ev_ops->abs_move(input, x, y, max_x, max_y);
 	async_answer_0(call, rc);
@@ -156,8 +156,8 @@ static void input_ev_button(input_t *input, ipc_call_t *call)
 	int press;
 	errno_t rc;
 
-	bnum = IPC_GET_ARG1(*call);
-	press = IPC_GET_ARG2(*call);
+	bnum = IPC_GET_ARG1(call);
+	press = IPC_GET_ARG2(call);
 
 	rc = input->ev_ops->button(input, bnum, press);
 	async_answer_0(call, rc);
@@ -171,12 +171,12 @@ static void input_cb_conn(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case INPUT_EVENT_ACTIVE:
 			input_ev_active(input, &call);
 			break;

--- a/uspace/lib/c/generic/io/log.c
+++ b/uspace/lib/c/generic/io/log.c
@@ -207,7 +207,7 @@ log_t log_create(const char *name, log_t parent)
 	if ((rc != EOK) || (reg_msg_rc != EOK))
 		return parent;
 
-	return IPC_GET_ARG1(&answer);
+	return ipc_get_arg1(&answer);
 }
 
 /** Write an entry to the log.

--- a/uspace/lib/c/generic/io/log.c
+++ b/uspace/lib/c/generic/io/log.c
@@ -207,7 +207,7 @@ log_t log_create(const char *name, log_t parent)
 	if ((rc != EOK) || (reg_msg_rc != EOK))
 		return parent;
 
-	return IPC_GET_ARG1(answer);
+	return IPC_GET_ARG1(&answer);
 }
 
 /** Write an entry to the log.

--- a/uspace/lib/c/generic/io/output.c
+++ b/uspace/lib/c/generic/io/output.c
@@ -99,7 +99,7 @@ frontbuf_handle_t output_frontbuf_create(async_sess_t *sess,
 	if ((rc != EOK) || (ret != EOK))
 		return 0;
 
-	return (frontbuf_handle_t) IPC_GET_ARG1(&answer);
+	return (frontbuf_handle_t) ipc_get_arg1(&answer);
 }
 
 errno_t output_set_style(async_sess_t *sess, console_style_t style)

--- a/uspace/lib/c/generic/io/output.c
+++ b/uspace/lib/c/generic/io/output.c
@@ -99,7 +99,7 @@ frontbuf_handle_t output_frontbuf_create(async_sess_t *sess,
 	if ((rc != EOK) || (ret != EOK))
 		return 0;
 
-	return (frontbuf_handle_t) IPC_GET_ARG1(answer);
+	return (frontbuf_handle_t) IPC_GET_ARG1(&answer);
 }
 
 errno_t output_set_style(async_sess_t *sess, console_style_t style)

--- a/uspace/lib/c/generic/ipc.c
+++ b/uspace/lib/c/generic/ipc.c
@@ -97,12 +97,12 @@ errno_t ipc_call_async_slow(cap_phone_handle_t phandle, sysarg_t imethod,
 {
 	ipc_call_t data;
 
-	IPC_SET_IMETHOD(&data, imethod);
-	IPC_SET_ARG1(&data, arg1);
-	IPC_SET_ARG2(&data, arg2);
-	IPC_SET_ARG3(&data, arg3);
-	IPC_SET_ARG4(&data, arg4);
-	IPC_SET_ARG5(&data, arg5);
+	ipc_set_imethod(&data, imethod);
+	ipc_set_arg1(&data, arg1);
+	ipc_set_arg2(&data, arg2);
+	ipc_set_arg3(&data, arg3);
+	ipc_set_arg4(&data, arg4);
+	ipc_set_arg5(&data, arg5);
 
 	return __SYSCALL3(SYS_IPC_CALL_ASYNC_SLOW,
 	    cap_handle_raw(phandle), (sysarg_t) &data,
@@ -151,12 +151,12 @@ errno_t ipc_answer_slow(cap_call_handle_t chandle, errno_t retval,
 {
 	ipc_call_t data;
 
-	IPC_SET_RETVAL(&data, retval);
-	IPC_SET_ARG1(&data, arg1);
-	IPC_SET_ARG2(&data, arg2);
-	IPC_SET_ARG3(&data, arg3);
-	IPC_SET_ARG4(&data, arg4);
-	IPC_SET_ARG5(&data, arg5);
+	ipc_set_retval(&data, retval);
+	ipc_set_arg1(&data, arg1);
+	ipc_set_arg2(&data, arg2);
+	ipc_set_arg3(&data, arg3);
+	ipc_set_arg4(&data, arg4);
+	ipc_set_arg5(&data, arg5);
 
 	return (errno_t) __SYSCALL2(SYS_IPC_ANSWER_SLOW,
 	    cap_handle_raw(chandle), (sysarg_t) &data);
@@ -219,12 +219,12 @@ errno_t ipc_forward_slow(cap_call_handle_t chandle, cap_phone_handle_t phandle,
 {
 	ipc_call_t data;
 
-	IPC_SET_IMETHOD(&data, imethod);
-	IPC_SET_ARG1(&data, arg1);
-	IPC_SET_ARG2(&data, arg2);
-	IPC_SET_ARG3(&data, arg3);
-	IPC_SET_ARG4(&data, arg4);
-	IPC_SET_ARG5(&data, arg5);
+	ipc_set_imethod(&data, imethod);
+	ipc_set_arg1(&data, arg1);
+	ipc_set_arg2(&data, arg2);
+	ipc_set_arg3(&data, arg3);
+	ipc_set_arg4(&data, arg4);
+	ipc_set_arg5(&data, arg5);
 
 	return (errno_t) __SYSCALL4(SYS_IPC_FORWARD_SLOW,
 	    cap_handle_raw(chandle), cap_handle_raw(phandle), (sysarg_t) &data,

--- a/uspace/lib/c/generic/ipc.c
+++ b/uspace/lib/c/generic/ipc.c
@@ -97,12 +97,12 @@ errno_t ipc_call_async_slow(cap_phone_handle_t phandle, sysarg_t imethod,
 {
 	ipc_call_t data;
 
-	IPC_SET_IMETHOD(data, imethod);
-	IPC_SET_ARG1(data, arg1);
-	IPC_SET_ARG2(data, arg2);
-	IPC_SET_ARG3(data, arg3);
-	IPC_SET_ARG4(data, arg4);
-	IPC_SET_ARG5(data, arg5);
+	IPC_SET_IMETHOD(&data, imethod);
+	IPC_SET_ARG1(&data, arg1);
+	IPC_SET_ARG2(&data, arg2);
+	IPC_SET_ARG3(&data, arg3);
+	IPC_SET_ARG4(&data, arg4);
+	IPC_SET_ARG5(&data, arg5);
 
 	return __SYSCALL3(SYS_IPC_CALL_ASYNC_SLOW,
 	    cap_handle_raw(phandle), (sysarg_t) &data,
@@ -151,12 +151,12 @@ errno_t ipc_answer_slow(cap_call_handle_t chandle, errno_t retval,
 {
 	ipc_call_t data;
 
-	IPC_SET_RETVAL(data, retval);
-	IPC_SET_ARG1(data, arg1);
-	IPC_SET_ARG2(data, arg2);
-	IPC_SET_ARG3(data, arg3);
-	IPC_SET_ARG4(data, arg4);
-	IPC_SET_ARG5(data, arg5);
+	IPC_SET_RETVAL(&data, retval);
+	IPC_SET_ARG1(&data, arg1);
+	IPC_SET_ARG2(&data, arg2);
+	IPC_SET_ARG3(&data, arg3);
+	IPC_SET_ARG4(&data, arg4);
+	IPC_SET_ARG5(&data, arg5);
 
 	return (errno_t) __SYSCALL2(SYS_IPC_ANSWER_SLOW,
 	    cap_handle_raw(chandle), (sysarg_t) &data);
@@ -219,12 +219,12 @@ errno_t ipc_forward_slow(cap_call_handle_t chandle, cap_phone_handle_t phandle,
 {
 	ipc_call_t data;
 
-	IPC_SET_IMETHOD(data, imethod);
-	IPC_SET_ARG1(data, arg1);
-	IPC_SET_ARG2(data, arg2);
-	IPC_SET_ARG3(data, arg3);
-	IPC_SET_ARG4(data, arg4);
-	IPC_SET_ARG5(data, arg5);
+	IPC_SET_IMETHOD(&data, imethod);
+	IPC_SET_ARG1(&data, arg1);
+	IPC_SET_ARG2(&data, arg2);
+	IPC_SET_ARG3(&data, arg3);
+	IPC_SET_ARG4(&data, arg4);
+	IPC_SET_ARG5(&data, arg5);
 
 	return (errno_t) __SYSCALL4(SYS_IPC_FORWARD_SLOW,
 	    cap_handle_raw(chandle), cap_handle_raw(phandle), (sysarg_t) &data,

--- a/uspace/lib/c/generic/ipc.c
+++ b/uspace/lib/c/generic/ipc.c
@@ -70,7 +70,7 @@ errno_t ipc_call_async_fast(cap_phone_handle_t phandle, sysarg_t imethod,
     sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, void *label)
 {
 	return __SYSCALL6(SYS_IPC_CALL_ASYNC_FAST,
-	    CAP_HANDLE_RAW(phandle), imethod, arg1, arg2, arg3,
+	    cap_handle_raw(phandle), imethod, arg1, arg2, arg3,
 	    (sysarg_t) label);
 }
 
@@ -105,7 +105,7 @@ errno_t ipc_call_async_slow(cap_phone_handle_t phandle, sysarg_t imethod,
 	IPC_SET_ARG5(data, arg5);
 
 	return __SYSCALL3(SYS_IPC_CALL_ASYNC_SLOW,
-	    CAP_HANDLE_RAW(phandle), (sysarg_t) &data,
+	    cap_handle_raw(phandle), (sysarg_t) &data,
 	    (sysarg_t) label);
 }
 
@@ -129,7 +129,7 @@ errno_t ipc_answer_fast(cap_call_handle_t chandle, errno_t retval,
     sysarg_t arg1, sysarg_t arg2, sysarg_t arg3, sysarg_t arg4)
 {
 	return (errno_t) __SYSCALL6(SYS_IPC_ANSWER_FAST,
-	    CAP_HANDLE_RAW(chandle), (sysarg_t) retval, arg1, arg2, arg3, arg4);
+	    cap_handle_raw(chandle), (sysarg_t) retval, arg1, arg2, arg3, arg4);
 }
 
 /** Answer received call (entire payload).
@@ -159,7 +159,7 @@ errno_t ipc_answer_slow(cap_call_handle_t chandle, errno_t retval,
 	IPC_SET_ARG5(data, arg5);
 
 	return (errno_t) __SYSCALL2(SYS_IPC_ANSWER_SLOW,
-	    CAP_HANDLE_RAW(chandle), (sysarg_t) &data);
+	    cap_handle_raw(chandle), (sysarg_t) &data);
 }
 
 /** Interrupt one thread of this task from waiting for IPC.
@@ -185,7 +185,7 @@ errno_t ipc_wait(ipc_call_t *call, sysarg_t usec, unsigned int flags)
  */
 errno_t ipc_hangup(cap_phone_handle_t phandle)
 {
-	return (errno_t) __SYSCALL1(SYS_IPC_HANGUP, CAP_HANDLE_RAW(phandle));
+	return (errno_t) __SYSCALL1(SYS_IPC_HANGUP, cap_handle_raw(phandle));
 }
 
 /** Forward a received call to another destination.
@@ -209,7 +209,7 @@ errno_t ipc_forward_fast(cap_call_handle_t chandle, cap_phone_handle_t phandle,
     sysarg_t imethod, sysarg_t arg1, sysarg_t arg2, unsigned int mode)
 {
 	return (errno_t) __SYSCALL6(SYS_IPC_FORWARD_FAST,
-	    CAP_HANDLE_RAW(chandle), CAP_HANDLE_RAW(phandle), imethod, arg1,
+	    cap_handle_raw(chandle), cap_handle_raw(phandle), imethod, arg1,
 	    arg2, mode);
 }
 
@@ -227,7 +227,7 @@ errno_t ipc_forward_slow(cap_call_handle_t chandle, cap_phone_handle_t phandle,
 	IPC_SET_ARG5(data, arg5);
 
 	return (errno_t) __SYSCALL4(SYS_IPC_FORWARD_SLOW,
-	    CAP_HANDLE_RAW(chandle), CAP_HANDLE_RAW(phandle), (sysarg_t) &data,
+	    cap_handle_raw(chandle), cap_handle_raw(phandle), (sysarg_t) &data,
 	    mode);
 }
 

--- a/uspace/lib/c/generic/iplink.c
+++ b/uspace/lib/c/generic/iplink.c
@@ -247,7 +247,7 @@ static void iplink_ev_recv(iplink_t *iplink, ipc_call_t *icall)
 {
 	iplink_recv_sdu_t sdu;
 
-	ip_ver_t ver = IPC_GET_ARG1(icall);
+	ip_ver_t ver = ipc_get_arg1(icall);
 
 	errno_t rc = async_data_write_accept(&sdu.data, false, 0, 0, 0,
 	    &sdu.size);
@@ -286,12 +286,12 @@ static void iplink_cb_conn(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case IPLINK_EV_RECV:
 			iplink_ev_recv(iplink, &call);
 			break;

--- a/uspace/lib/c/generic/iplink.c
+++ b/uspace/lib/c/generic/iplink.c
@@ -247,7 +247,7 @@ static void iplink_ev_recv(iplink_t *iplink, ipc_call_t *icall)
 {
 	iplink_recv_sdu_t sdu;
 
-	ip_ver_t ver = IPC_GET_ARG1(*icall);
+	ip_ver_t ver = IPC_GET_ARG1(icall);
 
 	errno_t rc = async_data_write_accept(&sdu.data, false, 0, 0, 0,
 	    &sdu.size);
@@ -286,12 +286,12 @@ static void iplink_cb_conn(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case IPLINK_EV_RECV:
 			iplink_ev_recv(iplink, &call);
 			break;

--- a/uspace/lib/c/generic/iplink_srv.c
+++ b/uspace/lib/c/generic/iplink_srv.c
@@ -161,8 +161,8 @@ static void iplink_send_srv(iplink_srv_t *srv, ipc_call_t *icall)
 {
 	iplink_sdu_t sdu;
 
-	sdu.src = IPC_GET_ARG1(*icall);
-	sdu.dest = IPC_GET_ARG2(*icall);
+	sdu.src = IPC_GET_ARG1(icall);
+	sdu.dest = IPC_GET_ARG2(icall);
 
 	errno_t rc = async_data_write_accept(&sdu.data, false, 0, 0, 0,
 	    &sdu.size);
@@ -252,7 +252,7 @@ errno_t iplink_conn(ipc_call_t *icall, void *arg)
 	while (true) {
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(call);
+		sysarg_t method = IPC_GET_IMETHOD(&call);
 
 		if (!method) {
 			/* The other side has hung up */

--- a/uspace/lib/c/generic/iplink_srv.c
+++ b/uspace/lib/c/generic/iplink_srv.c
@@ -161,8 +161,8 @@ static void iplink_send_srv(iplink_srv_t *srv, ipc_call_t *icall)
 {
 	iplink_sdu_t sdu;
 
-	sdu.src = IPC_GET_ARG1(icall);
-	sdu.dest = IPC_GET_ARG2(icall);
+	sdu.src = ipc_get_arg1(icall);
+	sdu.dest = ipc_get_arg2(icall);
 
 	errno_t rc = async_data_write_accept(&sdu.data, false, 0, 0, 0,
 	    &sdu.size);
@@ -252,7 +252,7 @@ errno_t iplink_conn(ipc_call_t *icall, void *arg)
 	while (true) {
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(&call);
+		sysarg_t method = ipc_get_imethod(&call);
 
 		if (!method) {
 			/* The other side has hung up */

--- a/uspace/lib/c/generic/irq.c
+++ b/uspace/lib/c/generic/irq.c
@@ -82,7 +82,7 @@ errno_t ipc_irq_subscribe(int inr, sysarg_t method, const irq_code_t *ucode,
 errno_t ipc_irq_unsubscribe(cap_irq_handle_t cap)
 {
 	return (errno_t) __SYSCALL1(SYS_IPC_IRQ_UNSUBSCRIBE,
-	    CAP_HANDLE_RAW(cap));
+	    cap_handle_raw(cap));
 }
 
 /** @}

--- a/uspace/lib/c/generic/loc.c
+++ b/uspace/lib/c/generic/loc.c
@@ -61,12 +61,12 @@ static void loc_cb_conn(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case LOC_EVENT_CAT_CHANGE:
 			fibril_mutex_lock(&loc_callback_mutex);
 			loc_cat_change_cb_t cb_fun = cat_change_cb;
@@ -302,7 +302,7 @@ errno_t loc_service_register(const char *fqsn, service_id_t *sid)
 	}
 
 	if (sid != NULL)
-		*sid = (service_id_t) IPC_GET_ARG1(answer);
+		*sid = (service_id_t) IPC_GET_ARG1(&answer);
 
 	return retval;
 }
@@ -358,7 +358,7 @@ errno_t loc_service_get_id(const char *fqdn, service_id_t *handle,
 	}
 
 	if (handle != NULL)
-		*handle = (service_id_t) IPC_GET_ARG1(answer);
+		*handle = (service_id_t) IPC_GET_ARG1(&answer);
 
 	return retval;
 }
@@ -403,7 +403,7 @@ static errno_t loc_get_name_internal(sysarg_t method, sysarg_t id, char **name)
 	if (retval != EOK)
 		return retval;
 
-	act_size = IPC_GET_ARG2(dreply);
+	act_size = IPC_GET_ARG2(&dreply);
 	assert(act_size <= LOC_NAME_MAXLEN);
 	name_buf[act_size] = '\0';
 
@@ -491,7 +491,7 @@ errno_t loc_namespace_get_id(const char *name, service_id_t *handle,
 	}
 
 	if (handle != NULL)
-		*handle = (service_id_t) IPC_GET_ARG1(answer);
+		*handle = (service_id_t) IPC_GET_ARG1(&answer);
 
 	return retval;
 }
@@ -540,7 +540,7 @@ errno_t loc_category_get_id(const char *name, category_id_t *cat_id,
 	}
 
 	if (cat_id != NULL)
-		*cat_id = (category_id_t) IPC_GET_ARG1(answer);
+		*cat_id = (category_id_t) IPC_GET_ARG1(&answer);
 
 	return retval;
 }
@@ -777,7 +777,7 @@ static errno_t loc_category_get_ids_once(sysarg_t method, sysarg_t arg1,
 		return retval;
 	}
 
-	*act_size = IPC_GET_ARG1(answer);
+	*act_size = IPC_GET_ARG1(&answer);
 	return EOK;
 }
 

--- a/uspace/lib/c/generic/loc.c
+++ b/uspace/lib/c/generic/loc.c
@@ -61,12 +61,12 @@ static void loc_cb_conn(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case LOC_EVENT_CAT_CHANGE:
 			fibril_mutex_lock(&loc_callback_mutex);
 			loc_cat_change_cb_t cb_fun = cat_change_cb;
@@ -302,7 +302,7 @@ errno_t loc_service_register(const char *fqsn, service_id_t *sid)
 	}
 
 	if (sid != NULL)
-		*sid = (service_id_t) IPC_GET_ARG1(&answer);
+		*sid = (service_id_t) ipc_get_arg1(&answer);
 
 	return retval;
 }
@@ -358,7 +358,7 @@ errno_t loc_service_get_id(const char *fqdn, service_id_t *handle,
 	}
 
 	if (handle != NULL)
-		*handle = (service_id_t) IPC_GET_ARG1(&answer);
+		*handle = (service_id_t) ipc_get_arg1(&answer);
 
 	return retval;
 }
@@ -403,7 +403,7 @@ static errno_t loc_get_name_internal(sysarg_t method, sysarg_t id, char **name)
 	if (retval != EOK)
 		return retval;
 
-	act_size = IPC_GET_ARG2(&dreply);
+	act_size = ipc_get_arg2(&dreply);
 	assert(act_size <= LOC_NAME_MAXLEN);
 	name_buf[act_size] = '\0';
 
@@ -491,7 +491,7 @@ errno_t loc_namespace_get_id(const char *name, service_id_t *handle,
 	}
 
 	if (handle != NULL)
-		*handle = (service_id_t) IPC_GET_ARG1(&answer);
+		*handle = (service_id_t) ipc_get_arg1(&answer);
 
 	return retval;
 }
@@ -540,7 +540,7 @@ errno_t loc_category_get_id(const char *name, category_id_t *cat_id,
 	}
 
 	if (cat_id != NULL)
-		*cat_id = (category_id_t) IPC_GET_ARG1(&answer);
+		*cat_id = (category_id_t) ipc_get_arg1(&answer);
 
 	return retval;
 }
@@ -777,7 +777,7 @@ static errno_t loc_category_get_ids_once(sysarg_t method, sysarg_t arg1,
 		return retval;
 	}
 
-	*act_size = IPC_GET_ARG1(&answer);
+	*act_size = ipc_get_arg1(&answer);
 	return EOK;
 }
 

--- a/uspace/lib/c/generic/pci.c
+++ b/uspace/lib/c/generic/pci.c
@@ -121,7 +121,7 @@ static errno_t pci_get_ids_once(pci_t *pci, sysarg_t method, sysarg_t arg1,
 		return retval;
 	}
 
-	*act_size = IPC_GET_ARG1(answer);
+	*act_size = IPC_GET_ARG1(&answer);
 	return EOK;
 }
 

--- a/uspace/lib/c/generic/pci.c
+++ b/uspace/lib/c/generic/pci.c
@@ -121,7 +121,7 @@ static errno_t pci_get_ids_once(pci_t *pci, sysarg_t method, sysarg_t arg1,
 		return retval;
 	}
 
-	*act_size = IPC_GET_ARG1(&answer);
+	*act_size = ipc_get_arg1(&answer);
 	return EOK;
 }
 

--- a/uspace/lib/c/generic/task.c
+++ b/uspace/lib/c/generic/task.c
@@ -373,8 +373,8 @@ errno_t task_wait(task_wait_t *wait, task_exit_t *texit, int *retval)
 	async_wait_for(wait->aid, &rc);
 
 	if (rc == EOK) {
-		*texit = IPC_GET_ARG1(&wait->result);
-		*retval = IPC_GET_ARG2(&wait->result);
+		*texit = ipc_get_arg1(&wait->result);
+		*retval = ipc_get_arg2(&wait->result);
 	}
 
 	return rc;

--- a/uspace/lib/c/generic/task.c
+++ b/uspace/lib/c/generic/task.c
@@ -373,8 +373,8 @@ errno_t task_wait(task_wait_t *wait, task_exit_t *texit, int *retval)
 	async_wait_for(wait->aid, &rc);
 
 	if (rc == EOK) {
-		*texit = IPC_GET_ARG1(wait->result);
-		*retval = IPC_GET_ARG2(wait->result);
+		*texit = IPC_GET_ARG1(&wait->result);
+		*retval = IPC_GET_ARG2(&wait->result);
 	}
 
 	return rc;

--- a/uspace/lib/c/generic/vbd.c
+++ b/uspace/lib/c/generic/vbd.c
@@ -189,7 +189,7 @@ static errno_t vbd_get_ids_once(vbd_t *vbd, sysarg_t method, sysarg_t arg1,
 		return retval;
 	}
 
-	*act_size = IPC_GET_ARG1(answer);
+	*act_size = IPC_GET_ARG1(&answer);
 	return EOK;
 }
 
@@ -299,7 +299,7 @@ errno_t vbd_part_create(vbd_t *vbd, service_id_t disk, vbd_part_spec_t *pspec,
 	if (retval != EOK)
 		return EIO;
 
-	*rpart = (vbd_part_id_t)IPC_GET_ARG1(answer);
+	*rpart = (vbd_part_id_t)IPC_GET_ARG1(&answer);
 	return EOK;
 
 }

--- a/uspace/lib/c/generic/vbd.c
+++ b/uspace/lib/c/generic/vbd.c
@@ -189,7 +189,7 @@ static errno_t vbd_get_ids_once(vbd_t *vbd, sysarg_t method, sysarg_t arg1,
 		return retval;
 	}
 
-	*act_size = IPC_GET_ARG1(&answer);
+	*act_size = ipc_get_arg1(&answer);
 	return EOK;
 }
 
@@ -299,7 +299,7 @@ errno_t vbd_part_create(vbd_t *vbd, service_id_t disk, vbd_part_spec_t *pspec,
 	if (retval != EOK)
 		return EIO;
 
-	*rpart = (vbd_part_id_t)IPC_GET_ARG1(&answer);
+	*rpart = (vbd_part_id_t)ipc_get_arg1(&answer);
 	return EOK;
 
 }

--- a/uspace/lib/c/generic/vfs/vfs.c
+++ b/uspace/lib/c/generic/vfs/vfs.c
@@ -640,7 +640,7 @@ errno_t vfs_mount(int mp, const char *fs_name, service_id_t serv, const char *op
 	async_wait_for(req, &rc);
 
 	if (mountedfd)
-		*mountedfd = (int) IPC_GET_ARG1(answer);
+		*mountedfd = (int) IPC_GET_ARG1(&answer);
 
 	if (rc != EOK)
 		return rc;
@@ -902,7 +902,7 @@ errno_t vfs_read_short(int file, aoff64_t pos, void *buf, size_t nbyte,
 	if (rc != EOK)
 		return rc;
 
-	*nread = (ssize_t) IPC_GET_ARG1(answer);
+	*nread = (ssize_t) IPC_GET_ARG1(&answer);
 	return EOK;
 }
 
@@ -1282,7 +1282,7 @@ errno_t vfs_walk(int parent, const char *path, int flags, int *handle)
 	if (rc != EOK)
 		return (errno_t) rc;
 
-	*handle = (int) IPC_GET_ARG1(answer);
+	*handle = (int) IPC_GET_ARG1(&answer);
 	return EOK;
 }
 
@@ -1366,7 +1366,7 @@ errno_t vfs_write_short(int file, aoff64_t pos, const void *buf, size_t nbyte,
 	if (rc != EOK)
 		return rc;
 
-	*nwritten = (ssize_t) IPC_GET_ARG1(answer);
+	*nwritten = (ssize_t) IPC_GET_ARG1(&answer);
 	return EOK;
 }
 

--- a/uspace/lib/c/generic/vfs/vfs.c
+++ b/uspace/lib/c/generic/vfs/vfs.c
@@ -640,7 +640,7 @@ errno_t vfs_mount(int mp, const char *fs_name, service_id_t serv, const char *op
 	async_wait_for(req, &rc);
 
 	if (mountedfd)
-		*mountedfd = (int) IPC_GET_ARG1(&answer);
+		*mountedfd = (int) ipc_get_arg1(&answer);
 
 	if (rc != EOK)
 		return rc;
@@ -902,7 +902,7 @@ errno_t vfs_read_short(int file, aoff64_t pos, void *buf, size_t nbyte,
 	if (rc != EOK)
 		return rc;
 
-	*nread = (ssize_t) IPC_GET_ARG1(&answer);
+	*nread = (ssize_t) ipc_get_arg1(&answer);
 	return EOK;
 }
 
@@ -1282,7 +1282,7 @@ errno_t vfs_walk(int parent, const char *path, int flags, int *handle)
 	if (rc != EOK)
 		return (errno_t) rc;
 
-	*handle = (int) IPC_GET_ARG1(&answer);
+	*handle = (int) ipc_get_arg1(&answer);
 	return EOK;
 }
 
@@ -1366,7 +1366,7 @@ errno_t vfs_write_short(int file, aoff64_t pos, const void *buf, size_t nbyte,
 	if (rc != EOK)
 		return rc;
 
-	*nwritten = (ssize_t) IPC_GET_ARG1(&answer);
+	*nwritten = (ssize_t) ipc_get_arg1(&answer);
 	return EOK;
 }
 

--- a/uspace/lib/c/generic/vol.c
+++ b/uspace/lib/c/generic/vol.c
@@ -126,7 +126,7 @@ static errno_t vol_get_ids_once(vol_t *vol, sysarg_t method, sysarg_t arg1,
 		return retval;
 	}
 
-	*act_size = IPC_GET_ARG1(&answer);
+	*act_size = ipc_get_arg1(&answer);
 	return EOK;
 }
 

--- a/uspace/lib/c/generic/vol.c
+++ b/uspace/lib/c/generic/vol.c
@@ -126,7 +126,7 @@ static errno_t vol_get_ids_once(vol_t *vol, sysarg_t method, sysarg_t arg1,
 		return retval;
 	}
 
-	*act_size = IPC_GET_ARG1(answer);
+	*act_size = IPC_GET_ARG1(&answer);
 	return EOK;
 }
 

--- a/uspace/lib/c/include/ipc/dev_iface.h
+++ b/uspace/lib/c/include/ipc/dev_iface.h
@@ -90,9 +90,9 @@ typedef enum {
  * for indexing into interfaces.
  */
 
-#define DEV_IPC_GET_ARG1(call) IPC_GET_ARG2((call))
-#define DEV_IPC_GET_ARG2(call) IPC_GET_ARG3((call))
-#define DEV_IPC_GET_ARG3(call) IPC_GET_ARG4((call))
-#define DEV_IPC_GET_ARG4(call) IPC_GET_ARG5((call))
+#define DEV_IPC_GET_ARG1(call) IPC_GET_ARG2(&(call))
+#define DEV_IPC_GET_ARG2(call) IPC_GET_ARG3(&(call))
+#define DEV_IPC_GET_ARG3(call) IPC_GET_ARG4(&(call))
+#define DEV_IPC_GET_ARG4(call) IPC_GET_ARG5(&(call))
 
 #endif

--- a/uspace/lib/c/include/ipc/dev_iface.h
+++ b/uspace/lib/c/include/ipc/dev_iface.h
@@ -90,9 +90,9 @@ typedef enum {
  * for indexing into interfaces.
  */
 
-#define DEV_IPC_GET_ARG1(call) IPC_GET_ARG2(&(call))
-#define DEV_IPC_GET_ARG2(call) IPC_GET_ARG3(&(call))
-#define DEV_IPC_GET_ARG3(call) IPC_GET_ARG4(&(call))
-#define DEV_IPC_GET_ARG4(call) IPC_GET_ARG5(&(call))
+#define DEV_IPC_GET_ARG1(call) ipc_get_arg2(&(call))
+#define DEV_IPC_GET_ARG2(call) ipc_get_arg3(&(call))
+#define DEV_IPC_GET_ARG3(call) ipc_get_arg4(&(call))
+#define DEV_IPC_GET_ARG4(call) ipc_get_arg5(&(call))
 
 #endif

--- a/uspace/lib/drv/generic/driver.c
+++ b/uspace/lib/drv/generic/driver.c
@@ -118,8 +118,8 @@ static ddf_fun_t *driver_get_function(devman_handle_t handle)
 
 static void driver_dev_add(ipc_call_t *icall)
 {
-	devman_handle_t dev_handle = IPC_GET_ARG1(*icall);
-	devman_handle_t parent_fun_handle = IPC_GET_ARG2(*icall);
+	devman_handle_t dev_handle = IPC_GET_ARG1(icall);
+	devman_handle_t parent_fun_handle = IPC_GET_ARG2(icall);
 
 	char *dev_name = NULL;
 	errno_t rc = async_data_write_accept((void **) &dev_name, true, 0, 0, 0, 0);
@@ -172,7 +172,7 @@ static void driver_dev_add(ipc_call_t *icall)
 
 static void driver_dev_remove(ipc_call_t *icall)
 {
-	devman_handle_t devh = IPC_GET_ARG1(*icall);
+	devman_handle_t devh = IPC_GET_ARG1(icall);
 
 	fibril_mutex_lock(&devices_mutex);
 	ddf_dev_t *dev = driver_get_device(devh);
@@ -205,7 +205,7 @@ static void driver_dev_remove(ipc_call_t *icall)
 
 static void driver_dev_gone(ipc_call_t *icall)
 {
-	devman_handle_t devh = IPC_GET_ARG1(*icall);
+	devman_handle_t devh = IPC_GET_ARG1(icall);
 
 	fibril_mutex_lock(&devices_mutex);
 	ddf_dev_t *dev = driver_get_device(devh);
@@ -238,7 +238,7 @@ static void driver_dev_gone(ipc_call_t *icall)
 
 static void driver_fun_online(ipc_call_t *icall)
 {
-	devman_handle_t funh = IPC_GET_ARG1(*icall);
+	devman_handle_t funh = IPC_GET_ARG1(icall);
 
 	/*
 	 * Look the function up. Bump reference count so that
@@ -273,7 +273,7 @@ static void driver_fun_online(ipc_call_t *icall)
 
 static void driver_fun_offline(ipc_call_t *icall)
 {
-	devman_handle_t funh = IPC_GET_ARG1(*icall);
+	devman_handle_t funh = IPC_GET_ARG1(icall);
 
 	/*
 	 * Look the function up. Bump reference count so that
@@ -342,12 +342,12 @@ static void driver_connection_devman(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case DRIVER_DEV_ADD:
 			driver_dev_add(&call);
 			break;
@@ -384,7 +384,7 @@ static void driver_connection_gen(ipc_call_t *icall, bool drv)
 	 * Answer the first IPC_M_CONNECT_ME_TO call and remember the handle of
 	 * the device to which the client connected.
 	 */
-	devman_handle_t handle = IPC_GET_ARG2(*icall);
+	devman_handle_t handle = IPC_GET_ARG2(icall);
 
 	fibril_mutex_lock(&functions_mutex);
 	ddf_fun_t *fun = driver_get_function(handle);
@@ -428,7 +428,7 @@ static void driver_connection_gen(ipc_call_t *icall, bool drv)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		sysarg_t method = IPC_GET_IMETHOD(call);
+		sysarg_t method = IPC_GET_IMETHOD(&call);
 
 		if (!method) {
 			/* Close device function */
@@ -482,7 +482,7 @@ static void driver_connection_gen(ipc_call_t *icall, bool drv)
 		assert(rem_iface != NULL);
 
 		/* get the method of the remote interface */
-		sysarg_t iface_method_idx = IPC_GET_ARG1(call);
+		sysarg_t iface_method_idx = IPC_GET_ARG1(&call);
 		remote_iface_func_ptr_t iface_method_ptr =
 		    get_remote_method(rem_iface, iface_method_idx);
 		if (iface_method_ptr == NULL) {

--- a/uspace/lib/drv/generic/driver.c
+++ b/uspace/lib/drv/generic/driver.c
@@ -118,8 +118,8 @@ static ddf_fun_t *driver_get_function(devman_handle_t handle)
 
 static void driver_dev_add(ipc_call_t *icall)
 {
-	devman_handle_t dev_handle = IPC_GET_ARG1(icall);
-	devman_handle_t parent_fun_handle = IPC_GET_ARG2(icall);
+	devman_handle_t dev_handle = ipc_get_arg1(icall);
+	devman_handle_t parent_fun_handle = ipc_get_arg2(icall);
 
 	char *dev_name = NULL;
 	errno_t rc = async_data_write_accept((void **) &dev_name, true, 0, 0, 0, 0);
@@ -172,7 +172,7 @@ static void driver_dev_add(ipc_call_t *icall)
 
 static void driver_dev_remove(ipc_call_t *icall)
 {
-	devman_handle_t devh = IPC_GET_ARG1(icall);
+	devman_handle_t devh = ipc_get_arg1(icall);
 
 	fibril_mutex_lock(&devices_mutex);
 	ddf_dev_t *dev = driver_get_device(devh);
@@ -205,7 +205,7 @@ static void driver_dev_remove(ipc_call_t *icall)
 
 static void driver_dev_gone(ipc_call_t *icall)
 {
-	devman_handle_t devh = IPC_GET_ARG1(icall);
+	devman_handle_t devh = ipc_get_arg1(icall);
 
 	fibril_mutex_lock(&devices_mutex);
 	ddf_dev_t *dev = driver_get_device(devh);
@@ -238,7 +238,7 @@ static void driver_dev_gone(ipc_call_t *icall)
 
 static void driver_fun_online(ipc_call_t *icall)
 {
-	devman_handle_t funh = IPC_GET_ARG1(icall);
+	devman_handle_t funh = ipc_get_arg1(icall);
 
 	/*
 	 * Look the function up. Bump reference count so that
@@ -273,7 +273,7 @@ static void driver_fun_online(ipc_call_t *icall)
 
 static void driver_fun_offline(ipc_call_t *icall)
 {
-	devman_handle_t funh = IPC_GET_ARG1(icall);
+	devman_handle_t funh = ipc_get_arg1(icall);
 
 	/*
 	 * Look the function up. Bump reference count so that
@@ -342,12 +342,12 @@ static void driver_connection_devman(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case DRIVER_DEV_ADD:
 			driver_dev_add(&call);
 			break;
@@ -384,7 +384,7 @@ static void driver_connection_gen(ipc_call_t *icall, bool drv)
 	 * Answer the first IPC_M_CONNECT_ME_TO call and remember the handle of
 	 * the device to which the client connected.
 	 */
-	devman_handle_t handle = IPC_GET_ARG2(icall);
+	devman_handle_t handle = ipc_get_arg2(icall);
 
 	fibril_mutex_lock(&functions_mutex);
 	ddf_fun_t *fun = driver_get_function(handle);
@@ -428,7 +428,7 @@ static void driver_connection_gen(ipc_call_t *icall, bool drv)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		sysarg_t method = IPC_GET_IMETHOD(&call);
+		sysarg_t method = ipc_get_imethod(&call);
 
 		if (!method) {
 			/* Close device function */
@@ -482,7 +482,7 @@ static void driver_connection_gen(ipc_call_t *icall, bool drv)
 		assert(rem_iface != NULL);
 
 		/* get the method of the remote interface */
-		sysarg_t iface_method_idx = IPC_GET_ARG1(&call);
+		sysarg_t iface_method_idx = ipc_get_arg1(&call);
 		remote_iface_func_ptr_t iface_method_ptr =
 		    get_remote_method(rem_iface, iface_method_idx);
 		if (iface_method_ptr == NULL) {

--- a/uspace/lib/drv/generic/remote_ieee80211.c
+++ b/uspace/lib/drv/generic/remote_ieee80211.c
@@ -275,7 +275,7 @@ static void remote_ieee80211_get_scan_results(ddf_fun_t *fun, void *iface,
 	ieee80211_scan_results_t scan_results;
 	memset(&scan_results, 0, sizeof(ieee80211_scan_results_t));
 
-	bool now = IPC_GET_ARG2(*call);
+	bool now = IPC_GET_ARG2(call);
 
 	errno_t rc = ieee80211_iface->get_scan_results(fun, &scan_results, now);
 	if (rc == EOK) {

--- a/uspace/lib/drv/generic/remote_ieee80211.c
+++ b/uspace/lib/drv/generic/remote_ieee80211.c
@@ -275,7 +275,7 @@ static void remote_ieee80211_get_scan_results(ddf_fun_t *fun, void *iface,
 	ieee80211_scan_results_t scan_results;
 	memset(&scan_results, 0, sizeof(ieee80211_scan_results_t));
 
-	bool now = IPC_GET_ARG2(call);
+	bool now = ipc_get_arg2(call);
 
 	errno_t rc = ieee80211_iface->get_scan_results(fun, &scan_results, now);
 	if (rc == EOK) {

--- a/uspace/lib/drv/generic/remote_nic.c
+++ b/uspace/lib/drv/generic/remote_nic.c
@@ -1009,7 +1009,7 @@ errno_t nic_wol_virtue_add(async_sess_t *dev_sess, nic_wv_type_t type,
 	async_exchange_end(exch);
 	async_wait_for(message_id, &res);
 
-	*id = IPC_GET_ARG1(result);
+	*id = IPC_GET_ARG1(&result);
 	return res;
 }
 
@@ -1384,7 +1384,7 @@ static void remote_nic_set_state(ddf_fun_t *dev, void *iface,
 	nic_iface_t *nic_iface = (nic_iface_t *) iface;
 	assert(nic_iface->set_state);
 
-	nic_device_state_t state = (nic_device_state_t) IPC_GET_ARG2(*call);
+	nic_device_state_t state = (nic_device_state_t) IPC_GET_ARG2(call);
 
 	errno_t rc = nic_iface->set_state(dev, state);
 	async_answer_0(call, rc);
@@ -1568,9 +1568,9 @@ static void remote_nic_set_operation_mode(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	int speed = (int) IPC_GET_ARG2(*call);
-	nic_channel_mode_t duplex = (nic_channel_mode_t) IPC_GET_ARG3(*call);
-	nic_role_t role = (nic_role_t) IPC_GET_ARG4(*call);
+	int speed = (int) IPC_GET_ARG2(call);
+	nic_channel_mode_t duplex = (nic_channel_mode_t) IPC_GET_ARG3(call);
+	nic_role_t role = (nic_role_t) IPC_GET_ARG4(call);
 
 	errno_t rc = nic_iface->set_operation_mode(dev, speed, duplex, role);
 	async_answer_0(call, rc);
@@ -1585,7 +1585,7 @@ static void remote_nic_autoneg_enable(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	uint32_t advertisement = (uint32_t) IPC_GET_ARG2(*call);
+	uint32_t advertisement = (uint32_t) IPC_GET_ARG2(call);
 
 	errno_t rc = nic_iface->autoneg_enable(dev, advertisement);
 	async_answer_0(call, rc);
@@ -1663,9 +1663,9 @@ static void remote_nic_set_pause(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	int allow_send = (int) IPC_GET_ARG2(*call);
-	int allow_receive = (int) IPC_GET_ARG3(*call);
-	uint16_t pause = (uint16_t) IPC_GET_ARG4(*call);
+	int allow_send = (int) IPC_GET_ARG2(call);
+	int allow_receive = (int) IPC_GET_ARG3(call);
+	uint16_t pause = (uint16_t) IPC_GET_ARG4(call);
 
 	errno_t rc = nic_iface->set_pause(dev, allow_send, allow_receive,
 	    pause);
@@ -1681,7 +1681,7 @@ static void remote_nic_unicast_get_mode(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	size_t max_count = IPC_GET_ARG2(*call);
+	size_t max_count = IPC_GET_ARG2(call);
 	nic_address_t *address_list = NULL;
 
 	if (max_count != 0) {
@@ -1732,8 +1732,8 @@ static void remote_nic_unicast_set_mode(ddf_fun_t *dev, void *iface,
 	nic_iface_t *nic_iface = (nic_iface_t *) iface;
 
 	size_t length;
-	nic_unicast_mode_t mode = IPC_GET_ARG2(*call);
-	size_t address_count = IPC_GET_ARG3(*call);
+	nic_unicast_mode_t mode = IPC_GET_ARG2(call);
+	size_t address_count = IPC_GET_ARG3(call);
 	nic_address_t *address_list = NULL;
 
 	if (address_count) {
@@ -1784,7 +1784,7 @@ static void remote_nic_multicast_get_mode(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	size_t max_count = IPC_GET_ARG2(*call);
+	size_t max_count = IPC_GET_ARG2(call);
 	nic_address_t *address_list = NULL;
 
 	if (max_count != 0) {
@@ -1834,8 +1834,8 @@ static void remote_nic_multicast_set_mode(ddf_fun_t *dev, void *iface,
 {
 	nic_iface_t *nic_iface = (nic_iface_t *) iface;
 
-	nic_multicast_mode_t mode = IPC_GET_ARG2(*call);
-	size_t address_count = IPC_GET_ARG3(*call);
+	nic_multicast_mode_t mode = IPC_GET_ARG2(call);
+	size_t address_count = IPC_GET_ARG3(call);
 	nic_address_t *address_list = NULL;
 
 	if (address_count) {
@@ -1902,7 +1902,7 @@ static void remote_nic_broadcast_set_mode(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	nic_broadcast_mode_t mode = IPC_GET_ARG2(*call);
+	nic_broadcast_mode_t mode = IPC_GET_ARG2(call);
 
 	errno_t rc = nic_iface->broadcast_set_mode(dev, mode);
 	async_answer_0(call, rc);
@@ -1932,7 +1932,7 @@ static void remote_nic_defective_set_mode(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	uint32_t mode = IPC_GET_ARG2(*call);
+	uint32_t mode = IPC_GET_ARG2(call);
 
 	errno_t rc = nic_iface->defective_set_mode(dev, mode);
 	async_answer_0(call, rc);
@@ -1947,7 +1947,7 @@ static void remote_nic_blocked_sources_get(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	size_t max_count = IPC_GET_ARG2(*call);
+	size_t max_count = IPC_GET_ARG2(call);
 	nic_address_t *address_list = NULL;
 
 	if (max_count != 0) {
@@ -1997,7 +1997,7 @@ static void remote_nic_blocked_sources_set(ddf_fun_t *dev, void *iface,
 	nic_iface_t *nic_iface = (nic_iface_t *) iface;
 
 	size_t length;
-	size_t address_count = IPC_GET_ARG2(*call);
+	size_t address_count = IPC_GET_ARG2(call);
 	nic_address_t *address_list = NULL;
 
 	if (address_count) {
@@ -2080,7 +2080,7 @@ static void remote_nic_vlan_set_mask(ddf_fun_t *dev, void *iface,
 
 	nic_vlan_mask_t vlan_mask;
 	nic_vlan_mask_t *vlan_mask_pointer = NULL;
-	bool vlan_mask_set = (bool) IPC_GET_ARG2(*call);
+	bool vlan_mask_set = (bool) IPC_GET_ARG2(call);
 
 	if (vlan_mask_set) {
 		ipc_call_t data;
@@ -2123,9 +2123,9 @@ static void remote_nic_vlan_set_tag(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	uint16_t tag = (uint16_t) IPC_GET_ARG2(*call);
-	bool add = (int) IPC_GET_ARG3(*call);
-	bool strip = (int) IPC_GET_ARG4(*call);
+	uint16_t tag = (uint16_t) IPC_GET_ARG2(call);
+	bool add = (int) IPC_GET_ARG3(call);
+	bool strip = (int) IPC_GET_ARG4(call);
 
 	errno_t rc = nic_iface->vlan_set_tag(dev, tag, add, strip);
 	async_answer_0(call, rc);
@@ -2136,7 +2136,7 @@ static void remote_nic_wol_virtue_add(ddf_fun_t *dev, void *iface,
 {
 	nic_iface_t *nic_iface = (nic_iface_t *) iface;
 
-	int send_data = (int) IPC_GET_ARG3(*call);
+	int send_data = (int) IPC_GET_ARG3(call);
 	ipc_call_t data;
 
 	if (nic_iface->wol_virtue_add == NULL) {
@@ -2174,7 +2174,7 @@ static void remote_nic_wol_virtue_add(ddf_fun_t *dev, void *iface,
 	}
 
 	nic_wv_id_t id = 0;
-	nic_wv_type_t type = (nic_wv_type_t) IPC_GET_ARG2(*call);
+	nic_wv_type_t type = (nic_wv_type_t) IPC_GET_ARG2(call);
 
 	errno_t rc = nic_iface->wol_virtue_add(dev, type, virtue, length, &id);
 	async_answer_1(call, rc, (sysarg_t) id);
@@ -2191,7 +2191,7 @@ static void remote_nic_wol_virtue_remove(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	nic_wv_id_t id = (nic_wv_id_t) IPC_GET_ARG2(*call);
+	nic_wv_id_t id = (nic_wv_id_t) IPC_GET_ARG2(call);
 
 	errno_t rc = nic_iface->wol_virtue_remove(dev, id);
 	async_answer_0(call, rc);
@@ -2207,8 +2207,8 @@ static void remote_nic_wol_virtue_probe(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	nic_wv_id_t id = (nic_wv_id_t) IPC_GET_ARG2(*call);
-	size_t max_length = IPC_GET_ARG3(*call);
+	nic_wv_id_t id = (nic_wv_id_t) IPC_GET_ARG2(call);
+	size_t max_length = IPC_GET_ARG3(call);
 	nic_wv_type_t type = NIC_WV_NONE;
 	size_t length = 0;
 	ipc_call_t data;
@@ -2258,8 +2258,8 @@ static void remote_nic_wol_virtue_list(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	nic_wv_type_t type = (nic_wv_type_t) IPC_GET_ARG2(*call);
-	size_t max_count = IPC_GET_ARG3(*call);
+	nic_wv_type_t type = (nic_wv_type_t) IPC_GET_ARG2(call);
+	size_t max_count = IPC_GET_ARG3(call);
 	size_t count = 0;
 	nic_wv_id_t *id_list = NULL;
 	ipc_call_t data;
@@ -2309,7 +2309,7 @@ static void remote_nic_wol_virtue_get_caps(ddf_fun_t *dev, void *iface,
 	}
 
 	int count = -1;
-	nic_wv_type_t type = (nic_wv_type_t) IPC_GET_ARG2(*call);
+	nic_wv_type_t type = (nic_wv_type_t) IPC_GET_ARG2(call);
 
 	errno_t rc = nic_iface->wol_virtue_get_caps(dev, type, &count);
 	async_answer_1(call, rc, (sysarg_t) count);
@@ -2324,7 +2324,7 @@ static void remote_nic_wol_load_info(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	size_t max_length = (size_t) IPC_GET_ARG2(*call);
+	size_t max_length = (size_t) IPC_GET_ARG2(call);
 	size_t frame_length = 0;
 	nic_wv_type_t type = NIC_WV_NONE;
 	uint8_t *info = NULL;
@@ -2385,8 +2385,8 @@ static void remote_nic_offload_set(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	uint32_t mask = (uint32_t) IPC_GET_ARG2(*call);
-	uint32_t active = (uint32_t) IPC_GET_ARG3(*call);
+	uint32_t mask = (uint32_t) IPC_GET_ARG2(call);
+	uint32_t active = (uint32_t) IPC_GET_ARG3(call);
 
 	errno_t rc = nic_iface->offload_set(dev, mask, active);
 	async_answer_0(call, rc);
@@ -2402,7 +2402,7 @@ static void remote_nic_poll_get_mode(ddf_fun_t *dev, void *iface,
 	}
 
 	nic_poll_mode_t mode = NIC_POLL_IMMEDIATE;
-	int request_data = IPC_GET_ARG2(*call);
+	int request_data = IPC_GET_ARG2(call);
 	struct timespec period = {
 		.tv_sec = 0,
 		.tv_nsec = 0
@@ -2437,8 +2437,8 @@ static void remote_nic_poll_set_mode(ddf_fun_t *dev, void *iface,
 {
 	nic_iface_t *nic_iface = (nic_iface_t *) iface;
 
-	nic_poll_mode_t mode = IPC_GET_ARG2(*call);
-	int has_period = IPC_GET_ARG3(*call);
+	nic_poll_mode_t mode = IPC_GET_ARG2(call);
+	int has_period = IPC_GET_ARG3(call);
 	struct timespec period_buf;
 	struct timespec *period = NULL;
 	size_t length;

--- a/uspace/lib/drv/generic/remote_nic.c
+++ b/uspace/lib/drv/generic/remote_nic.c
@@ -1009,7 +1009,7 @@ errno_t nic_wol_virtue_add(async_sess_t *dev_sess, nic_wv_type_t type,
 	async_exchange_end(exch);
 	async_wait_for(message_id, &res);
 
-	*id = IPC_GET_ARG1(&result);
+	*id = ipc_get_arg1(&result);
 	return res;
 }
 
@@ -1384,7 +1384,7 @@ static void remote_nic_set_state(ddf_fun_t *dev, void *iface,
 	nic_iface_t *nic_iface = (nic_iface_t *) iface;
 	assert(nic_iface->set_state);
 
-	nic_device_state_t state = (nic_device_state_t) IPC_GET_ARG2(call);
+	nic_device_state_t state = (nic_device_state_t) ipc_get_arg2(call);
 
 	errno_t rc = nic_iface->set_state(dev, state);
 	async_answer_0(call, rc);
@@ -1568,9 +1568,9 @@ static void remote_nic_set_operation_mode(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	int speed = (int) IPC_GET_ARG2(call);
-	nic_channel_mode_t duplex = (nic_channel_mode_t) IPC_GET_ARG3(call);
-	nic_role_t role = (nic_role_t) IPC_GET_ARG4(call);
+	int speed = (int) ipc_get_arg2(call);
+	nic_channel_mode_t duplex = (nic_channel_mode_t) ipc_get_arg3(call);
+	nic_role_t role = (nic_role_t) ipc_get_arg4(call);
 
 	errno_t rc = nic_iface->set_operation_mode(dev, speed, duplex, role);
 	async_answer_0(call, rc);
@@ -1585,7 +1585,7 @@ static void remote_nic_autoneg_enable(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	uint32_t advertisement = (uint32_t) IPC_GET_ARG2(call);
+	uint32_t advertisement = (uint32_t) ipc_get_arg2(call);
 
 	errno_t rc = nic_iface->autoneg_enable(dev, advertisement);
 	async_answer_0(call, rc);
@@ -1663,9 +1663,9 @@ static void remote_nic_set_pause(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	int allow_send = (int) IPC_GET_ARG2(call);
-	int allow_receive = (int) IPC_GET_ARG3(call);
-	uint16_t pause = (uint16_t) IPC_GET_ARG4(call);
+	int allow_send = (int) ipc_get_arg2(call);
+	int allow_receive = (int) ipc_get_arg3(call);
+	uint16_t pause = (uint16_t) ipc_get_arg4(call);
 
 	errno_t rc = nic_iface->set_pause(dev, allow_send, allow_receive,
 	    pause);
@@ -1681,7 +1681,7 @@ static void remote_nic_unicast_get_mode(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	size_t max_count = IPC_GET_ARG2(call);
+	size_t max_count = ipc_get_arg2(call);
 	nic_address_t *address_list = NULL;
 
 	if (max_count != 0) {
@@ -1732,8 +1732,8 @@ static void remote_nic_unicast_set_mode(ddf_fun_t *dev, void *iface,
 	nic_iface_t *nic_iface = (nic_iface_t *) iface;
 
 	size_t length;
-	nic_unicast_mode_t mode = IPC_GET_ARG2(call);
-	size_t address_count = IPC_GET_ARG3(call);
+	nic_unicast_mode_t mode = ipc_get_arg2(call);
+	size_t address_count = ipc_get_arg3(call);
 	nic_address_t *address_list = NULL;
 
 	if (address_count) {
@@ -1784,7 +1784,7 @@ static void remote_nic_multicast_get_mode(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	size_t max_count = IPC_GET_ARG2(call);
+	size_t max_count = ipc_get_arg2(call);
 	nic_address_t *address_list = NULL;
 
 	if (max_count != 0) {
@@ -1834,8 +1834,8 @@ static void remote_nic_multicast_set_mode(ddf_fun_t *dev, void *iface,
 {
 	nic_iface_t *nic_iface = (nic_iface_t *) iface;
 
-	nic_multicast_mode_t mode = IPC_GET_ARG2(call);
-	size_t address_count = IPC_GET_ARG3(call);
+	nic_multicast_mode_t mode = ipc_get_arg2(call);
+	size_t address_count = ipc_get_arg3(call);
 	nic_address_t *address_list = NULL;
 
 	if (address_count) {
@@ -1902,7 +1902,7 @@ static void remote_nic_broadcast_set_mode(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	nic_broadcast_mode_t mode = IPC_GET_ARG2(call);
+	nic_broadcast_mode_t mode = ipc_get_arg2(call);
 
 	errno_t rc = nic_iface->broadcast_set_mode(dev, mode);
 	async_answer_0(call, rc);
@@ -1932,7 +1932,7 @@ static void remote_nic_defective_set_mode(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	uint32_t mode = IPC_GET_ARG2(call);
+	uint32_t mode = ipc_get_arg2(call);
 
 	errno_t rc = nic_iface->defective_set_mode(dev, mode);
 	async_answer_0(call, rc);
@@ -1947,7 +1947,7 @@ static void remote_nic_blocked_sources_get(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	size_t max_count = IPC_GET_ARG2(call);
+	size_t max_count = ipc_get_arg2(call);
 	nic_address_t *address_list = NULL;
 
 	if (max_count != 0) {
@@ -1997,7 +1997,7 @@ static void remote_nic_blocked_sources_set(ddf_fun_t *dev, void *iface,
 	nic_iface_t *nic_iface = (nic_iface_t *) iface;
 
 	size_t length;
-	size_t address_count = IPC_GET_ARG2(call);
+	size_t address_count = ipc_get_arg2(call);
 	nic_address_t *address_list = NULL;
 
 	if (address_count) {
@@ -2080,7 +2080,7 @@ static void remote_nic_vlan_set_mask(ddf_fun_t *dev, void *iface,
 
 	nic_vlan_mask_t vlan_mask;
 	nic_vlan_mask_t *vlan_mask_pointer = NULL;
-	bool vlan_mask_set = (bool) IPC_GET_ARG2(call);
+	bool vlan_mask_set = (bool) ipc_get_arg2(call);
 
 	if (vlan_mask_set) {
 		ipc_call_t data;
@@ -2123,9 +2123,9 @@ static void remote_nic_vlan_set_tag(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	uint16_t tag = (uint16_t) IPC_GET_ARG2(call);
-	bool add = (int) IPC_GET_ARG3(call);
-	bool strip = (int) IPC_GET_ARG4(call);
+	uint16_t tag = (uint16_t) ipc_get_arg2(call);
+	bool add = (int) ipc_get_arg3(call);
+	bool strip = (int) ipc_get_arg4(call);
 
 	errno_t rc = nic_iface->vlan_set_tag(dev, tag, add, strip);
 	async_answer_0(call, rc);
@@ -2136,7 +2136,7 @@ static void remote_nic_wol_virtue_add(ddf_fun_t *dev, void *iface,
 {
 	nic_iface_t *nic_iface = (nic_iface_t *) iface;
 
-	int send_data = (int) IPC_GET_ARG3(call);
+	int send_data = (int) ipc_get_arg3(call);
 	ipc_call_t data;
 
 	if (nic_iface->wol_virtue_add == NULL) {
@@ -2174,7 +2174,7 @@ static void remote_nic_wol_virtue_add(ddf_fun_t *dev, void *iface,
 	}
 
 	nic_wv_id_t id = 0;
-	nic_wv_type_t type = (nic_wv_type_t) IPC_GET_ARG2(call);
+	nic_wv_type_t type = (nic_wv_type_t) ipc_get_arg2(call);
 
 	errno_t rc = nic_iface->wol_virtue_add(dev, type, virtue, length, &id);
 	async_answer_1(call, rc, (sysarg_t) id);
@@ -2191,7 +2191,7 @@ static void remote_nic_wol_virtue_remove(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	nic_wv_id_t id = (nic_wv_id_t) IPC_GET_ARG2(call);
+	nic_wv_id_t id = (nic_wv_id_t) ipc_get_arg2(call);
 
 	errno_t rc = nic_iface->wol_virtue_remove(dev, id);
 	async_answer_0(call, rc);
@@ -2207,8 +2207,8 @@ static void remote_nic_wol_virtue_probe(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	nic_wv_id_t id = (nic_wv_id_t) IPC_GET_ARG2(call);
-	size_t max_length = IPC_GET_ARG3(call);
+	nic_wv_id_t id = (nic_wv_id_t) ipc_get_arg2(call);
+	size_t max_length = ipc_get_arg3(call);
 	nic_wv_type_t type = NIC_WV_NONE;
 	size_t length = 0;
 	ipc_call_t data;
@@ -2258,8 +2258,8 @@ static void remote_nic_wol_virtue_list(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	nic_wv_type_t type = (nic_wv_type_t) IPC_GET_ARG2(call);
-	size_t max_count = IPC_GET_ARG3(call);
+	nic_wv_type_t type = (nic_wv_type_t) ipc_get_arg2(call);
+	size_t max_count = ipc_get_arg3(call);
 	size_t count = 0;
 	nic_wv_id_t *id_list = NULL;
 	ipc_call_t data;
@@ -2309,7 +2309,7 @@ static void remote_nic_wol_virtue_get_caps(ddf_fun_t *dev, void *iface,
 	}
 
 	int count = -1;
-	nic_wv_type_t type = (nic_wv_type_t) IPC_GET_ARG2(call);
+	nic_wv_type_t type = (nic_wv_type_t) ipc_get_arg2(call);
 
 	errno_t rc = nic_iface->wol_virtue_get_caps(dev, type, &count);
 	async_answer_1(call, rc, (sysarg_t) count);
@@ -2324,7 +2324,7 @@ static void remote_nic_wol_load_info(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	size_t max_length = (size_t) IPC_GET_ARG2(call);
+	size_t max_length = (size_t) ipc_get_arg2(call);
 	size_t frame_length = 0;
 	nic_wv_type_t type = NIC_WV_NONE;
 	uint8_t *info = NULL;
@@ -2385,8 +2385,8 @@ static void remote_nic_offload_set(ddf_fun_t *dev, void *iface,
 		return;
 	}
 
-	uint32_t mask = (uint32_t) IPC_GET_ARG2(call);
-	uint32_t active = (uint32_t) IPC_GET_ARG3(call);
+	uint32_t mask = (uint32_t) ipc_get_arg2(call);
+	uint32_t active = (uint32_t) ipc_get_arg3(call);
 
 	errno_t rc = nic_iface->offload_set(dev, mask, active);
 	async_answer_0(call, rc);
@@ -2402,7 +2402,7 @@ static void remote_nic_poll_get_mode(ddf_fun_t *dev, void *iface,
 	}
 
 	nic_poll_mode_t mode = NIC_POLL_IMMEDIATE;
-	int request_data = IPC_GET_ARG2(call);
+	int request_data = ipc_get_arg2(call);
 	struct timespec period = {
 		.tv_sec = 0,
 		.tv_nsec = 0
@@ -2437,8 +2437,8 @@ static void remote_nic_poll_set_mode(ddf_fun_t *dev, void *iface,
 {
 	nic_iface_t *nic_iface = (nic_iface_t *) iface;
 
-	nic_poll_mode_t mode = IPC_GET_ARG2(call);
-	int has_period = IPC_GET_ARG3(call);
+	nic_poll_mode_t mode = ipc_get_arg2(call);
+	int has_period = ipc_get_arg3(call);
 	struct timespec period_buf;
 	struct timespec *period = NULL;
 	size_t length;

--- a/uspace/lib/drv/generic/remote_usbhc.c
+++ b/uspace/lib/drv/generic/remote_usbhc.c
@@ -220,7 +220,7 @@ errno_t usbhc_transfer(async_exch_t *exch,
 	async_wait_for(opening_request, &opening_request_rc);
 
 	if (transferred)
-		*transferred = IPC_GET_ARG1(&call);
+		*transferred = ipc_get_arg1(&call);
 
 	return (errno_t) opening_request_rc;
 }
@@ -264,7 +264,7 @@ void remote_usbhc_default_address_reservation(ddf_fun_t *fun, void *iface,
 		return;
 	}
 
-	const bool reserve = IPC_GET_ARG2(call);
+	const bool reserve = ipc_get_arg2(call);
 	const errno_t ret = usbhc_iface->default_address_reservation(fun, reserve);
 	async_answer_0(call, ret);
 }

--- a/uspace/lib/drv/generic/remote_usbhc.c
+++ b/uspace/lib/drv/generic/remote_usbhc.c
@@ -220,7 +220,7 @@ errno_t usbhc_transfer(async_exch_t *exch,
 	async_wait_for(opening_request, &opening_request_rc);
 
 	if (transferred)
-		*transferred = IPC_GET_ARG1(call);
+		*transferred = IPC_GET_ARG1(&call);
 
 	return (errno_t) opening_request_rc;
 }
@@ -264,7 +264,7 @@ void remote_usbhc_default_address_reservation(ddf_fun_t *fun, void *iface,
 		return;
 	}
 
-	const bool reserve = IPC_GET_ARG2(*call);
+	const bool reserve = IPC_GET_ARG2(call);
 	const errno_t ret = usbhc_iface->default_address_reservation(fun, reserve);
 	async_answer_0(call, ret);
 }

--- a/uspace/lib/drv/generic/remote_usbhid.c
+++ b/uspace/lib/drv/generic/remote_usbhid.c
@@ -189,7 +189,7 @@ errno_t usbhid_dev_get_event(async_sess_t *dev_sess, uint8_t *buf,
 	if (opening_request_rc != EOK)
 		return (errno_t) opening_request_rc;
 
-	size_t act_size = IPC_GET_ARG2(&data_request_call);
+	size_t act_size = ipc_get_arg2(&data_request_call);
 
 	/* Copy the individual items. */
 	memcpy(buf, buffer, act_size);
@@ -198,7 +198,7 @@ errno_t usbhid_dev_get_event(async_sess_t *dev_sess, uint8_t *buf,
 		*actual_size = act_size;
 
 	if (event_nr != NULL)
-		*event_nr = IPC_GET_ARG1(&opening_request_call);
+		*event_nr = ipc_get_arg1(&opening_request_call);
 
 	return EOK;
 }
@@ -274,7 +274,7 @@ errno_t usbhid_dev_get_report_descriptor(async_sess_t *dev_sess, uint8_t *buf,
 	if (opening_request_rc != EOK)
 		return (errno_t) opening_request_rc;
 
-	size_t act_size = IPC_GET_ARG2(&data_request_call);
+	size_t act_size = ipc_get_arg2(&data_request_call);
 
 	if (actual_size != NULL)
 		*actual_size = act_size;

--- a/uspace/lib/drv/generic/remote_usbhid.c
+++ b/uspace/lib/drv/generic/remote_usbhid.c
@@ -189,7 +189,7 @@ errno_t usbhid_dev_get_event(async_sess_t *dev_sess, uint8_t *buf,
 	if (opening_request_rc != EOK)
 		return (errno_t) opening_request_rc;
 
-	size_t act_size = IPC_GET_ARG2(data_request_call);
+	size_t act_size = IPC_GET_ARG2(&data_request_call);
 
 	/* Copy the individual items. */
 	memcpy(buf, buffer, act_size);
@@ -198,7 +198,7 @@ errno_t usbhid_dev_get_event(async_sess_t *dev_sess, uint8_t *buf,
 		*actual_size = act_size;
 
 	if (event_nr != NULL)
-		*event_nr = IPC_GET_ARG1(opening_request_call);
+		*event_nr = IPC_GET_ARG1(&opening_request_call);
 
 	return EOK;
 }
@@ -274,7 +274,7 @@ errno_t usbhid_dev_get_report_descriptor(async_sess_t *dev_sess, uint8_t *buf,
 	if (opening_request_rc != EOK)
 		return (errno_t) opening_request_rc;
 
-	size_t act_size = IPC_GET_ARG2(data_request_call);
+	size_t act_size = IPC_GET_ARG2(&data_request_call);
 
 	if (actual_size != NULL)
 		*actual_size = act_size;

--- a/uspace/lib/fs/libfs.c
+++ b/uspace/lib/fs/libfs.c
@@ -78,7 +78,7 @@ static void libfs_statfs(libfs_ops_t *, fs_handle_t, ipc_call_t *);
 
 static void vfs_out_fsprobe(ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
+	service_id_t service_id = (service_id_t) ipc_get_arg1(req);
 	errno_t rc;
 	vfs_fs_probe_info_t info;
 
@@ -105,7 +105,7 @@ static void vfs_out_fsprobe(ipc_call_t *req)
 
 static void vfs_out_mounted(ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
+	service_id_t service_id = (service_id_t) ipc_get_arg1(req);
 	char *opts;
 	errno_t rc;
 
@@ -131,7 +131,7 @@ static void vfs_out_mounted(ipc_call_t *req)
 
 static void vfs_out_unmounted(ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
+	service_id_t service_id = (service_id_t) ipc_get_arg1(req);
 	errno_t rc;
 
 	rc = vfs_out_ops->unmounted(service_id);
@@ -151,10 +151,10 @@ static void vfs_out_lookup(ipc_call_t *req)
 
 static void vfs_out_read(ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
-	fs_index_t index = (fs_index_t) IPC_GET_ARG2(req);
-	aoff64_t pos = (aoff64_t) MERGE_LOUP32(IPC_GET_ARG3(req),
-	    IPC_GET_ARG4(req));
+	service_id_t service_id = (service_id_t) ipc_get_arg1(req);
+	fs_index_t index = (fs_index_t) ipc_get_arg2(req);
+	aoff64_t pos = (aoff64_t) MERGE_LOUP32(ipc_get_arg3(req),
+	    ipc_get_arg4(req));
 	size_t rbytes;
 	errno_t rc;
 
@@ -168,10 +168,10 @@ static void vfs_out_read(ipc_call_t *req)
 
 static void vfs_out_write(ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
-	fs_index_t index = (fs_index_t) IPC_GET_ARG2(req);
-	aoff64_t pos = (aoff64_t) MERGE_LOUP32(IPC_GET_ARG3(req),
-	    IPC_GET_ARG4(req));
+	service_id_t service_id = (service_id_t) ipc_get_arg1(req);
+	fs_index_t index = (fs_index_t) ipc_get_arg2(req);
+	aoff64_t pos = (aoff64_t) MERGE_LOUP32(ipc_get_arg3(req),
+	    ipc_get_arg4(req));
 	size_t wbytes;
 	aoff64_t nsize;
 	errno_t rc;
@@ -187,10 +187,10 @@ static void vfs_out_write(ipc_call_t *req)
 
 static void vfs_out_truncate(ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
-	fs_index_t index = (fs_index_t) IPC_GET_ARG2(req);
-	aoff64_t size = (aoff64_t) MERGE_LOUP32(IPC_GET_ARG3(req),
-	    IPC_GET_ARG4(req));
+	service_id_t service_id = (service_id_t) ipc_get_arg1(req);
+	fs_index_t index = (fs_index_t) ipc_get_arg2(req);
+	aoff64_t size = (aoff64_t) MERGE_LOUP32(ipc_get_arg3(req),
+	    ipc_get_arg4(req));
 	errno_t rc;
 
 	rc = vfs_out_ops->truncate(service_id, index, size);
@@ -200,8 +200,8 @@ static void vfs_out_truncate(ipc_call_t *req)
 
 static void vfs_out_close(ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
-	fs_index_t index = (fs_index_t) IPC_GET_ARG2(req);
+	service_id_t service_id = (service_id_t) ipc_get_arg1(req);
+	fs_index_t index = (fs_index_t) ipc_get_arg2(req);
 	errno_t rc;
 
 	rc = vfs_out_ops->close(service_id, index);
@@ -211,8 +211,8 @@ static void vfs_out_close(ipc_call_t *req)
 
 static void vfs_out_destroy(ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
-	fs_index_t index = (fs_index_t) IPC_GET_ARG2(req);
+	service_id_t service_id = (service_id_t) ipc_get_arg1(req);
+	fs_index_t index = (fs_index_t) ipc_get_arg2(req);
 
 	errno_t rc;
 	fs_node_t *node = NULL;
@@ -238,8 +238,8 @@ static void vfs_out_stat(ipc_call_t *req)
 
 static void vfs_out_sync(ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
-	fs_index_t index = (fs_index_t) IPC_GET_ARG2(req);
+	service_id_t service_id = (service_id_t) ipc_get_arg1(req);
+	fs_index_t index = (fs_index_t) ipc_get_arg2(req);
 	errno_t rc;
 
 	rc = vfs_out_ops->sync(service_id, index);
@@ -254,8 +254,8 @@ static void vfs_out_statfs(ipc_call_t *req)
 
 static void vfs_out_is_empty(ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
-	fs_index_t index = (fs_index_t) IPC_GET_ARG2(req);
+	service_id_t service_id = (service_id_t) ipc_get_arg1(req);
+	fs_index_t index = (fs_index_t) ipc_get_arg2(req);
 	errno_t rc;
 
 	fs_node_t *node = NULL;
@@ -289,12 +289,12 @@ static void vfs_connection(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case VFS_OUT_FSPROBE:
 			vfs_out_fsprobe(&call);
 			break;
@@ -423,9 +423,9 @@ errno_t fs_register(async_sess_t *sess, vfs_info_t *info, vfs_out_ops_t *vops,
 	 * Pick up the answer for the request to the VFS_IN_REQUEST call.
 	 */
 	async_wait_for(req, NULL);
-	reg.fs_handle = (int) IPC_GET_ARG1(&answer);
+	reg.fs_handle = (int) ipc_get_arg1(&answer);
 
-	return IPC_GET_RETVAL(&answer);
+	return ipc_get_retval(&answer);
 }
 
 void fs_node_initialize(fs_node_t *fn)
@@ -489,9 +489,9 @@ static errno_t receive_fname(char *buffer)
  */
 void libfs_link(libfs_ops_t *ops, fs_handle_t fs_handle, ipc_call_t *req)
 {
-	service_id_t parent_sid = IPC_GET_ARG1(req);
-	fs_index_t parent_index = IPC_GET_ARG2(req);
-	fs_index_t child_index = IPC_GET_ARG3(req);
+	service_id_t parent_sid = ipc_get_arg1(req);
+	fs_index_t parent_index = ipc_get_arg2(req);
+	fs_index_t child_index = ipc_get_arg3(req);
 
 	char component[NAME_MAX + 1];
 	errno_t rc = receive_fname(component);
@@ -535,11 +535,11 @@ void libfs_link(libfs_ops_t *ops, fs_handle_t fs_handle, ipc_call_t *req)
  */
 void libfs_lookup(libfs_ops_t *ops, fs_handle_t fs_handle, ipc_call_t *req)
 {
-	unsigned first = IPC_GET_ARG1(req);
-	unsigned len = IPC_GET_ARG2(req);
-	service_id_t service_id = IPC_GET_ARG3(req);
-	fs_index_t index = IPC_GET_ARG4(req);
-	int lflag = IPC_GET_ARG5(req);
+	unsigned first = ipc_get_arg1(req);
+	unsigned len = ipc_get_arg2(req);
+	service_id_t service_id = ipc_get_arg3(req);
+	fs_index_t index = ipc_get_arg4(req);
+	int lflag = ipc_get_arg5(req);
 
 	// TODO: Validate flags.
 
@@ -715,8 +715,8 @@ out:
 
 void libfs_stat(libfs_ops_t *ops, fs_handle_t fs_handle, ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
-	fs_index_t index = (fs_index_t) IPC_GET_ARG2(req);
+	service_id_t service_id = (service_id_t) ipc_get_arg1(req);
+	fs_index_t index = (fs_index_t) ipc_get_arg2(req);
 
 	fs_node_t *fn;
 	errno_t rc = ops->node_get(&fn, service_id, index);
@@ -752,8 +752,8 @@ void libfs_stat(libfs_ops_t *ops, fs_handle_t fs_handle, ipc_call_t *req)
 
 void libfs_statfs(libfs_ops_t *ops, fs_handle_t fs_handle, ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
-	fs_index_t index = (fs_index_t) IPC_GET_ARG2(req);
+	service_id_t service_id = (service_id_t) ipc_get_arg1(req);
+	fs_index_t index = (fs_index_t) ipc_get_arg2(req);
 
 	fs_node_t *fn;
 	errno_t rc = ops->node_get(&fn, service_id, index);
@@ -809,8 +809,8 @@ error:
  */
 void libfs_open_node(libfs_ops_t *ops, fs_handle_t fs_handle, ipc_call_t *req)
 {
-	service_id_t service_id = IPC_GET_ARG1(req);
-	fs_index_t index = IPC_GET_ARG2(req);
+	service_id_t service_id = ipc_get_arg1(req);
+	fs_index_t index = ipc_get_arg2(req);
 
 	fs_node_t *fn;
 	errno_t rc = ops->node_get(&fn, service_id, index);

--- a/uspace/lib/fs/libfs.c
+++ b/uspace/lib/fs/libfs.c
@@ -78,7 +78,7 @@ static void libfs_statfs(libfs_ops_t *, fs_handle_t, ipc_call_t *);
 
 static void vfs_out_fsprobe(ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(*req);
+	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
 	errno_t rc;
 	vfs_fs_probe_info_t info;
 
@@ -105,7 +105,7 @@ static void vfs_out_fsprobe(ipc_call_t *req)
 
 static void vfs_out_mounted(ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(*req);
+	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
 	char *opts;
 	errno_t rc;
 
@@ -131,7 +131,7 @@ static void vfs_out_mounted(ipc_call_t *req)
 
 static void vfs_out_unmounted(ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(*req);
+	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
 	errno_t rc;
 
 	rc = vfs_out_ops->unmounted(service_id);
@@ -151,10 +151,10 @@ static void vfs_out_lookup(ipc_call_t *req)
 
 static void vfs_out_read(ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(*req);
-	fs_index_t index = (fs_index_t) IPC_GET_ARG2(*req);
-	aoff64_t pos = (aoff64_t) MERGE_LOUP32(IPC_GET_ARG3(*req),
-	    IPC_GET_ARG4(*req));
+	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
+	fs_index_t index = (fs_index_t) IPC_GET_ARG2(req);
+	aoff64_t pos = (aoff64_t) MERGE_LOUP32(IPC_GET_ARG3(req),
+	    IPC_GET_ARG4(req));
 	size_t rbytes;
 	errno_t rc;
 
@@ -168,10 +168,10 @@ static void vfs_out_read(ipc_call_t *req)
 
 static void vfs_out_write(ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(*req);
-	fs_index_t index = (fs_index_t) IPC_GET_ARG2(*req);
-	aoff64_t pos = (aoff64_t) MERGE_LOUP32(IPC_GET_ARG3(*req),
-	    IPC_GET_ARG4(*req));
+	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
+	fs_index_t index = (fs_index_t) IPC_GET_ARG2(req);
+	aoff64_t pos = (aoff64_t) MERGE_LOUP32(IPC_GET_ARG3(req),
+	    IPC_GET_ARG4(req));
 	size_t wbytes;
 	aoff64_t nsize;
 	errno_t rc;
@@ -187,10 +187,10 @@ static void vfs_out_write(ipc_call_t *req)
 
 static void vfs_out_truncate(ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(*req);
-	fs_index_t index = (fs_index_t) IPC_GET_ARG2(*req);
-	aoff64_t size = (aoff64_t) MERGE_LOUP32(IPC_GET_ARG3(*req),
-	    IPC_GET_ARG4(*req));
+	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
+	fs_index_t index = (fs_index_t) IPC_GET_ARG2(req);
+	aoff64_t size = (aoff64_t) MERGE_LOUP32(IPC_GET_ARG3(req),
+	    IPC_GET_ARG4(req));
 	errno_t rc;
 
 	rc = vfs_out_ops->truncate(service_id, index, size);
@@ -200,8 +200,8 @@ static void vfs_out_truncate(ipc_call_t *req)
 
 static void vfs_out_close(ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(*req);
-	fs_index_t index = (fs_index_t) IPC_GET_ARG2(*req);
+	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
+	fs_index_t index = (fs_index_t) IPC_GET_ARG2(req);
 	errno_t rc;
 
 	rc = vfs_out_ops->close(service_id, index);
@@ -211,8 +211,8 @@ static void vfs_out_close(ipc_call_t *req)
 
 static void vfs_out_destroy(ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(*req);
-	fs_index_t index = (fs_index_t) IPC_GET_ARG2(*req);
+	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
+	fs_index_t index = (fs_index_t) IPC_GET_ARG2(req);
 
 	errno_t rc;
 	fs_node_t *node = NULL;
@@ -238,8 +238,8 @@ static void vfs_out_stat(ipc_call_t *req)
 
 static void vfs_out_sync(ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(*req);
-	fs_index_t index = (fs_index_t) IPC_GET_ARG2(*req);
+	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
+	fs_index_t index = (fs_index_t) IPC_GET_ARG2(req);
 	errno_t rc;
 
 	rc = vfs_out_ops->sync(service_id, index);
@@ -254,8 +254,8 @@ static void vfs_out_statfs(ipc_call_t *req)
 
 static void vfs_out_is_empty(ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(*req);
-	fs_index_t index = (fs_index_t) IPC_GET_ARG2(*req);
+	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
+	fs_index_t index = (fs_index_t) IPC_GET_ARG2(req);
 	errno_t rc;
 
 	fs_node_t *node = NULL;
@@ -289,12 +289,12 @@ static void vfs_connection(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case VFS_OUT_FSPROBE:
 			vfs_out_fsprobe(&call);
 			break;
@@ -423,9 +423,9 @@ errno_t fs_register(async_sess_t *sess, vfs_info_t *info, vfs_out_ops_t *vops,
 	 * Pick up the answer for the request to the VFS_IN_REQUEST call.
 	 */
 	async_wait_for(req, NULL);
-	reg.fs_handle = (int) IPC_GET_ARG1(answer);
+	reg.fs_handle = (int) IPC_GET_ARG1(&answer);
 
-	return IPC_GET_RETVAL(answer);
+	return IPC_GET_RETVAL(&answer);
 }
 
 void fs_node_initialize(fs_node_t *fn)
@@ -489,9 +489,9 @@ static errno_t receive_fname(char *buffer)
  */
 void libfs_link(libfs_ops_t *ops, fs_handle_t fs_handle, ipc_call_t *req)
 {
-	service_id_t parent_sid = IPC_GET_ARG1(*req);
-	fs_index_t parent_index = IPC_GET_ARG2(*req);
-	fs_index_t child_index = IPC_GET_ARG3(*req);
+	service_id_t parent_sid = IPC_GET_ARG1(req);
+	fs_index_t parent_index = IPC_GET_ARG2(req);
+	fs_index_t child_index = IPC_GET_ARG3(req);
 
 	char component[NAME_MAX + 1];
 	errno_t rc = receive_fname(component);
@@ -535,11 +535,11 @@ void libfs_link(libfs_ops_t *ops, fs_handle_t fs_handle, ipc_call_t *req)
  */
 void libfs_lookup(libfs_ops_t *ops, fs_handle_t fs_handle, ipc_call_t *req)
 {
-	unsigned first = IPC_GET_ARG1(*req);
-	unsigned len = IPC_GET_ARG2(*req);
-	service_id_t service_id = IPC_GET_ARG3(*req);
-	fs_index_t index = IPC_GET_ARG4(*req);
-	int lflag = IPC_GET_ARG5(*req);
+	unsigned first = IPC_GET_ARG1(req);
+	unsigned len = IPC_GET_ARG2(req);
+	service_id_t service_id = IPC_GET_ARG3(req);
+	fs_index_t index = IPC_GET_ARG4(req);
+	int lflag = IPC_GET_ARG5(req);
 
 	// TODO: Validate flags.
 
@@ -715,8 +715,8 @@ out:
 
 void libfs_stat(libfs_ops_t *ops, fs_handle_t fs_handle, ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(*req);
-	fs_index_t index = (fs_index_t) IPC_GET_ARG2(*req);
+	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
+	fs_index_t index = (fs_index_t) IPC_GET_ARG2(req);
 
 	fs_node_t *fn;
 	errno_t rc = ops->node_get(&fn, service_id, index);
@@ -752,8 +752,8 @@ void libfs_stat(libfs_ops_t *ops, fs_handle_t fs_handle, ipc_call_t *req)
 
 void libfs_statfs(libfs_ops_t *ops, fs_handle_t fs_handle, ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(*req);
-	fs_index_t index = (fs_index_t) IPC_GET_ARG2(*req);
+	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
+	fs_index_t index = (fs_index_t) IPC_GET_ARG2(req);
 
 	fs_node_t *fn;
 	errno_t rc = ops->node_get(&fn, service_id, index);
@@ -809,8 +809,8 @@ error:
  */
 void libfs_open_node(libfs_ops_t *ops, fs_handle_t fs_handle, ipc_call_t *req)
 {
-	service_id_t service_id = IPC_GET_ARG1(*req);
-	fs_index_t index = IPC_GET_ARG2(*req);
+	service_id_t service_id = IPC_GET_ARG1(req);
+	fs_index_t index = IPC_GET_ARG2(req);
 
 	fs_node_t *fn;
 	errno_t rc = ops->node_get(&fn, service_id, index);

--- a/uspace/lib/graph/graph.c
+++ b/uspace/lib/graph/graph.c
@@ -242,7 +242,7 @@ errno_t graph_notify_disconnect(async_sess_t *sess, sysarg_t handle)
 
 static void vs_claim(visualizer_t *vs, ipc_call_t *icall)
 {
-	vs->client_side_handle = IPC_GET_ARG1(icall);
+	vs->client_side_handle = ipc_get_arg1(icall);
 	errno_t rc = vs->ops.claim(vs);
 	async_answer_0(icall, rc);
 }
@@ -282,7 +282,7 @@ static void vs_enumerate_modes(visualizer_t *vs, ipc_call_t *icall)
 	}
 
 	fibril_mutex_lock(&vs->mode_mtx);
-	link_t *link = list_nth(&vs->modes, IPC_GET_ARG1(icall));
+	link_t *link = list_nth(&vs->modes, ipc_get_arg1(icall));
 
 	if (link != NULL) {
 		vslmode_list_element_t *mode_elem =
@@ -359,7 +359,7 @@ static void vs_get_mode(visualizer_t *vs, ipc_call_t *icall)
 		return;
 	}
 
-	sysarg_t mode_idx = IPC_GET_ARG1(icall);
+	sysarg_t mode_idx = ipc_get_arg1(icall);
 
 	fibril_mutex_lock(&vs->mode_mtx);
 	vslmode_list_element_t *mode_elem = NULL;
@@ -396,8 +396,8 @@ static void vs_set_mode(visualizer_t *vs, ipc_call_t *icall)
 	}
 
 	/* Retrieve mode index and version. */
-	sysarg_t mode_idx = IPC_GET_ARG1(icall);
-	sysarg_t mode_version = IPC_GET_ARG2(icall);
+	sysarg_t mode_idx = ipc_get_arg1(icall);
+	sysarg_t mode_version = ipc_get_arg2(icall);
 
 	/* Find mode in the list. */
 	fibril_mutex_lock(&vs->mode_mtx);
@@ -469,12 +469,12 @@ static void vs_set_mode(visualizer_t *vs, ipc_call_t *icall)
 
 static void vs_update_damaged_region(visualizer_t *vs, ipc_call_t *icall)
 {
-	sysarg_t x_offset = (IPC_GET_ARG5(icall) >> 16);
-	sysarg_t y_offset = (IPC_GET_ARG5(icall) & 0x0000ffff);
+	sysarg_t x_offset = (ipc_get_arg5(icall) >> 16);
+	sysarg_t y_offset = (ipc_get_arg5(icall) & 0x0000ffff);
 
 	errno_t rc = vs->ops.handle_damage(vs,
-	    IPC_GET_ARG1(icall), IPC_GET_ARG2(icall),
-	    IPC_GET_ARG3(icall), IPC_GET_ARG4(icall),
+	    ipc_get_arg1(icall), ipc_get_arg2(icall),
+	    ipc_get_arg3(icall), ipc_get_arg4(icall),
 	    x_offset, y_offset);
 	async_answer_0(icall, rc);
 }
@@ -515,12 +515,12 @@ void graph_visualizer_connection(visualizer_t *vs, ipc_call_t *icall, void *arg)
 	while (true) {
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case VISUALIZER_CLAIM:
 			vs_claim(vs, &call);
 			break;
@@ -575,12 +575,12 @@ void graph_renderer_connection(renderer_t *rnd, ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		default:
 			async_answer_0(&call, EINVAL);
 			goto terminate;
@@ -594,8 +594,8 @@ terminate:
 void graph_client_connection(ipc_call_t *icall, void *arg)
 {
 	/* Find the visualizer or renderer with the given service ID. */
-	visualizer_t *vs = graph_get_visualizer(IPC_GET_ARG2(icall));
-	renderer_t *rnd = graph_get_renderer(IPC_GET_ARG2(icall));
+	visualizer_t *vs = graph_get_visualizer(ipc_get_arg2(icall));
+	renderer_t *rnd = graph_get_renderer(ipc_get_arg2(icall));
 
 	if (vs != NULL)
 		graph_visualizer_connection(vs, icall, arg);

--- a/uspace/lib/graph/graph.c
+++ b/uspace/lib/graph/graph.c
@@ -242,7 +242,7 @@ errno_t graph_notify_disconnect(async_sess_t *sess, sysarg_t handle)
 
 static void vs_claim(visualizer_t *vs, ipc_call_t *icall)
 {
-	vs->client_side_handle = IPC_GET_ARG1(*icall);
+	vs->client_side_handle = IPC_GET_ARG1(icall);
 	errno_t rc = vs->ops.claim(vs);
 	async_answer_0(icall, rc);
 }
@@ -282,7 +282,7 @@ static void vs_enumerate_modes(visualizer_t *vs, ipc_call_t *icall)
 	}
 
 	fibril_mutex_lock(&vs->mode_mtx);
-	link_t *link = list_nth(&vs->modes, IPC_GET_ARG1(*icall));
+	link_t *link = list_nth(&vs->modes, IPC_GET_ARG1(icall));
 
 	if (link != NULL) {
 		vslmode_list_element_t *mode_elem =
@@ -359,7 +359,7 @@ static void vs_get_mode(visualizer_t *vs, ipc_call_t *icall)
 		return;
 	}
 
-	sysarg_t mode_idx = IPC_GET_ARG1(*icall);
+	sysarg_t mode_idx = IPC_GET_ARG1(icall);
 
 	fibril_mutex_lock(&vs->mode_mtx);
 	vslmode_list_element_t *mode_elem = NULL;
@@ -396,8 +396,8 @@ static void vs_set_mode(visualizer_t *vs, ipc_call_t *icall)
 	}
 
 	/* Retrieve mode index and version. */
-	sysarg_t mode_idx = IPC_GET_ARG1(*icall);
-	sysarg_t mode_version = IPC_GET_ARG2(*icall);
+	sysarg_t mode_idx = IPC_GET_ARG1(icall);
+	sysarg_t mode_version = IPC_GET_ARG2(icall);
 
 	/* Find mode in the list. */
 	fibril_mutex_lock(&vs->mode_mtx);
@@ -469,12 +469,12 @@ static void vs_set_mode(visualizer_t *vs, ipc_call_t *icall)
 
 static void vs_update_damaged_region(visualizer_t *vs, ipc_call_t *icall)
 {
-	sysarg_t x_offset = (IPC_GET_ARG5(*icall) >> 16);
-	sysarg_t y_offset = (IPC_GET_ARG5(*icall) & 0x0000ffff);
+	sysarg_t x_offset = (IPC_GET_ARG5(icall) >> 16);
+	sysarg_t y_offset = (IPC_GET_ARG5(icall) & 0x0000ffff);
 
 	errno_t rc = vs->ops.handle_damage(vs,
-	    IPC_GET_ARG1(*icall), IPC_GET_ARG2(*icall),
-	    IPC_GET_ARG3(*icall), IPC_GET_ARG4(*icall),
+	    IPC_GET_ARG1(icall), IPC_GET_ARG2(icall),
+	    IPC_GET_ARG3(icall), IPC_GET_ARG4(icall),
 	    x_offset, y_offset);
 	async_answer_0(icall, rc);
 }
@@ -515,12 +515,12 @@ void graph_visualizer_connection(visualizer_t *vs, ipc_call_t *icall, void *arg)
 	while (true) {
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case VISUALIZER_CLAIM:
 			vs_claim(vs, &call);
 			break;
@@ -575,12 +575,12 @@ void graph_renderer_connection(renderer_t *rnd, ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		default:
 			async_answer_0(&call, EINVAL);
 			goto terminate;
@@ -594,8 +594,8 @@ terminate:
 void graph_client_connection(ipc_call_t *icall, void *arg)
 {
 	/* Find the visualizer or renderer with the given service ID. */
-	visualizer_t *vs = graph_get_visualizer(IPC_GET_ARG2(*icall));
-	renderer_t *rnd = graph_get_renderer(IPC_GET_ARG2(*icall));
+	visualizer_t *vs = graph_get_visualizer(IPC_GET_ARG2(icall));
+	renderer_t *rnd = graph_get_renderer(IPC_GET_ARG2(icall));
 
 	if (vs != NULL)
 		graph_visualizer_connection(vs, icall, arg);

--- a/uspace/lib/gui/terminal.c
+++ b/uspace/lib/gui/terminal.c
@@ -681,7 +681,7 @@ static void term_connection(ipc_call_t *icall, void *arg)
 	terminal_t *term = NULL;
 
 	list_foreach(terms, link, terminal_t, cur) {
-		if (cur->dsid == (service_id_t) IPC_GET_ARG2(icall)) {
+		if (cur->dsid == (service_id_t) ipc_get_arg2(icall)) {
 			term = cur;
 			break;
 		}

--- a/uspace/lib/gui/terminal.c
+++ b/uspace/lib/gui/terminal.c
@@ -681,7 +681,7 @@ static void term_connection(ipc_call_t *icall, void *arg)
 	terminal_t *term = NULL;
 
 	list_foreach(terms, link, terminal_t, cur) {
-		if (cur->dsid == (service_id_t) IPC_GET_ARG2(*icall)) {
+		if (cur->dsid == (service_id_t) IPC_GET_ARG2(icall)) {
 			term = cur;
 			break;
 		}

--- a/uspace/lib/hound/src/protocol.c
+++ b/uspace/lib/hound/src/protocol.c
@@ -139,7 +139,7 @@ errno_t hound_service_register_context(hound_sess_t *sess,
 
 	async_exchange_end(exch);
 	if (ret == EOK) {
-		*id = (hound_context_id_t) IPC_GET_ARG1(call);
+		*id = (hound_context_id_t) IPC_GET_ARG1(&call);
 	}
 
 	return ret;
@@ -202,7 +202,7 @@ errno_t hound_service_get_list(hound_sess_t *sess, char ***ids, size_t *count,
 		async_exchange_end(exch);
 		return ret;
 	}
-	unsigned name_count = IPC_GET_ARG1(res_call);
+	unsigned name_count = IPC_GET_ARG1(&res_call);
 
 	/* Start receiving names */
 	char **names = NULL;
@@ -405,14 +405,14 @@ void hound_connection_handler(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case IPC_M_HOUND_CONTEXT_REGISTER:
 			/* check interface functions */
 			if (!server_iface || !server_iface->add_context) {
 				async_answer_0(&call, ENOTSUP);
 				break;
 			}
-			bool record = IPC_GET_ARG1(call);
+			bool record = IPC_GET_ARG1(&call);
 			void *name;
 
 			/* Get context name */
@@ -441,7 +441,7 @@ void hound_connection_handler(ipc_call_t *icall, void *arg)
 			}
 
 			/* get id, 1st param */
-			context = (hound_context_id_t) IPC_GET_ARG1(call);
+			context = (hound_context_id_t) IPC_GET_ARG1(&call);
 			ret = server_iface->rem_context(server_iface->server,
 			    context);
 			async_answer_0(&call, ret);
@@ -454,9 +454,9 @@ void hound_connection_handler(ipc_call_t *icall, void *arg)
 			}
 
 			char **list = NULL;
-			flags = IPC_GET_ARG1(call);
-			size_t count = IPC_GET_ARG2(call);
-			const bool conn = IPC_GET_ARG3(call);
+			flags = IPC_GET_ARG1(&call);
+			size_t count = IPC_GET_ARG2(&call);
+			const bool conn = IPC_GET_ARG3(&call);
 			char *conn_name = NULL;
 			ret = EOK;
 
@@ -567,15 +567,15 @@ void hound_connection_handler(ipc_call_t *icall, void *arg)
 			}
 
 			/* get parameters */
-			context = (hound_context_id_t) IPC_GET_ARG1(call);
-			flags = IPC_GET_ARG2(call);
-			const format_convert_t c = { .arg = IPC_GET_ARG3(call) };
+			context = (hound_context_id_t) IPC_GET_ARG1(&call);
+			flags = IPC_GET_ARG2(&call);
+			const format_convert_t c = { .arg = IPC_GET_ARG3(&call) };
 			const pcm_format_t f = {
 				.sampling_rate = c.f.rate * 100,
 				.channels = c.f.channels,
 				.sample_format = c.f.format,
 			};
-			size_t bsize = IPC_GET_ARG4(call);
+			size_t bsize = IPC_GET_ARG4(&call);
 
 			void *stream;
 			ret = server_iface->add_stream(server_iface->server,
@@ -639,9 +639,9 @@ static void hound_server_read_data(void *stream)
 
 	/* accept data write or drain */
 	while (async_data_write_receive(&call, &size) ||
-	    (IPC_GET_IMETHOD(call) == IPC_M_HOUND_STREAM_DRAIN)) {
+	    (IPC_GET_IMETHOD(&call) == IPC_M_HOUND_STREAM_DRAIN)) {
 		/* check drain first */
-		if (IPC_GET_IMETHOD(call) == IPC_M_HOUND_STREAM_DRAIN) {
+		if (IPC_GET_IMETHOD(&call) == IPC_M_HOUND_STREAM_DRAIN) {
 			errno_t ret = ENOTSUP;
 			if (server_iface->drain_stream)
 				ret = server_iface->drain_stream(stream);
@@ -667,7 +667,7 @@ static void hound_server_read_data(void *stream)
 			    stream, buffer, size);
 		}
 	}
-	const errno_t ret = IPC_GET_IMETHOD(call) == IPC_M_HOUND_STREAM_EXIT ?
+	const errno_t ret = IPC_GET_IMETHOD(&call) == IPC_M_HOUND_STREAM_EXIT ?
 	    EOK : EINVAL;
 
 	async_answer_0(&call, ret);
@@ -686,9 +686,9 @@ static void hound_server_write_data(void *stream)
 
 	/* accept data read and drain */
 	while (async_data_read_receive(&call, &size) ||
-	    (IPC_GET_IMETHOD(call) == IPC_M_HOUND_STREAM_DRAIN)) {
+	    (IPC_GET_IMETHOD(&call) == IPC_M_HOUND_STREAM_DRAIN)) {
 		/* drain does not make much sense but it is allowed */
-		if (IPC_GET_IMETHOD(call) == IPC_M_HOUND_STREAM_DRAIN) {
+		if (IPC_GET_IMETHOD(&call) == IPC_M_HOUND_STREAM_DRAIN) {
 			errno_t ret = ENOTSUP;
 			if (server_iface->drain_stream)
 				ret = server_iface->drain_stream(stream);
@@ -711,7 +711,7 @@ static void hound_server_write_data(void *stream)
 			    async_data_read_finalize(&call, buffer, size);
 		}
 	}
-	const errno_t ret = IPC_GET_IMETHOD(call) == IPC_M_HOUND_STREAM_EXIT ?
+	const errno_t ret = IPC_GET_IMETHOD(&call) == IPC_M_HOUND_STREAM_EXIT ?
 	    EOK : EINVAL;
 
 	async_answer_0(&call, ret);

--- a/uspace/lib/hound/src/protocol.c
+++ b/uspace/lib/hound/src/protocol.c
@@ -139,7 +139,7 @@ errno_t hound_service_register_context(hound_sess_t *sess,
 
 	async_exchange_end(exch);
 	if (ret == EOK) {
-		*id = (hound_context_id_t) IPC_GET_ARG1(&call);
+		*id = (hound_context_id_t) ipc_get_arg1(&call);
 	}
 
 	return ret;
@@ -202,7 +202,7 @@ errno_t hound_service_get_list(hound_sess_t *sess, char ***ids, size_t *count,
 		async_exchange_end(exch);
 		return ret;
 	}
-	unsigned name_count = IPC_GET_ARG1(&res_call);
+	unsigned name_count = ipc_get_arg1(&res_call);
 
 	/* Start receiving names */
 	char **names = NULL;
@@ -405,14 +405,14 @@ void hound_connection_handler(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case IPC_M_HOUND_CONTEXT_REGISTER:
 			/* check interface functions */
 			if (!server_iface || !server_iface->add_context) {
 				async_answer_0(&call, ENOTSUP);
 				break;
 			}
-			bool record = IPC_GET_ARG1(&call);
+			bool record = ipc_get_arg1(&call);
 			void *name;
 
 			/* Get context name */
@@ -441,7 +441,7 @@ void hound_connection_handler(ipc_call_t *icall, void *arg)
 			}
 
 			/* get id, 1st param */
-			context = (hound_context_id_t) IPC_GET_ARG1(&call);
+			context = (hound_context_id_t) ipc_get_arg1(&call);
 			ret = server_iface->rem_context(server_iface->server,
 			    context);
 			async_answer_0(&call, ret);
@@ -454,9 +454,9 @@ void hound_connection_handler(ipc_call_t *icall, void *arg)
 			}
 
 			char **list = NULL;
-			flags = IPC_GET_ARG1(&call);
-			size_t count = IPC_GET_ARG2(&call);
-			const bool conn = IPC_GET_ARG3(&call);
+			flags = ipc_get_arg1(&call);
+			size_t count = ipc_get_arg2(&call);
+			const bool conn = ipc_get_arg3(&call);
 			char *conn_name = NULL;
 			ret = EOK;
 
@@ -567,15 +567,15 @@ void hound_connection_handler(ipc_call_t *icall, void *arg)
 			}
 
 			/* get parameters */
-			context = (hound_context_id_t) IPC_GET_ARG1(&call);
-			flags = IPC_GET_ARG2(&call);
-			const format_convert_t c = { .arg = IPC_GET_ARG3(&call) };
+			context = (hound_context_id_t) ipc_get_arg1(&call);
+			flags = ipc_get_arg2(&call);
+			const format_convert_t c = { .arg = ipc_get_arg3(&call) };
 			const pcm_format_t f = {
 				.sampling_rate = c.f.rate * 100,
 				.channels = c.f.channels,
 				.sample_format = c.f.format,
 			};
-			size_t bsize = IPC_GET_ARG4(&call);
+			size_t bsize = ipc_get_arg4(&call);
 
 			void *stream;
 			ret = server_iface->add_stream(server_iface->server,
@@ -639,9 +639,9 @@ static void hound_server_read_data(void *stream)
 
 	/* accept data write or drain */
 	while (async_data_write_receive(&call, &size) ||
-	    (IPC_GET_IMETHOD(&call) == IPC_M_HOUND_STREAM_DRAIN)) {
+	    (ipc_get_imethod(&call) == IPC_M_HOUND_STREAM_DRAIN)) {
 		/* check drain first */
-		if (IPC_GET_IMETHOD(&call) == IPC_M_HOUND_STREAM_DRAIN) {
+		if (ipc_get_imethod(&call) == IPC_M_HOUND_STREAM_DRAIN) {
 			errno_t ret = ENOTSUP;
 			if (server_iface->drain_stream)
 				ret = server_iface->drain_stream(stream);
@@ -667,7 +667,7 @@ static void hound_server_read_data(void *stream)
 			    stream, buffer, size);
 		}
 	}
-	const errno_t ret = IPC_GET_IMETHOD(&call) == IPC_M_HOUND_STREAM_EXIT ?
+	const errno_t ret = ipc_get_imethod(&call) == IPC_M_HOUND_STREAM_EXIT ?
 	    EOK : EINVAL;
 
 	async_answer_0(&call, ret);
@@ -686,9 +686,9 @@ static void hound_server_write_data(void *stream)
 
 	/* accept data read and drain */
 	while (async_data_read_receive(&call, &size) ||
-	    (IPC_GET_IMETHOD(&call) == IPC_M_HOUND_STREAM_DRAIN)) {
+	    (ipc_get_imethod(&call) == IPC_M_HOUND_STREAM_DRAIN)) {
 		/* drain does not make much sense but it is allowed */
-		if (IPC_GET_IMETHOD(&call) == IPC_M_HOUND_STREAM_DRAIN) {
+		if (ipc_get_imethod(&call) == IPC_M_HOUND_STREAM_DRAIN) {
 			errno_t ret = ENOTSUP;
 			if (server_iface->drain_stream)
 				ret = server_iface->drain_stream(stream);
@@ -711,7 +711,7 @@ static void hound_server_write_data(void *stream)
 			    async_data_read_finalize(&call, buffer, size);
 		}
 	}
-	const errno_t ret = IPC_GET_IMETHOD(&call) == IPC_M_HOUND_STREAM_EXIT ?
+	const errno_t ret = ipc_get_imethod(&call) == IPC_M_HOUND_STREAM_EXIT ?
 	    EOK : EINVAL;
 
 	async_answer_0(&call, ret);

--- a/uspace/lib/hound/src/protocol.c
+++ b/uspace/lib/hound/src/protocol.c
@@ -157,7 +157,7 @@ errno_t hound_service_unregister_context(hound_sess_t *sess,
 	assert(sess);
 	async_exch_t *exch = async_exchange_begin(sess);
 	const errno_t ret = async_req_1_0(exch, IPC_M_HOUND_CONTEXT_UNREGISTER,
-	    CAP_HANDLE_RAW(id));
+	    cap_handle_raw(id));
 	async_exchange_end(exch);
 	return ret;
 }
@@ -314,7 +314,7 @@ errno_t hound_service_stream_enter(async_exch_t *exch, hound_context_id_t id,
 		}
 	};
 
-	return async_req_4_0(exch, IPC_M_HOUND_STREAM_ENTER, CAP_HANDLE_RAW(id),
+	return async_req_4_0(exch, IPC_M_HOUND_STREAM_ENTER, cap_handle_raw(id),
 	    flags, c.arg, bsize);
 }
 
@@ -430,7 +430,7 @@ void hound_connection_handler(ipc_call_t *icall, void *arg)
 			if (ret != EOK) {
 				async_answer_0(&call, ret);
 			} else {
-				async_answer_1(&call, EOK, CAP_HANDLE_RAW(context));
+				async_answer_1(&call, EOK, cap_handle_raw(context));
 			}
 			break;
 		case IPC_M_HOUND_CONTEXT_UNREGISTER:

--- a/uspace/lib/usbhost/src/hcd.c
+++ b/uspace/lib/usbhost/src/hcd.c
@@ -100,7 +100,7 @@ static void irq_handler(ipc_call_t *call, ddf_dev_t *dev)
 	assert(dev);
 	hc_device_t *hcd = dev_to_hcd(dev);
 
-	const uint32_t status = IPC_GET_ARG1(*call);
+	const uint32_t status = IPC_GET_ARG1(call);
 	hcd->bus->ops->interrupt(hcd->bus, status);
 }
 

--- a/uspace/lib/usbhost/src/hcd.c
+++ b/uspace/lib/usbhost/src/hcd.c
@@ -100,7 +100,7 @@ static void irq_handler(ipc_call_t *call, ddf_dev_t *dev)
 	assert(dev);
 	hc_device_t *hcd = dev_to_hcd(dev);
 
-	const uint32_t status = IPC_GET_ARG1(call);
+	const uint32_t status = ipc_get_arg1(call);
 	hcd->bus->ops->interrupt(hcd->bus, status);
 }
 

--- a/uspace/lib/usbvirt/src/device.c
+++ b/uspace/lib/usbvirt/src/device.c
@@ -65,7 +65,7 @@ static void callback_connection(ipc_call_t *icall, void *arg)
 
 		bool processed = usbvirt_ipc_handle_call(DEV, &call);
 		if (!processed) {
-			if (!IPC_GET_IMETHOD(call)) {
+			if (!IPC_GET_IMETHOD(&call)) {
 				async_answer_0(&call, EOK);
 				return;
 			} else

--- a/uspace/lib/usbvirt/src/device.c
+++ b/uspace/lib/usbvirt/src/device.c
@@ -65,7 +65,7 @@ static void callback_connection(ipc_call_t *icall, void *arg)
 
 		bool processed = usbvirt_ipc_handle_call(DEV, &call);
 		if (!processed) {
-			if (!IPC_GET_IMETHOD(&call)) {
+			if (!ipc_get_imethod(&call)) {
 				async_answer_0(&call, EOK);
 				return;
 			} else

--- a/uspace/lib/usbvirt/src/ipc_dev.c
+++ b/uspace/lib/usbvirt/src/ipc_dev.c
@@ -132,7 +132,7 @@ static void ipc_control_read(usbvirt_device_t *dev, ipc_call_t *icall)
  */
 static void ipc_control_write(usbvirt_device_t *dev, ipc_call_t *icall)
 {
-	size_t data_buffer_len = IPC_GET_ARG1(icall);
+	size_t data_buffer_len = ipc_get_arg1(icall);
 	errno_t rc;
 
 	void *setup_packet = NULL;
@@ -176,7 +176,7 @@ static void ipc_control_write(usbvirt_device_t *dev, ipc_call_t *icall)
 static void ipc_data_in(usbvirt_device_t *dev,
     usb_transfer_type_t transfer_type, ipc_call_t *icall)
 {
-	usb_endpoint_t endpoint = IPC_GET_ARG1(icall);
+	usb_endpoint_t endpoint = ipc_get_arg1(icall);
 
 	errno_t rc;
 
@@ -219,7 +219,7 @@ static void ipc_data_in(usbvirt_device_t *dev,
 static void ipc_data_out(usbvirt_device_t *dev,
     usb_transfer_type_t transfer_type, ipc_call_t *icall)
 {
-	usb_endpoint_t endpoint = IPC_GET_ARG1(icall);
+	usb_endpoint_t endpoint = ipc_get_arg1(icall);
 
 	void *data_buffer = NULL;
 	size_t data_buffer_size = 0;
@@ -249,7 +249,7 @@ static void ipc_data_out(usbvirt_device_t *dev,
  */
 bool usbvirt_ipc_handle_call(usbvirt_device_t *dev, ipc_call_t *call)
 {
-	switch (IPC_GET_IMETHOD(call)) {
+	switch (ipc_get_imethod(call)) {
 	case IPC_M_USBVIRT_GET_NAME:
 		ipc_get_name(dev, call);
 		break;

--- a/uspace/lib/usbvirt/src/ipc_dev.c
+++ b/uspace/lib/usbvirt/src/ipc_dev.c
@@ -132,7 +132,7 @@ static void ipc_control_read(usbvirt_device_t *dev, ipc_call_t *icall)
  */
 static void ipc_control_write(usbvirt_device_t *dev, ipc_call_t *icall)
 {
-	size_t data_buffer_len = IPC_GET_ARG1(*icall);
+	size_t data_buffer_len = IPC_GET_ARG1(icall);
 	errno_t rc;
 
 	void *setup_packet = NULL;
@@ -176,7 +176,7 @@ static void ipc_control_write(usbvirt_device_t *dev, ipc_call_t *icall)
 static void ipc_data_in(usbvirt_device_t *dev,
     usb_transfer_type_t transfer_type, ipc_call_t *icall)
 {
-	usb_endpoint_t endpoint = IPC_GET_ARG1(*icall);
+	usb_endpoint_t endpoint = IPC_GET_ARG1(icall);
 
 	errno_t rc;
 
@@ -219,7 +219,7 @@ static void ipc_data_in(usbvirt_device_t *dev,
 static void ipc_data_out(usbvirt_device_t *dev,
     usb_transfer_type_t transfer_type, ipc_call_t *icall)
 {
-	usb_endpoint_t endpoint = IPC_GET_ARG1(*icall);
+	usb_endpoint_t endpoint = IPC_GET_ARG1(icall);
 
 	void *data_buffer = NULL;
 	size_t data_buffer_size = 0;
@@ -249,7 +249,7 @@ static void ipc_data_out(usbvirt_device_t *dev,
  */
 bool usbvirt_ipc_handle_call(usbvirt_device_t *dev, ipc_call_t *call)
 {
-	switch (IPC_GET_IMETHOD(*call)) {
+	switch (IPC_GET_IMETHOD(call)) {
 	case IPC_M_USBVIRT_GET_NAME:
 		ipc_get_name(dev, call);
 		break;

--- a/uspace/lib/usbvirt/src/ipc_hc.c
+++ b/uspace/lib/usbvirt/src/ipc_hc.c
@@ -112,7 +112,7 @@ errno_t usbvirt_ipc_send_control_read(async_sess_t *sess, void *setup_buffer,
 		return (errno_t) opening_request_rc;
 
 	if (data_transferred_size != NULL)
-		*data_transferred_size = IPC_GET_ARG2(&data_request_call);
+		*data_transferred_size = ipc_get_arg2(&data_request_call);
 
 	return EOK;
 }
@@ -249,7 +249,7 @@ errno_t usbvirt_ipc_send_data_in(async_sess_t *sess, usb_endpoint_t ep,
 		return (errno_t) opening_request_rc;
 
 	if (act_size != NULL)
-		*act_size = IPC_GET_ARG2(&data_request_call);
+		*act_size = ipc_get_arg2(&data_request_call);
 
 	return EOK;
 }

--- a/uspace/lib/usbvirt/src/ipc_hc.c
+++ b/uspace/lib/usbvirt/src/ipc_hc.c
@@ -112,7 +112,7 @@ errno_t usbvirt_ipc_send_control_read(async_sess_t *sess, void *setup_buffer,
 		return (errno_t) opening_request_rc;
 
 	if (data_transferred_size != NULL)
-		*data_transferred_size = IPC_GET_ARG2(data_request_call);
+		*data_transferred_size = IPC_GET_ARG2(&data_request_call);
 
 	return EOK;
 }
@@ -249,7 +249,7 @@ errno_t usbvirt_ipc_send_data_in(async_sess_t *sess, usb_endpoint_t ep,
 		return (errno_t) opening_request_rc;
 
 	if (act_size != NULL)
-		*act_size = IPC_GET_ARG2(data_request_call);
+		*act_size = IPC_GET_ARG2(&data_request_call);
 
 	return EOK;
 }

--- a/uspace/srv/audio/hound/audio_device.c
+++ b/uspace/srv/audio/hound/audio_device.c
@@ -274,7 +274,7 @@ static void device_event_callback(ipc_call_t *icall, void *arg)
 		async_get_call(&call);
 		async_answer_0(&call, EOK);
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case PCM_EVENT_FRAMES_PLAYED:
 			getuptime(&time1);
 			//TODO add underrun detection.

--- a/uspace/srv/audio/hound/audio_device.c
+++ b/uspace/srv/audio/hound/audio_device.c
@@ -274,7 +274,7 @@ static void device_event_callback(ipc_call_t *icall, void *arg)
 		async_get_call(&call);
 		async_answer_0(&call, EOK);
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case PCM_EVENT_FRAMES_PLAYED:
 			getuptime(&time1);
 			//TODO add underrun detection.

--- a/uspace/srv/bd/sata_bd/sata_bd.c
+++ b/uspace/srv/bd/sata_bd/sata_bd.c
@@ -172,7 +172,7 @@ static void sata_bd_connection(ipc_call_t *icall, void *arg)
 	int disk_id, i;
 
 	/* Get the device service ID. */
-	dsid = IPC_GET_ARG2(icall);
+	dsid = ipc_get_arg2(icall);
 
 	/* Determine which disk device is the client connecting to. */
 	disk_id = -1;

--- a/uspace/srv/bd/sata_bd/sata_bd.c
+++ b/uspace/srv/bd/sata_bd/sata_bd.c
@@ -172,7 +172,7 @@ static void sata_bd_connection(ipc_call_t *icall, void *arg)
 	int disk_id, i;
 
 	/* Get the device service ID. */
-	dsid = IPC_GET_ARG2(*icall);
+	dsid = IPC_GET_ARG2(icall);
 
 	/* Determine which disk device is the client connecting to. */
 	disk_id = -1;

--- a/uspace/srv/bd/vbd/disk.c
+++ b/uspace/srv/bd/vbd/disk.c
@@ -1076,7 +1076,7 @@ void vbds_bd_conn(ipc_call_t *icall, void *arg)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vbds_bd_conn()");
 
-	svcid = IPC_GET_ARG2(icall);
+	svcid = ipc_get_arg2(icall);
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vbds_bd_conn() - svcid=%zu", svcid);
 

--- a/uspace/srv/bd/vbd/disk.c
+++ b/uspace/srv/bd/vbd/disk.c
@@ -1076,7 +1076,7 @@ void vbds_bd_conn(ipc_call_t *icall, void *arg)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vbds_bd_conn()");
 
-	svcid = IPC_GET_ARG2(*icall);
+	svcid = IPC_GET_ARG2(icall);
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vbds_bd_conn() - svcid=%zu", svcid);
 

--- a/uspace/srv/bd/vbd/vbd.c
+++ b/uspace/srv/bd/vbd/vbd.c
@@ -128,7 +128,7 @@ static void vbds_disk_info_srv(ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vbds_disk_info_srv()");
 
-	disk_sid = IPC_GET_ARG1(*icall);
+	disk_sid = IPC_GET_ARG1(icall);
 	rc = vbds_disk_info(disk_sid, &dinfo);
 	if (rc != EOK) {
 		async_answer_0(icall, rc);
@@ -168,8 +168,8 @@ static void vbds_label_create_srv(ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vbds_label_create_srv()");
 
-	disk_sid = IPC_GET_ARG1(*icall);
-	ltype = IPC_GET_ARG2(*icall);
+	disk_sid = IPC_GET_ARG1(icall);
+	ltype = IPC_GET_ARG2(icall);
 	rc = vbds_label_create(disk_sid, ltype);
 	async_answer_0(icall, rc);
 }
@@ -181,7 +181,7 @@ static void vbds_label_delete_srv(ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vbds_label_delete_srv()");
 
-	disk_sid = IPC_GET_ARG1(*icall);
+	disk_sid = IPC_GET_ARG1(icall);
 	rc = vbds_label_delete(disk_sid);
 	async_answer_0(icall, rc);
 }
@@ -202,7 +202,7 @@ static void vbds_label_get_parts_srv(ipc_call_t *icall)
 		return;
 	}
 
-	sid = IPC_GET_ARG1(*icall);
+	sid = IPC_GET_ARG1(icall);
 
 	category_id_t *id_buf = (category_id_t *) malloc(size);
 	if (id_buf == NULL) {
@@ -232,7 +232,7 @@ static void vbds_part_get_info_srv(ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vbds_part_get_info_srv()");
 
-	part = IPC_GET_ARG1(*icall);
+	part = IPC_GET_ARG1(icall);
 	rc = vbds_part_get_info(part, &pinfo);
 	if (rc != EOK) {
 		async_answer_0(icall, rc);
@@ -273,7 +273,7 @@ static void vbds_part_create_srv(ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vbds_part_create_srv()");
 
-	disk_sid = IPC_GET_ARG1(*icall);
+	disk_sid = IPC_GET_ARG1(icall);
 
 	ipc_call_t call;
 	size_t size;
@@ -312,7 +312,7 @@ static void vbds_part_delete_srv(ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vbds_part_delete_srv()");
 
-	part = IPC_GET_ARG1(*icall);
+	part = IPC_GET_ARG1(icall);
 	rc = vbds_part_delete(part);
 	async_answer_0(icall, rc);
 }
@@ -326,8 +326,8 @@ static void vbds_suggest_ptype_srv(ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vbds_suggest_ptype_srv()");
 
-	disk_sid = IPC_GET_ARG1(*icall);
-	pcnt = IPC_GET_ARG2(*icall);
+	disk_sid = IPC_GET_ARG1(icall);
+	pcnt = IPC_GET_ARG2(icall);
 
 	rc = vbds_suggest_ptype(disk_sid, pcnt, &ptype);
 	if (rc != EOK) {
@@ -369,7 +369,7 @@ static void vbds_ctl_conn(ipc_call_t *icall, void *arg)
 	while (true) {
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(call);
+		sysarg_t method = IPC_GET_IMETHOD(&call);
 
 		if (!method) {
 			/* The other side has hung up */
@@ -417,7 +417,7 @@ static void vbds_client_conn(ipc_call_t *icall, void *arg)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vbds_client_conn()");
 
-	sid = (service_id_t) IPC_GET_ARG2(*icall);
+	sid = (service_id_t) IPC_GET_ARG2(icall);
 
 	if (sid == ctl_sid)
 		vbds_ctl_conn(icall, arg);

--- a/uspace/srv/bd/vbd/vbd.c
+++ b/uspace/srv/bd/vbd/vbd.c
@@ -128,7 +128,7 @@ static void vbds_disk_info_srv(ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vbds_disk_info_srv()");
 
-	disk_sid = IPC_GET_ARG1(icall);
+	disk_sid = ipc_get_arg1(icall);
 	rc = vbds_disk_info(disk_sid, &dinfo);
 	if (rc != EOK) {
 		async_answer_0(icall, rc);
@@ -168,8 +168,8 @@ static void vbds_label_create_srv(ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vbds_label_create_srv()");
 
-	disk_sid = IPC_GET_ARG1(icall);
-	ltype = IPC_GET_ARG2(icall);
+	disk_sid = ipc_get_arg1(icall);
+	ltype = ipc_get_arg2(icall);
 	rc = vbds_label_create(disk_sid, ltype);
 	async_answer_0(icall, rc);
 }
@@ -181,7 +181,7 @@ static void vbds_label_delete_srv(ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vbds_label_delete_srv()");
 
-	disk_sid = IPC_GET_ARG1(icall);
+	disk_sid = ipc_get_arg1(icall);
 	rc = vbds_label_delete(disk_sid);
 	async_answer_0(icall, rc);
 }
@@ -202,7 +202,7 @@ static void vbds_label_get_parts_srv(ipc_call_t *icall)
 		return;
 	}
 
-	sid = IPC_GET_ARG1(icall);
+	sid = ipc_get_arg1(icall);
 
 	category_id_t *id_buf = (category_id_t *) malloc(size);
 	if (id_buf == NULL) {
@@ -232,7 +232,7 @@ static void vbds_part_get_info_srv(ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vbds_part_get_info_srv()");
 
-	part = IPC_GET_ARG1(icall);
+	part = ipc_get_arg1(icall);
 	rc = vbds_part_get_info(part, &pinfo);
 	if (rc != EOK) {
 		async_answer_0(icall, rc);
@@ -273,7 +273,7 @@ static void vbds_part_create_srv(ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vbds_part_create_srv()");
 
-	disk_sid = IPC_GET_ARG1(icall);
+	disk_sid = ipc_get_arg1(icall);
 
 	ipc_call_t call;
 	size_t size;
@@ -312,7 +312,7 @@ static void vbds_part_delete_srv(ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vbds_part_delete_srv()");
 
-	part = IPC_GET_ARG1(icall);
+	part = ipc_get_arg1(icall);
 	rc = vbds_part_delete(part);
 	async_answer_0(icall, rc);
 }
@@ -326,8 +326,8 @@ static void vbds_suggest_ptype_srv(ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vbds_suggest_ptype_srv()");
 
-	disk_sid = IPC_GET_ARG1(icall);
-	pcnt = IPC_GET_ARG2(icall);
+	disk_sid = ipc_get_arg1(icall);
+	pcnt = ipc_get_arg2(icall);
 
 	rc = vbds_suggest_ptype(disk_sid, pcnt, &ptype);
 	if (rc != EOK) {
@@ -369,7 +369,7 @@ static void vbds_ctl_conn(ipc_call_t *icall, void *arg)
 	while (true) {
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(&call);
+		sysarg_t method = ipc_get_imethod(&call);
 
 		if (!method) {
 			/* The other side has hung up */
@@ -417,7 +417,7 @@ static void vbds_client_conn(ipc_call_t *icall, void *arg)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vbds_client_conn()");
 
-	sid = (service_id_t) IPC_GET_ARG2(icall);
+	sid = (service_id_t) ipc_get_arg2(icall);
 
 	if (sid == ctl_sid)
 		vbds_ctl_conn(icall, arg);

--- a/uspace/srv/clipboard/clipboard.c
+++ b/uspace/srv/clipboard/clipboard.c
@@ -52,7 +52,7 @@ static void clip_put_data(ipc_call_t *req)
 	errno_t rc;
 	size_t size;
 
-	switch (IPC_GET_ARG1(req)) {
+	switch (ipc_get_arg1(req)) {
 	case CLIPBOARD_TAG_NONE:
 		fibril_mutex_lock(&clip_mtx);
 
@@ -98,7 +98,7 @@ static void clip_get_data(ipc_call_t *req)
 	size_t size;
 
 	/* Check for clipboard data tag compatibility */
-	switch (IPC_GET_ARG1(req)) {
+	switch (ipc_get_arg1(req)) {
 	case CLIPBOARD_TAG_DATA:
 		if (!async_data_read_receive(&call, &size)) {
 			async_answer_0(&call, EINVAL);
@@ -160,12 +160,12 @@ static void clip_connection(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case CLIPBOARD_PUT_DATA:
 			clip_put_data(&call);
 			break;

--- a/uspace/srv/clipboard/clipboard.c
+++ b/uspace/srv/clipboard/clipboard.c
@@ -52,7 +52,7 @@ static void clip_put_data(ipc_call_t *req)
 	errno_t rc;
 	size_t size;
 
-	switch (IPC_GET_ARG1(*req)) {
+	switch (IPC_GET_ARG1(req)) {
 	case CLIPBOARD_TAG_NONE:
 		fibril_mutex_lock(&clip_mtx);
 
@@ -98,7 +98,7 @@ static void clip_get_data(ipc_call_t *req)
 	size_t size;
 
 	/* Check for clipboard data tag compatibility */
-	switch (IPC_GET_ARG1(*req)) {
+	switch (IPC_GET_ARG1(req)) {
 	case CLIPBOARD_TAG_DATA:
 		if (!async_data_read_receive(&call, &size)) {
 			async_answer_0(&call, EINVAL);
@@ -160,12 +160,12 @@ static void clip_connection(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case CLIPBOARD_PUT_DATA:
 			clip_put_data(&call);
 			break;

--- a/uspace/srv/devman/client_conn.c
+++ b/uspace/srv/devman/client_conn.c
@@ -101,8 +101,8 @@ static void devman_function_get_handle(ipc_call_t *icall)
 /** Get device match ID. */
 static void devman_fun_get_match_id(ipc_call_t *icall)
 {
-	devman_handle_t handle = IPC_GET_ARG1(*icall);
-	size_t index = IPC_GET_ARG2(*icall);
+	devman_handle_t handle = IPC_GET_ARG1(icall);
+	size_t index = IPC_GET_ARG2(icall);
 	void *buffer = NULL;
 
 	fun_node_t *fun = find_fun_node(&device_tree, handle);
@@ -164,7 +164,7 @@ error:
 /** Get device name. */
 static void devman_fun_get_name(ipc_call_t *icall)
 {
-	devman_handle_t handle = IPC_GET_ARG1(*icall);
+	devman_handle_t handle = IPC_GET_ARG1(icall);
 
 	fun_node_t *fun = find_fun_node(&device_tree, handle);
 	if (fun == NULL) {
@@ -217,7 +217,7 @@ static void devman_fun_get_name(ipc_call_t *icall)
 /** Get function driver name. */
 static void devman_fun_get_driver_name(ipc_call_t *icall)
 {
-	devman_handle_t handle = IPC_GET_ARG1(*icall);
+	devman_handle_t handle = IPC_GET_ARG1(icall);
 
 	fun_node_t *fun = find_fun_node(&device_tree, handle);
 	if (fun == NULL) {
@@ -282,7 +282,7 @@ static void devman_fun_get_driver_name(ipc_call_t *icall)
 /** Get device path. */
 static void devman_fun_get_path(ipc_call_t *icall)
 {
-	devman_handle_t handle = IPC_GET_ARG1(*icall);
+	devman_handle_t handle = IPC_GET_ARG1(icall);
 
 	fun_node_t *fun = find_fun_node(&device_tree, handle);
 	if (fun == NULL) {
@@ -339,7 +339,7 @@ static void devman_dev_get_parent(ipc_call_t *icall)
 
 	fibril_rwlock_read_lock(&device_tree.rwlock);
 
-	dev = find_dev_node_no_lock(&device_tree, IPC_GET_ARG1(*icall));
+	dev = find_dev_node_no_lock(&device_tree, IPC_GET_ARG1(icall));
 	if (dev == NULL || dev->state == DEVICE_REMOVED) {
 		fibril_rwlock_read_unlock(&device_tree.rwlock);
 		async_answer_0(icall, ENOENT);
@@ -373,7 +373,7 @@ static void devman_dev_get_functions(ipc_call_t *icall)
 	fibril_rwlock_read_lock(&device_tree.rwlock);
 
 	dev_node_t *dev = find_dev_node_no_lock(&device_tree,
-	    IPC_GET_ARG1(*icall));
+	    IPC_GET_ARG1(icall));
 	if (dev == NULL || dev->state == DEVICE_REMOVED) {
 		fibril_rwlock_read_unlock(&device_tree.rwlock);
 		async_answer_0(&call, ENOENT);
@@ -412,7 +412,7 @@ static void devman_fun_get_child(ipc_call_t *icall)
 
 	fibril_rwlock_read_lock(&device_tree.rwlock);
 
-	fun = find_fun_node_no_lock(&device_tree, IPC_GET_ARG1(*icall));
+	fun = find_fun_node_no_lock(&device_tree, IPC_GET_ARG1(icall));
 	if (fun == NULL || fun->state == FUN_REMOVED) {
 		fibril_rwlock_read_unlock(&device_tree.rwlock);
 		async_answer_0(icall, ENOENT);
@@ -441,7 +441,7 @@ static void devman_fun_online(ipc_call_t *icall)
 	fun_node_t *fun;
 	errno_t rc;
 
-	fun = find_fun_node(&device_tree, IPC_GET_ARG1(*icall));
+	fun = find_fun_node(&device_tree, IPC_GET_ARG1(icall));
 	if (fun == NULL) {
 		async_answer_0(icall, ENOENT);
 		return;
@@ -466,7 +466,7 @@ static void devman_fun_offline(ipc_call_t *icall)
 	fun_node_t *fun;
 	errno_t rc;
 
-	fun = find_fun_node(&device_tree, IPC_GET_ARG1(*icall));
+	fun = find_fun_node(&device_tree, IPC_GET_ARG1(icall));
 	if (fun == NULL) {
 		async_answer_0(icall, ENOENT);
 		return;
@@ -483,7 +483,7 @@ static void devman_fun_sid_to_handle(ipc_call_t *icall)
 {
 	fun_node_t *fun;
 
-	fun = find_loc_tree_function(&device_tree, IPC_GET_ARG1(*icall));
+	fun = find_loc_tree_function(&device_tree, IPC_GET_ARG1(icall));
 
 	if (fun == NULL) {
 		async_answer_0(icall, ENOENT);
@@ -549,7 +549,7 @@ static void devman_driver_get_devices(ipc_call_t *icall)
 		return;
 	}
 
-	driver_t *drv = driver_find(&drivers_list, IPC_GET_ARG1(*icall));
+	driver_t *drv = driver_find(&drivers_list, IPC_GET_ARG1(icall));
 	if (drv == NULL) {
 		async_answer_0(&call, ENOENT);
 		async_answer_0(icall, ENOENT);
@@ -603,8 +603,8 @@ static void devman_driver_get_handle(ipc_call_t *icall)
 /** Get driver match ID. */
 static void devman_driver_get_match_id(ipc_call_t *icall)
 {
-	devman_handle_t handle = IPC_GET_ARG1(*icall);
-	size_t index = IPC_GET_ARG2(*icall);
+	devman_handle_t handle = IPC_GET_ARG1(icall);
+	size_t index = IPC_GET_ARG2(icall);
 
 	driver_t *drv = driver_find(&drivers_list, handle);
 	if (drv == NULL) {
@@ -654,7 +654,7 @@ static void devman_driver_get_match_id(ipc_call_t *icall)
 /** Get driver name. */
 static void devman_driver_get_name(ipc_call_t *icall)
 {
-	devman_handle_t handle = IPC_GET_ARG1(*icall);
+	devman_handle_t handle = IPC_GET_ARG1(icall);
 
 	driver_t *drv = driver_find(&drivers_list, handle);
 	if (drv == NULL) {
@@ -696,7 +696,7 @@ static void devman_driver_get_state(ipc_call_t *icall)
 {
 	driver_t *drv;
 
-	drv = driver_find(&drivers_list, IPC_GET_ARG1(*icall));
+	drv = driver_find(&drivers_list, IPC_GET_ARG1(icall));
 	if (drv == NULL) {
 		async_answer_0(icall, ENOENT);
 		return;
@@ -711,7 +711,7 @@ static void devman_driver_load(ipc_call_t *icall)
 	driver_t *drv;
 	errno_t rc;
 
-	drv = driver_find(&drivers_list, IPC_GET_ARG1(*icall));
+	drv = driver_find(&drivers_list, IPC_GET_ARG1(icall));
 	if (drv == NULL) {
 		async_answer_0(icall, ENOENT);
 		return;
@@ -730,7 +730,7 @@ static void devman_driver_unload(ipc_call_t *icall)
 	driver_t *drv;
 	errno_t rc;
 
-	drv = driver_find(&drivers_list, IPC_GET_ARG1(*icall));
+	drv = driver_find(&drivers_list, IPC_GET_ARG1(icall));
 	if (drv == NULL) {
 		async_answer_0(icall, ENOENT);
 		return;
@@ -753,12 +753,12 @@ void devman_connection_client(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case DEVMAN_DEVICE_GET_HANDLE:
 			devman_function_get_handle(&call);
 			break;

--- a/uspace/srv/devman/client_conn.c
+++ b/uspace/srv/devman/client_conn.c
@@ -101,8 +101,8 @@ static void devman_function_get_handle(ipc_call_t *icall)
 /** Get device match ID. */
 static void devman_fun_get_match_id(ipc_call_t *icall)
 {
-	devman_handle_t handle = IPC_GET_ARG1(icall);
-	size_t index = IPC_GET_ARG2(icall);
+	devman_handle_t handle = ipc_get_arg1(icall);
+	size_t index = ipc_get_arg2(icall);
 	void *buffer = NULL;
 
 	fun_node_t *fun = find_fun_node(&device_tree, handle);
@@ -164,7 +164,7 @@ error:
 /** Get device name. */
 static void devman_fun_get_name(ipc_call_t *icall)
 {
-	devman_handle_t handle = IPC_GET_ARG1(icall);
+	devman_handle_t handle = ipc_get_arg1(icall);
 
 	fun_node_t *fun = find_fun_node(&device_tree, handle);
 	if (fun == NULL) {
@@ -217,7 +217,7 @@ static void devman_fun_get_name(ipc_call_t *icall)
 /** Get function driver name. */
 static void devman_fun_get_driver_name(ipc_call_t *icall)
 {
-	devman_handle_t handle = IPC_GET_ARG1(icall);
+	devman_handle_t handle = ipc_get_arg1(icall);
 
 	fun_node_t *fun = find_fun_node(&device_tree, handle);
 	if (fun == NULL) {
@@ -282,7 +282,7 @@ static void devman_fun_get_driver_name(ipc_call_t *icall)
 /** Get device path. */
 static void devman_fun_get_path(ipc_call_t *icall)
 {
-	devman_handle_t handle = IPC_GET_ARG1(icall);
+	devman_handle_t handle = ipc_get_arg1(icall);
 
 	fun_node_t *fun = find_fun_node(&device_tree, handle);
 	if (fun == NULL) {
@@ -339,7 +339,7 @@ static void devman_dev_get_parent(ipc_call_t *icall)
 
 	fibril_rwlock_read_lock(&device_tree.rwlock);
 
-	dev = find_dev_node_no_lock(&device_tree, IPC_GET_ARG1(icall));
+	dev = find_dev_node_no_lock(&device_tree, ipc_get_arg1(icall));
 	if (dev == NULL || dev->state == DEVICE_REMOVED) {
 		fibril_rwlock_read_unlock(&device_tree.rwlock);
 		async_answer_0(icall, ENOENT);
@@ -373,7 +373,7 @@ static void devman_dev_get_functions(ipc_call_t *icall)
 	fibril_rwlock_read_lock(&device_tree.rwlock);
 
 	dev_node_t *dev = find_dev_node_no_lock(&device_tree,
-	    IPC_GET_ARG1(icall));
+	    ipc_get_arg1(icall));
 	if (dev == NULL || dev->state == DEVICE_REMOVED) {
 		fibril_rwlock_read_unlock(&device_tree.rwlock);
 		async_answer_0(&call, ENOENT);
@@ -412,7 +412,7 @@ static void devman_fun_get_child(ipc_call_t *icall)
 
 	fibril_rwlock_read_lock(&device_tree.rwlock);
 
-	fun = find_fun_node_no_lock(&device_tree, IPC_GET_ARG1(icall));
+	fun = find_fun_node_no_lock(&device_tree, ipc_get_arg1(icall));
 	if (fun == NULL || fun->state == FUN_REMOVED) {
 		fibril_rwlock_read_unlock(&device_tree.rwlock);
 		async_answer_0(icall, ENOENT);
@@ -441,7 +441,7 @@ static void devman_fun_online(ipc_call_t *icall)
 	fun_node_t *fun;
 	errno_t rc;
 
-	fun = find_fun_node(&device_tree, IPC_GET_ARG1(icall));
+	fun = find_fun_node(&device_tree, ipc_get_arg1(icall));
 	if (fun == NULL) {
 		async_answer_0(icall, ENOENT);
 		return;
@@ -466,7 +466,7 @@ static void devman_fun_offline(ipc_call_t *icall)
 	fun_node_t *fun;
 	errno_t rc;
 
-	fun = find_fun_node(&device_tree, IPC_GET_ARG1(icall));
+	fun = find_fun_node(&device_tree, ipc_get_arg1(icall));
 	if (fun == NULL) {
 		async_answer_0(icall, ENOENT);
 		return;
@@ -483,7 +483,7 @@ static void devman_fun_sid_to_handle(ipc_call_t *icall)
 {
 	fun_node_t *fun;
 
-	fun = find_loc_tree_function(&device_tree, IPC_GET_ARG1(icall));
+	fun = find_loc_tree_function(&device_tree, ipc_get_arg1(icall));
 
 	if (fun == NULL) {
 		async_answer_0(icall, ENOENT);
@@ -549,7 +549,7 @@ static void devman_driver_get_devices(ipc_call_t *icall)
 		return;
 	}
 
-	driver_t *drv = driver_find(&drivers_list, IPC_GET_ARG1(icall));
+	driver_t *drv = driver_find(&drivers_list, ipc_get_arg1(icall));
 	if (drv == NULL) {
 		async_answer_0(&call, ENOENT);
 		async_answer_0(icall, ENOENT);
@@ -603,8 +603,8 @@ static void devman_driver_get_handle(ipc_call_t *icall)
 /** Get driver match ID. */
 static void devman_driver_get_match_id(ipc_call_t *icall)
 {
-	devman_handle_t handle = IPC_GET_ARG1(icall);
-	size_t index = IPC_GET_ARG2(icall);
+	devman_handle_t handle = ipc_get_arg1(icall);
+	size_t index = ipc_get_arg2(icall);
 
 	driver_t *drv = driver_find(&drivers_list, handle);
 	if (drv == NULL) {
@@ -654,7 +654,7 @@ static void devman_driver_get_match_id(ipc_call_t *icall)
 /** Get driver name. */
 static void devman_driver_get_name(ipc_call_t *icall)
 {
-	devman_handle_t handle = IPC_GET_ARG1(icall);
+	devman_handle_t handle = ipc_get_arg1(icall);
 
 	driver_t *drv = driver_find(&drivers_list, handle);
 	if (drv == NULL) {
@@ -696,7 +696,7 @@ static void devman_driver_get_state(ipc_call_t *icall)
 {
 	driver_t *drv;
 
-	drv = driver_find(&drivers_list, IPC_GET_ARG1(icall));
+	drv = driver_find(&drivers_list, ipc_get_arg1(icall));
 	if (drv == NULL) {
 		async_answer_0(icall, ENOENT);
 		return;
@@ -711,7 +711,7 @@ static void devman_driver_load(ipc_call_t *icall)
 	driver_t *drv;
 	errno_t rc;
 
-	drv = driver_find(&drivers_list, IPC_GET_ARG1(icall));
+	drv = driver_find(&drivers_list, ipc_get_arg1(icall));
 	if (drv == NULL) {
 		async_answer_0(icall, ENOENT);
 		return;
@@ -730,7 +730,7 @@ static void devman_driver_unload(ipc_call_t *icall)
 	driver_t *drv;
 	errno_t rc;
 
-	drv = driver_find(&drivers_list, IPC_GET_ARG1(icall));
+	drv = driver_find(&drivers_list, ipc_get_arg1(icall));
 	if (drv == NULL) {
 		async_answer_0(icall, ENOENT);
 		return;
@@ -753,12 +753,12 @@ void devman_connection_client(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case DEVMAN_DEVICE_GET_HANDLE:
 			devman_function_get_handle(&call);
 			break;

--- a/uspace/srv/devman/drv_conn.c
+++ b/uspace/srv/devman/drv_conn.c
@@ -168,7 +168,7 @@ static errno_t devman_receive_match_id(match_id_list_t *match_ids)
 	errno_t rc = 0;
 
 	async_get_call(&call);
-	if (DEVMAN_ADD_MATCH_ID != IPC_GET_IMETHOD(call)) {
+	if (DEVMAN_ADD_MATCH_ID != IPC_GET_IMETHOD(&call)) {
 		log_msg(LOG_DEFAULT, LVL_ERROR,
 		    "Invalid protocol when trying to receive match id.");
 		async_answer_0(&call, EINVAL);
@@ -184,7 +184,7 @@ static errno_t devman_receive_match_id(match_id_list_t *match_ids)
 
 	async_answer_0(&call, EOK);
 
-	match_id->score = IPC_GET_ARG1(call);
+	match_id->score = IPC_GET_ARG1(&call);
 
 	char *match_id_str;
 	rc = async_data_write_accept((void **) &match_id_str, true, 0, 0, 0, 0);
@@ -229,9 +229,9 @@ static errno_t devman_receive_match_ids(sysarg_t match_count,
  */
 static void devman_add_function(ipc_call_t *call)
 {
-	fun_type_t ftype = (fun_type_t) IPC_GET_ARG1(*call);
-	devman_handle_t dev_handle = IPC_GET_ARG2(*call);
-	sysarg_t match_count = IPC_GET_ARG3(*call);
+	fun_type_t ftype = (fun_type_t) IPC_GET_ARG1(call);
+	devman_handle_t dev_handle = IPC_GET_ARG2(call);
+	sysarg_t match_count = IPC_GET_ARG3(call);
 	dev_tree_t *tree = &device_tree;
 
 	dev_node_t *pdev = find_dev_node(&device_tree, dev_handle);
@@ -329,7 +329,7 @@ static void devman_add_function(ipc_call_t *call)
 
 static void devman_add_function_to_cat(ipc_call_t *call)
 {
-	devman_handle_t handle = IPC_GET_ARG1(*call);
+	devman_handle_t handle = IPC_GET_ARG1(call);
 	category_id_t cat_id;
 	errno_t rc;
 
@@ -384,7 +384,7 @@ static void devman_drv_fun_online(ipc_call_t *icall, driver_t *drv)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "devman_drv_fun_online()");
 
-	fun = find_fun_node(&device_tree, IPC_GET_ARG1(*icall));
+	fun = find_fun_node(&device_tree, IPC_GET_ARG1(icall));
 	if (fun == NULL) {
 		async_answer_0(icall, ENOENT);
 		return;
@@ -424,7 +424,7 @@ static void devman_drv_fun_offline(ipc_call_t *icall, driver_t *drv)
 	fun_node_t *fun;
 	errno_t rc;
 
-	fun = find_fun_node(&device_tree, IPC_GET_ARG1(*icall));
+	fun = find_fun_node(&device_tree, IPC_GET_ARG1(icall));
 	if (fun == NULL) {
 		async_answer_0(icall, ENOENT);
 		return;
@@ -457,7 +457,7 @@ static void devman_drv_fun_offline(ipc_call_t *icall, driver_t *drv)
 /** Remove function. */
 static void devman_remove_function(ipc_call_t *call)
 {
-	devman_handle_t fun_handle = IPC_GET_ARG1(*call);
+	devman_handle_t fun_handle = IPC_GET_ARG1(call);
 	dev_tree_t *tree = &device_tree;
 	errno_t rc;
 
@@ -601,12 +601,12 @@ void devman_connection_driver(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		if (IPC_GET_IMETHOD(call) != DEVMAN_DRIVER_REGISTER) {
+		if (IPC_GET_IMETHOD(&call) != DEVMAN_DRIVER_REGISTER) {
 			fibril_mutex_lock(&client->mutex);
 			driver = client->driver;
 			fibril_mutex_unlock(&client->mutex);
@@ -617,7 +617,7 @@ void devman_connection_driver(ipc_call_t *icall, void *arg)
 			}
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case DEVMAN_DRIVER_REGISTER:
 			fibril_mutex_lock(&client->mutex);
 			if (client->driver != NULL) {

--- a/uspace/srv/devman/drv_conn.c
+++ b/uspace/srv/devman/drv_conn.c
@@ -168,7 +168,7 @@ static errno_t devman_receive_match_id(match_id_list_t *match_ids)
 	errno_t rc = 0;
 
 	async_get_call(&call);
-	if (DEVMAN_ADD_MATCH_ID != IPC_GET_IMETHOD(&call)) {
+	if (DEVMAN_ADD_MATCH_ID != ipc_get_imethod(&call)) {
 		log_msg(LOG_DEFAULT, LVL_ERROR,
 		    "Invalid protocol when trying to receive match id.");
 		async_answer_0(&call, EINVAL);
@@ -184,7 +184,7 @@ static errno_t devman_receive_match_id(match_id_list_t *match_ids)
 
 	async_answer_0(&call, EOK);
 
-	match_id->score = IPC_GET_ARG1(&call);
+	match_id->score = ipc_get_arg1(&call);
 
 	char *match_id_str;
 	rc = async_data_write_accept((void **) &match_id_str, true, 0, 0, 0, 0);
@@ -229,9 +229,9 @@ static errno_t devman_receive_match_ids(sysarg_t match_count,
  */
 static void devman_add_function(ipc_call_t *call)
 {
-	fun_type_t ftype = (fun_type_t) IPC_GET_ARG1(call);
-	devman_handle_t dev_handle = IPC_GET_ARG2(call);
-	sysarg_t match_count = IPC_GET_ARG3(call);
+	fun_type_t ftype = (fun_type_t) ipc_get_arg1(call);
+	devman_handle_t dev_handle = ipc_get_arg2(call);
+	sysarg_t match_count = ipc_get_arg3(call);
 	dev_tree_t *tree = &device_tree;
 
 	dev_node_t *pdev = find_dev_node(&device_tree, dev_handle);
@@ -329,7 +329,7 @@ static void devman_add_function(ipc_call_t *call)
 
 static void devman_add_function_to_cat(ipc_call_t *call)
 {
-	devman_handle_t handle = IPC_GET_ARG1(call);
+	devman_handle_t handle = ipc_get_arg1(call);
 	category_id_t cat_id;
 	errno_t rc;
 
@@ -384,7 +384,7 @@ static void devman_drv_fun_online(ipc_call_t *icall, driver_t *drv)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "devman_drv_fun_online()");
 
-	fun = find_fun_node(&device_tree, IPC_GET_ARG1(icall));
+	fun = find_fun_node(&device_tree, ipc_get_arg1(icall));
 	if (fun == NULL) {
 		async_answer_0(icall, ENOENT);
 		return;
@@ -424,7 +424,7 @@ static void devman_drv_fun_offline(ipc_call_t *icall, driver_t *drv)
 	fun_node_t *fun;
 	errno_t rc;
 
-	fun = find_fun_node(&device_tree, IPC_GET_ARG1(icall));
+	fun = find_fun_node(&device_tree, ipc_get_arg1(icall));
 	if (fun == NULL) {
 		async_answer_0(icall, ENOENT);
 		return;
@@ -457,7 +457,7 @@ static void devman_drv_fun_offline(ipc_call_t *icall, driver_t *drv)
 /** Remove function. */
 static void devman_remove_function(ipc_call_t *call)
 {
-	devman_handle_t fun_handle = IPC_GET_ARG1(call);
+	devman_handle_t fun_handle = ipc_get_arg1(call);
 	dev_tree_t *tree = &device_tree;
 	errno_t rc;
 
@@ -601,12 +601,12 @@ void devman_connection_driver(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		if (IPC_GET_IMETHOD(&call) != DEVMAN_DRIVER_REGISTER) {
+		if (ipc_get_imethod(&call) != DEVMAN_DRIVER_REGISTER) {
 			fibril_mutex_lock(&client->mutex);
 			driver = client->driver;
 			fibril_mutex_unlock(&client->mutex);
@@ -617,7 +617,7 @@ void devman_connection_driver(ipc_call_t *icall, void *arg)
 			}
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case DEVMAN_DRIVER_REGISTER:
 			fibril_mutex_lock(&client->mutex);
 			if (client->driver != NULL) {

--- a/uspace/srv/devman/main.c
+++ b/uspace/srv/devman/main.c
@@ -66,7 +66,7 @@ dev_tree_t device_tree;
 
 static void devman_connection_device(ipc_call_t *icall, void *arg)
 {
-	devman_handle_t handle = IPC_GET_ARG2(icall);
+	devman_handle_t handle = ipc_get_arg2(icall);
 	dev_node_t *dev = NULL;
 
 	fun_node_t *fun = find_fun_node(&device_tree, handle);
@@ -148,7 +148,7 @@ cleanup:
 
 static void devman_connection_parent(ipc_call_t *icall, void *arg)
 {
-	devman_handle_t handle = IPC_GET_ARG2(icall);
+	devman_handle_t handle = ipc_get_arg2(icall);
 	dev_node_t *dev = NULL;
 
 	fun_node_t *fun = find_fun_node(&device_tree, handle);
@@ -227,8 +227,8 @@ cleanup:
 
 static void devman_forward(ipc_call_t *icall, void *arg)
 {
-	iface_t iface = IPC_GET_ARG1(icall);
-	service_id_t service_id = IPC_GET_ARG2(icall);
+	iface_t iface = ipc_get_arg1(icall);
+	service_id_t service_id = ipc_get_arg2(icall);
 
 	fun_node_t *fun = find_loc_tree_function(&device_tree, service_id);
 

--- a/uspace/srv/devman/main.c
+++ b/uspace/srv/devman/main.c
@@ -66,7 +66,7 @@ dev_tree_t device_tree;
 
 static void devman_connection_device(ipc_call_t *icall, void *arg)
 {
-	devman_handle_t handle = IPC_GET_ARG2(*icall);
+	devman_handle_t handle = IPC_GET_ARG2(icall);
 	dev_node_t *dev = NULL;
 
 	fun_node_t *fun = find_fun_node(&device_tree, handle);
@@ -148,7 +148,7 @@ cleanup:
 
 static void devman_connection_parent(ipc_call_t *icall, void *arg)
 {
-	devman_handle_t handle = IPC_GET_ARG2(*icall);
+	devman_handle_t handle = IPC_GET_ARG2(icall);
 	dev_node_t *dev = NULL;
 
 	fun_node_t *fun = find_fun_node(&device_tree, handle);
@@ -227,8 +227,8 @@ cleanup:
 
 static void devman_forward(ipc_call_t *icall, void *arg)
 {
-	iface_t iface = IPC_GET_ARG1(*icall);
-	service_id_t service_id = IPC_GET_ARG2(*icall);
+	iface_t iface = IPC_GET_ARG1(icall);
+	service_id_t service_id = IPC_GET_ARG2(icall);
 
 	fun_node_t *fun = find_loc_tree_function(&device_tree, service_id);
 

--- a/uspace/srv/fs/locfs/locfs_ops.c
+++ b/uspace/srv/fs/locfs/locfs_ops.c
@@ -596,7 +596,7 @@ locfs_read(service_id_t service_id, fs_index_t index, aoff64_t pos,
 		if ((errno_t) rc == EHANGUP)
 			rc = ENOTSUP;
 
-		*rbytes = IPC_GET_ARG1(&answer);
+		*rbytes = ipc_get_arg1(&answer);
 		return rc;
 	}
 
@@ -660,7 +660,7 @@ locfs_write(service_id_t service_id, fs_index_t index, aoff64_t pos,
 		if ((errno_t) rc == EHANGUP)
 			rc = ENOTSUP;
 
-		*wbytes = IPC_GET_ARG1(&answer);
+		*wbytes = ipc_get_arg1(&answer);
 		*nsize = 0;
 		return rc;
 	}

--- a/uspace/srv/fs/locfs/locfs_ops.c
+++ b/uspace/srv/fs/locfs/locfs_ops.c
@@ -596,7 +596,7 @@ locfs_read(service_id_t service_id, fs_index_t index, aoff64_t pos,
 		if ((errno_t) rc == EHANGUP)
 			rc = ENOTSUP;
 
-		*rbytes = IPC_GET_ARG1(answer);
+		*rbytes = IPC_GET_ARG1(&answer);
 		return rc;
 	}
 
@@ -660,7 +660,7 @@ locfs_write(service_id_t service_id, fs_index_t index, aoff64_t pos,
 		if ((errno_t) rc == EHANGUP)
 			rc = ENOTSUP;
 
-		*wbytes = IPC_GET_ARG1(answer);
+		*wbytes = IPC_GET_ARG1(&answer);
 		*nsize = 0;
 		return rc;
 	}

--- a/uspace/srv/hid/compositor/compositor.c
+++ b/uspace/srv/hid/compositor/compositor.c
@@ -633,10 +633,10 @@ static void comp_window_get_event(window_t *win, ipc_call_t *icall)
 
 static void comp_window_damage(window_t *win, ipc_call_t *icall)
 {
-	double x = IPC_GET_ARG1(icall);
-	double y = IPC_GET_ARG2(icall);
-	double width = IPC_GET_ARG3(icall);
-	double height = IPC_GET_ARG4(icall);
+	double x = ipc_get_arg1(icall);
+	double y = ipc_get_arg2(icall);
+	double width = ipc_get_arg3(icall);
+	double height = ipc_get_arg4(icall);
 
 	if ((width == 0) || (height == 0)) {
 		comp_damage(0, 0, UINT32_MAX, UINT32_MAX);
@@ -654,8 +654,8 @@ static void comp_window_damage(window_t *win, ipc_call_t *icall)
 
 static void comp_window_grab(window_t *win, ipc_call_t *icall)
 {
-	sysarg_t pos_id = IPC_GET_ARG1(icall);
-	sysarg_t grab_flags = IPC_GET_ARG2(icall);
+	sysarg_t pos_id = ipc_get_arg1(icall);
+	sysarg_t grab_flags = ipc_get_arg2(icall);
 
 	/*
 	 * Filter out resize grab flags if the window
@@ -731,18 +731,18 @@ static void comp_window_resize(window_t *win, ipc_call_t *icall)
 	}
 
 	/* Create new surface for the resized window. */
-	surface_t *new_surface = surface_create(IPC_GET_ARG3(icall),
-	    IPC_GET_ARG4(icall), new_cell_storage, SURFACE_FLAG_SHARED);
+	surface_t *new_surface = surface_create(ipc_get_arg3(icall),
+	    ipc_get_arg4(icall), new_cell_storage, SURFACE_FLAG_SHARED);
 	if (!new_surface) {
 		as_area_destroy(new_cell_storage);
 		async_answer_0(icall, ENOMEM);
 		return;
 	}
 
-	sysarg_t offset_x = IPC_GET_ARG1(icall);
-	sysarg_t offset_y = IPC_GET_ARG2(icall);
+	sysarg_t offset_x = ipc_get_arg1(icall);
+	sysarg_t offset_y = ipc_get_arg2(icall);
 	window_placement_flags_t placement_flags =
-	    (window_placement_flags_t) IPC_GET_ARG5(icall);
+	    (window_placement_flags_t) ipc_get_arg5(icall);
 
 	comp_update_viewport_bound_rect();
 
@@ -920,14 +920,14 @@ static void comp_window_close_request(window_t *win, ipc_call_t *icall)
 static void client_connection(ipc_call_t *icall, void *arg)
 {
 	ipc_call_t call;
-	service_id_t service_id = (service_id_t) IPC_GET_ARG2(icall);
+	service_id_t service_id = (service_id_t) ipc_get_arg2(icall);
 
 	/* Allocate resources for new window and register it to the location service. */
 	if (service_id == winreg_id) {
 		async_accept_0(icall);
 
 		async_get_call(&call);
-		if (IPC_GET_IMETHOD(&call) == WINDOW_REGISTER) {
+		if (ipc_get_imethod(&call) == WINDOW_REGISTER) {
 			fibril_mutex_lock(&window_list_mtx);
 
 			window_t *win = window_create();
@@ -937,7 +937,7 @@ static void client_connection(ipc_call_t *icall, void *arg)
 				return;
 			}
 
-			win->flags = IPC_GET_ARG1(&call);
+			win->flags = ipc_get_arg1(&call);
 
 			char name_in[LOC_NAME_MAXLEN + 1];
 			snprintf(name_in, LOC_NAME_MAXLEN, "%s%s/win%zuin", NAMESPACE,
@@ -1013,13 +1013,13 @@ static void client_connection(ipc_call_t *icall, void *arg)
 		while (true) {
 			async_get_call(&call);
 
-			if (!IPC_GET_IMETHOD(&call)) {
+			if (!ipc_get_imethod(&call)) {
 				async_answer_0(&call, EOK);
 				window_destroy(win);
 				return;
 			}
 
-			switch (IPC_GET_IMETHOD(&call)) {
+			switch (ipc_get_imethod(&call)) {
 			case WINDOW_GET_EVENT:
 				comp_window_get_event(win, &call);
 				break;
@@ -1031,13 +1031,13 @@ static void client_connection(ipc_call_t *icall, void *arg)
 		while (true) {
 			async_get_call(&call);
 
-			if (!IPC_GET_IMETHOD(&call)) {
+			if (!ipc_get_imethod(&call)) {
 				comp_window_close(win, &call);
 				window_destroy(win);
 				return;
 			}
 
-			switch (IPC_GET_IMETHOD(&call)) {
+			switch (ipc_get_imethod(&call)) {
 			case WINDOW_DAMAGE:
 				comp_window_damage(win, &call);
 				break;
@@ -1066,7 +1066,7 @@ static void client_connection(ipc_call_t *icall, void *arg)
 
 static void comp_mode_change(viewport_t *vp, ipc_call_t *icall)
 {
-	sysarg_t mode_idx = IPC_GET_ARG2(icall);
+	sysarg_t mode_idx = ipc_get_arg2(icall);
 	fibril_mutex_lock(&viewport_list_mtx);
 
 	/* Retrieve the mode that shall be set. */
@@ -1164,7 +1164,7 @@ static void vsl_notifications(ipc_call_t *icall, void *arg)
 	viewport_t *vp = NULL;
 	fibril_mutex_lock(&viewport_list_mtx);
 	list_foreach(viewport_list, link, viewport_t, cur) {
-		if (cur->dsid == (service_id_t) IPC_GET_ARG1(icall)) {
+		if (cur->dsid == (service_id_t) ipc_get_arg1(icall)) {
 			vp = cur;
 			break;
 		}
@@ -1179,12 +1179,12 @@ static void vsl_notifications(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_hangup(vp->sess);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case VISUALIZER_MODE_CHANGE:
 			comp_mode_change(vp, &call);
 			break;

--- a/uspace/srv/hid/compositor/compositor.c
+++ b/uspace/srv/hid/compositor/compositor.c
@@ -633,10 +633,10 @@ static void comp_window_get_event(window_t *win, ipc_call_t *icall)
 
 static void comp_window_damage(window_t *win, ipc_call_t *icall)
 {
-	double x = IPC_GET_ARG1(*icall);
-	double y = IPC_GET_ARG2(*icall);
-	double width = IPC_GET_ARG3(*icall);
-	double height = IPC_GET_ARG4(*icall);
+	double x = IPC_GET_ARG1(icall);
+	double y = IPC_GET_ARG2(icall);
+	double width = IPC_GET_ARG3(icall);
+	double height = IPC_GET_ARG4(icall);
 
 	if ((width == 0) || (height == 0)) {
 		comp_damage(0, 0, UINT32_MAX, UINT32_MAX);
@@ -654,8 +654,8 @@ static void comp_window_damage(window_t *win, ipc_call_t *icall)
 
 static void comp_window_grab(window_t *win, ipc_call_t *icall)
 {
-	sysarg_t pos_id = IPC_GET_ARG1(*icall);
-	sysarg_t grab_flags = IPC_GET_ARG2(*icall);
+	sysarg_t pos_id = IPC_GET_ARG1(icall);
+	sysarg_t grab_flags = IPC_GET_ARG2(icall);
 
 	/*
 	 * Filter out resize grab flags if the window
@@ -731,18 +731,18 @@ static void comp_window_resize(window_t *win, ipc_call_t *icall)
 	}
 
 	/* Create new surface for the resized window. */
-	surface_t *new_surface = surface_create(IPC_GET_ARG3(*icall),
-	    IPC_GET_ARG4(*icall), new_cell_storage, SURFACE_FLAG_SHARED);
+	surface_t *new_surface = surface_create(IPC_GET_ARG3(icall),
+	    IPC_GET_ARG4(icall), new_cell_storage, SURFACE_FLAG_SHARED);
 	if (!new_surface) {
 		as_area_destroy(new_cell_storage);
 		async_answer_0(icall, ENOMEM);
 		return;
 	}
 
-	sysarg_t offset_x = IPC_GET_ARG1(*icall);
-	sysarg_t offset_y = IPC_GET_ARG2(*icall);
+	sysarg_t offset_x = IPC_GET_ARG1(icall);
+	sysarg_t offset_y = IPC_GET_ARG2(icall);
 	window_placement_flags_t placement_flags =
-	    (window_placement_flags_t) IPC_GET_ARG5(*icall);
+	    (window_placement_flags_t) IPC_GET_ARG5(icall);
 
 	comp_update_viewport_bound_rect();
 
@@ -920,14 +920,14 @@ static void comp_window_close_request(window_t *win, ipc_call_t *icall)
 static void client_connection(ipc_call_t *icall, void *arg)
 {
 	ipc_call_t call;
-	service_id_t service_id = (service_id_t) IPC_GET_ARG2(*icall);
+	service_id_t service_id = (service_id_t) IPC_GET_ARG2(icall);
 
 	/* Allocate resources for new window and register it to the location service. */
 	if (service_id == winreg_id) {
 		async_accept_0(icall);
 
 		async_get_call(&call);
-		if (IPC_GET_IMETHOD(call) == WINDOW_REGISTER) {
+		if (IPC_GET_IMETHOD(&call) == WINDOW_REGISTER) {
 			fibril_mutex_lock(&window_list_mtx);
 
 			window_t *win = window_create();
@@ -937,7 +937,7 @@ static void client_connection(ipc_call_t *icall, void *arg)
 				return;
 			}
 
-			win->flags = IPC_GET_ARG1(call);
+			win->flags = IPC_GET_ARG1(&call);
 
 			char name_in[LOC_NAME_MAXLEN + 1];
 			snprintf(name_in, LOC_NAME_MAXLEN, "%s%s/win%zuin", NAMESPACE,
@@ -1013,13 +1013,13 @@ static void client_connection(ipc_call_t *icall, void *arg)
 		while (true) {
 			async_get_call(&call);
 
-			if (!IPC_GET_IMETHOD(call)) {
+			if (!IPC_GET_IMETHOD(&call)) {
 				async_answer_0(&call, EOK);
 				window_destroy(win);
 				return;
 			}
 
-			switch (IPC_GET_IMETHOD(call)) {
+			switch (IPC_GET_IMETHOD(&call)) {
 			case WINDOW_GET_EVENT:
 				comp_window_get_event(win, &call);
 				break;
@@ -1031,13 +1031,13 @@ static void client_connection(ipc_call_t *icall, void *arg)
 		while (true) {
 			async_get_call(&call);
 
-			if (!IPC_GET_IMETHOD(call)) {
+			if (!IPC_GET_IMETHOD(&call)) {
 				comp_window_close(win, &call);
 				window_destroy(win);
 				return;
 			}
 
-			switch (IPC_GET_IMETHOD(call)) {
+			switch (IPC_GET_IMETHOD(&call)) {
 			case WINDOW_DAMAGE:
 				comp_window_damage(win, &call);
 				break;
@@ -1066,7 +1066,7 @@ static void client_connection(ipc_call_t *icall, void *arg)
 
 static void comp_mode_change(viewport_t *vp, ipc_call_t *icall)
 {
-	sysarg_t mode_idx = IPC_GET_ARG2(*icall);
+	sysarg_t mode_idx = IPC_GET_ARG2(icall);
 	fibril_mutex_lock(&viewport_list_mtx);
 
 	/* Retrieve the mode that shall be set. */
@@ -1164,7 +1164,7 @@ static void vsl_notifications(ipc_call_t *icall, void *arg)
 	viewport_t *vp = NULL;
 	fibril_mutex_lock(&viewport_list_mtx);
 	list_foreach(viewport_list, link, viewport_t, cur) {
-		if (cur->dsid == (service_id_t) IPC_GET_ARG1(*icall)) {
+		if (cur->dsid == (service_id_t) IPC_GET_ARG1(icall)) {
 			vp = cur;
 			break;
 		}
@@ -1179,12 +1179,12 @@ static void vsl_notifications(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_hangup(vp->sess);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case VISUALIZER_MODE_CHANGE:
 			comp_mode_change(vp, &call);
 			break;

--- a/uspace/srv/hid/console/console.c
+++ b/uspace/srv/hid/console/console.c
@@ -512,7 +512,7 @@ static void client_connection(ipc_call_t *icall, void *arg)
 	console_t *cons = NULL;
 
 	for (size_t i = 0; i < CONSOLE_COUNT; i++) {
-		if (consoles[i].dsid == (service_id_t) IPC_GET_ARG2(*icall)) {
+		if (consoles[i].dsid == (service_id_t) IPC_GET_ARG2(icall)) {
 			cons = &consoles[i];
 			break;
 		}

--- a/uspace/srv/hid/console/console.c
+++ b/uspace/srv/hid/console/console.c
@@ -512,7 +512,7 @@ static void client_connection(ipc_call_t *icall, void *arg)
 	console_t *cons = NULL;
 
 	for (size_t i = 0; i < CONSOLE_COUNT; i++) {
-		if (consoles[i].dsid == (service_id_t) IPC_GET_ARG2(icall)) {
+		if (consoles[i].dsid == (service_id_t) ipc_get_arg2(icall)) {
 			cons = &consoles[i];
 			break;
 		}

--- a/uspace/srv/hid/input/ctl/kbdev.c
+++ b/uspace/srv/hid/input/ctl/kbdev.c
@@ -159,18 +159,18 @@ static void kbdev_callback_conn(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			kbdev_destroy(kbdev);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case KBDEV_EVENT:
 			/* Got event from keyboard device */
 			retval = 0;
-			type = IPC_GET_ARG1(&call);
-			key = IPC_GET_ARG2(&call);
+			type = ipc_get_arg1(&call);
+			key = ipc_get_arg2(&call);
 			kbd_push_event(kbdev->kbd_dev, type, key);
 			break;
 		default:

--- a/uspace/srv/hid/input/ctl/kbdev.c
+++ b/uspace/srv/hid/input/ctl/kbdev.c
@@ -159,18 +159,18 @@ static void kbdev_callback_conn(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			kbdev_destroy(kbdev);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case KBDEV_EVENT:
 			/* Got event from keyboard device */
 			retval = 0;
-			type = IPC_GET_ARG1(call);
-			key = IPC_GET_ARG2(call);
+			type = IPC_GET_ARG1(&call);
+			key = IPC_GET_ARG2(&call);
 			kbd_push_event(kbdev->kbd_dev, type, key);
 			break;
 		default:

--- a/uspace/srv/hid/input/input.c
+++ b/uspace/srv/hid/input/input.c
@@ -333,7 +333,7 @@ static void client_connection(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			if (client->sess != NULL) {
 				async_hangup(client->sess);
 				client->sess = NULL;
@@ -352,7 +352,7 @@ static void client_connection(ipc_call_t *icall, void *arg)
 			} else
 				async_answer_0(&call, ELIMIT);
 		} else {
-			switch (IPC_GET_IMETHOD(call)) {
+			switch (IPC_GET_IMETHOD(&call)) {
 			case INPUT_ACTIVATE:
 				active_client = client;
 				client_arbitration();
@@ -367,7 +367,7 @@ static void client_connection(ipc_call_t *icall, void *arg)
 
 static void kconsole_event_handler(ipc_call_t *call, void *arg)
 {
-	if (IPC_GET_ARG1(*call)) {
+	if (IPC_GET_ARG1(call)) {
 		/* Kernel console activated */
 		active = false;
 	} else {

--- a/uspace/srv/hid/input/input.c
+++ b/uspace/srv/hid/input/input.c
@@ -333,7 +333,7 @@ static void client_connection(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			if (client->sess != NULL) {
 				async_hangup(client->sess);
 				client->sess = NULL;
@@ -352,7 +352,7 @@ static void client_connection(ipc_call_t *icall, void *arg)
 			} else
 				async_answer_0(&call, ELIMIT);
 		} else {
-			switch (IPC_GET_IMETHOD(&call)) {
+			switch (ipc_get_imethod(&call)) {
 			case INPUT_ACTIVATE:
 				active_client = client;
 				client_arbitration();
@@ -367,7 +367,7 @@ static void client_connection(ipc_call_t *icall, void *arg)
 
 static void kconsole_event_handler(ipc_call_t *call, void *arg)
 {
-	if (IPC_GET_ARG1(call)) {
+	if (ipc_get_arg1(call)) {
 		/* Kernel console activated */
 		active = false;
 	} else {

--- a/uspace/srv/hid/input/proto/mousedev.c
+++ b/uspace/srv/hid/input/proto/mousedev.c
@@ -78,7 +78,7 @@ static void mousedev_callback_conn(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			mousedev_destroy(mousedev);
 			return;
@@ -86,22 +86,22 @@ static void mousedev_callback_conn(ipc_call_t *icall, void *arg)
 
 		errno_t retval;
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case MOUSEEV_MOVE_EVENT:
 			mouse_push_event_move(mousedev->mouse_dev,
-			    IPC_GET_ARG1(&call), IPC_GET_ARG2(&call),
-			    IPC_GET_ARG3(&call));
+			    ipc_get_arg1(&call), ipc_get_arg2(&call),
+			    ipc_get_arg3(&call));
 			retval = EOK;
 			break;
 		case MOUSEEV_ABS_MOVE_EVENT:
 			mouse_push_event_abs_move(mousedev->mouse_dev,
-			    IPC_GET_ARG1(&call), IPC_GET_ARG2(&call),
-			    IPC_GET_ARG3(&call), IPC_GET_ARG4(&call));
+			    ipc_get_arg1(&call), ipc_get_arg2(&call),
+			    ipc_get_arg3(&call), ipc_get_arg4(&call));
 			retval = EOK;
 			break;
 		case MOUSEEV_BUTTON_EVENT:
 			mouse_push_event_button(mousedev->mouse_dev,
-			    IPC_GET_ARG1(&call), IPC_GET_ARG2(&call));
+			    ipc_get_arg1(&call), ipc_get_arg2(&call));
 			retval = EOK;
 			break;
 		default:

--- a/uspace/srv/hid/input/proto/mousedev.c
+++ b/uspace/srv/hid/input/proto/mousedev.c
@@ -78,7 +78,7 @@ static void mousedev_callback_conn(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			mousedev_destroy(mousedev);
 			return;
@@ -86,22 +86,22 @@ static void mousedev_callback_conn(ipc_call_t *icall, void *arg)
 
 		errno_t retval;
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case MOUSEEV_MOVE_EVENT:
 			mouse_push_event_move(mousedev->mouse_dev,
-			    IPC_GET_ARG1(call), IPC_GET_ARG2(call),
-			    IPC_GET_ARG3(call));
+			    IPC_GET_ARG1(&call), IPC_GET_ARG2(&call),
+			    IPC_GET_ARG3(&call));
 			retval = EOK;
 			break;
 		case MOUSEEV_ABS_MOVE_EVENT:
 			mouse_push_event_abs_move(mousedev->mouse_dev,
-			    IPC_GET_ARG1(call), IPC_GET_ARG2(call),
-			    IPC_GET_ARG3(call), IPC_GET_ARG4(call));
+			    IPC_GET_ARG1(&call), IPC_GET_ARG2(&call),
+			    IPC_GET_ARG3(&call), IPC_GET_ARG4(&call));
 			retval = EOK;
 			break;
 		case MOUSEEV_BUTTON_EVENT:
 			mouse_push_event_button(mousedev->mouse_dev,
-			    IPC_GET_ARG1(call), IPC_GET_ARG2(call));
+			    IPC_GET_ARG1(&call), IPC_GET_ARG2(&call));
 			retval = EOK;
 			break;
 		default:

--- a/uspace/srv/hid/isdv4_tablet/main.c
+++ b/uspace/srv/hid/isdv4_tablet/main.c
@@ -80,7 +80,7 @@ static void mouse_connection(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}

--- a/uspace/srv/hid/isdv4_tablet/main.c
+++ b/uspace/srv/hid/isdv4_tablet/main.c
@@ -80,7 +80,7 @@ static void mouse_connection(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}

--- a/uspace/srv/hid/output/output.c
+++ b/uspace/srv/hid/output/output.c
@@ -186,7 +186,7 @@ static void srv_frontbuf_create(ipc_call_t *icall)
 
 static void srv_frontbuf_destroy(ipc_call_t *icall)
 {
-	frontbuf_t *frontbuf = resolve_frontbuf(IPC_GET_ARG1(*icall), icall);
+	frontbuf_t *frontbuf = resolve_frontbuf(IPC_GET_ARG1(icall), icall);
 	if (frontbuf == NULL)
 		return;
 
@@ -199,7 +199,7 @@ static void srv_frontbuf_destroy(ipc_call_t *icall)
 
 static void srv_cursor_update(ipc_call_t *icall)
 {
-	frontbuf_t *frontbuf = resolve_frontbuf(IPC_GET_ARG1(*icall), icall);
+	frontbuf_t *frontbuf = resolve_frontbuf(IPC_GET_ARG1(icall), icall);
 	if (frontbuf == NULL)
 		return;
 
@@ -234,7 +234,7 @@ static void srv_set_style(ipc_call_t *icall)
 	list_foreach(outdevs, link, outdev_t, dev) {
 		dev->attrs.type = CHAR_ATTR_STYLE;
 		dev->attrs.val.style =
-		    (console_style_t) IPC_GET_ARG1(*icall);
+		    (console_style_t) IPC_GET_ARG1(icall);
 	}
 
 	async_answer_0(icall, EOK);
@@ -245,11 +245,11 @@ static void srv_set_color(ipc_call_t *icall)
 	list_foreach(outdevs, link, outdev_t, dev) {
 		dev->attrs.type = CHAR_ATTR_INDEX;
 		dev->attrs.val.index.bgcolor =
-		    (console_color_t) IPC_GET_ARG1(*icall);
+		    (console_color_t) IPC_GET_ARG1(icall);
 		dev->attrs.val.index.fgcolor =
-		    (console_color_t) IPC_GET_ARG2(*icall);
+		    (console_color_t) IPC_GET_ARG2(icall);
 		dev->attrs.val.index.attr =
-		    (console_color_attr_t) IPC_GET_ARG3(*icall);
+		    (console_color_attr_t) IPC_GET_ARG3(icall);
 	}
 
 	async_answer_0(icall, EOK);
@@ -259,8 +259,8 @@ static void srv_set_rgb_color(ipc_call_t *icall)
 {
 	list_foreach(outdevs, link, outdev_t, dev) {
 		dev->attrs.type = CHAR_ATTR_RGB;
-		dev->attrs.val.rgb.bgcolor = IPC_GET_ARG1(*icall);
-		dev->attrs.val.rgb.fgcolor = IPC_GET_ARG2(*icall);
+		dev->attrs.val.rgb.bgcolor = IPC_GET_ARG1(icall);
+		dev->attrs.val.rgb.fgcolor = IPC_GET_ARG2(icall);
 	}
 
 	async_answer_0(icall, EOK);
@@ -307,7 +307,7 @@ static bool srv_update_scroll(outdev_t *dev, chargrid_t *buf)
 
 static void srv_update(ipc_call_t *icall)
 {
-	frontbuf_t *frontbuf = resolve_frontbuf(IPC_GET_ARG1(*icall), icall);
+	frontbuf_t *frontbuf = resolve_frontbuf(IPC_GET_ARG1(icall), icall);
 	if (frontbuf == NULL)
 		return;
 
@@ -356,7 +356,7 @@ static void srv_update(ipc_call_t *icall)
 
 static void srv_damage(ipc_call_t *icall)
 {
-	frontbuf_t *frontbuf = resolve_frontbuf(IPC_GET_ARG1(*icall), icall);
+	frontbuf_t *frontbuf = resolve_frontbuf(IPC_GET_ARG1(icall), icall);
 	if (frontbuf == NULL)
 		return;
 
@@ -368,11 +368,11 @@ static void srv_damage(ipc_call_t *icall)
 		if (srv_update_scroll(dev, buf))
 			continue;
 
-		sysarg_t col = IPC_GET_ARG2(*icall);
-		sysarg_t row = IPC_GET_ARG3(*icall);
+		sysarg_t col = IPC_GET_ARG2(icall);
+		sysarg_t row = IPC_GET_ARG3(icall);
 
-		sysarg_t cols = IPC_GET_ARG4(*icall);
-		sysarg_t rows = IPC_GET_ARG5(*icall);
+		sysarg_t cols = IPC_GET_ARG4(icall);
+		sysarg_t rows = IPC_GET_ARG5(icall);
 
 		for (sysarg_t y = 0; y < rows; y++) {
 			for (sysarg_t x = 0; x < cols; x++) {
@@ -403,12 +403,12 @@ static void client_connection(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case OUTPUT_YIELD:
 			srv_yield(&call);
 			break;

--- a/uspace/srv/hid/output/output.c
+++ b/uspace/srv/hid/output/output.c
@@ -186,7 +186,7 @@ static void srv_frontbuf_create(ipc_call_t *icall)
 
 static void srv_frontbuf_destroy(ipc_call_t *icall)
 {
-	frontbuf_t *frontbuf = resolve_frontbuf(IPC_GET_ARG1(icall), icall);
+	frontbuf_t *frontbuf = resolve_frontbuf(ipc_get_arg1(icall), icall);
 	if (frontbuf == NULL)
 		return;
 
@@ -199,7 +199,7 @@ static void srv_frontbuf_destroy(ipc_call_t *icall)
 
 static void srv_cursor_update(ipc_call_t *icall)
 {
-	frontbuf_t *frontbuf = resolve_frontbuf(IPC_GET_ARG1(icall), icall);
+	frontbuf_t *frontbuf = resolve_frontbuf(ipc_get_arg1(icall), icall);
 	if (frontbuf == NULL)
 		return;
 
@@ -234,7 +234,7 @@ static void srv_set_style(ipc_call_t *icall)
 	list_foreach(outdevs, link, outdev_t, dev) {
 		dev->attrs.type = CHAR_ATTR_STYLE;
 		dev->attrs.val.style =
-		    (console_style_t) IPC_GET_ARG1(icall);
+		    (console_style_t) ipc_get_arg1(icall);
 	}
 
 	async_answer_0(icall, EOK);
@@ -245,11 +245,11 @@ static void srv_set_color(ipc_call_t *icall)
 	list_foreach(outdevs, link, outdev_t, dev) {
 		dev->attrs.type = CHAR_ATTR_INDEX;
 		dev->attrs.val.index.bgcolor =
-		    (console_color_t) IPC_GET_ARG1(icall);
+		    (console_color_t) ipc_get_arg1(icall);
 		dev->attrs.val.index.fgcolor =
-		    (console_color_t) IPC_GET_ARG2(icall);
+		    (console_color_t) ipc_get_arg2(icall);
 		dev->attrs.val.index.attr =
-		    (console_color_attr_t) IPC_GET_ARG3(icall);
+		    (console_color_attr_t) ipc_get_arg3(icall);
 	}
 
 	async_answer_0(icall, EOK);
@@ -259,8 +259,8 @@ static void srv_set_rgb_color(ipc_call_t *icall)
 {
 	list_foreach(outdevs, link, outdev_t, dev) {
 		dev->attrs.type = CHAR_ATTR_RGB;
-		dev->attrs.val.rgb.bgcolor = IPC_GET_ARG1(icall);
-		dev->attrs.val.rgb.fgcolor = IPC_GET_ARG2(icall);
+		dev->attrs.val.rgb.bgcolor = ipc_get_arg1(icall);
+		dev->attrs.val.rgb.fgcolor = ipc_get_arg2(icall);
 	}
 
 	async_answer_0(icall, EOK);
@@ -307,7 +307,7 @@ static bool srv_update_scroll(outdev_t *dev, chargrid_t *buf)
 
 static void srv_update(ipc_call_t *icall)
 {
-	frontbuf_t *frontbuf = resolve_frontbuf(IPC_GET_ARG1(icall), icall);
+	frontbuf_t *frontbuf = resolve_frontbuf(ipc_get_arg1(icall), icall);
 	if (frontbuf == NULL)
 		return;
 
@@ -356,7 +356,7 @@ static void srv_update(ipc_call_t *icall)
 
 static void srv_damage(ipc_call_t *icall)
 {
-	frontbuf_t *frontbuf = resolve_frontbuf(IPC_GET_ARG1(icall), icall);
+	frontbuf_t *frontbuf = resolve_frontbuf(ipc_get_arg1(icall), icall);
 	if (frontbuf == NULL)
 		return;
 
@@ -368,11 +368,11 @@ static void srv_damage(ipc_call_t *icall)
 		if (srv_update_scroll(dev, buf))
 			continue;
 
-		sysarg_t col = IPC_GET_ARG2(icall);
-		sysarg_t row = IPC_GET_ARG3(icall);
+		sysarg_t col = ipc_get_arg2(icall);
+		sysarg_t row = ipc_get_arg3(icall);
 
-		sysarg_t cols = IPC_GET_ARG4(icall);
-		sysarg_t rows = IPC_GET_ARG5(icall);
+		sysarg_t cols = ipc_get_arg4(icall);
+		sysarg_t rows = ipc_get_arg5(icall);
 
 		for (sysarg_t y = 0; y < rows; y++) {
 			for (sysarg_t x = 0; x < cols; x++) {
@@ -403,12 +403,12 @@ static void client_connection(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case OUTPUT_YIELD:
 			srv_yield(&call);
 			break;

--- a/uspace/srv/hid/remcons/remcons.c
+++ b/uspace/srv/hid/remcons/remcons.c
@@ -218,7 +218,7 @@ static errno_t remcons_get_event(con_srv_t *srv, cons_event_t *event)
 static void client_connection(ipc_call_t *icall, void *arg)
 {
 	/* Find the user. */
-	telnet_user_t *user = telnet_user_get_for_client_connection(IPC_GET_ARG2(icall));
+	telnet_user_t *user = telnet_user_get_for_client_connection(ipc_get_arg2(icall));
 	if (user == NULL) {
 		async_answer_0(icall, ENOENT);
 		return;

--- a/uspace/srv/hid/remcons/remcons.c
+++ b/uspace/srv/hid/remcons/remcons.c
@@ -218,7 +218,7 @@ static errno_t remcons_get_event(con_srv_t *srv, cons_event_t *event)
 static void client_connection(ipc_call_t *icall, void *arg)
 {
 	/* Find the user. */
-	telnet_user_t *user = telnet_user_get_for_client_connection(IPC_GET_ARG2(*icall));
+	telnet_user_t *user = telnet_user_get_for_client_connection(IPC_GET_ARG2(icall));
 	if (user == NULL) {
 		async_answer_0(icall, ENOENT);
 		return;

--- a/uspace/srv/hid/s3c24xx_ts/s3c24xx_ts.c
+++ b/uspace/srv/hid/s3c24xx_ts/s3c24xx_ts.c
@@ -377,7 +377,7 @@ static void s3c24xx_ts_connection(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			if (ts->client_sess != NULL) {
 				async_hangup(ts->client_sess);
 				ts->client_sess = NULL;

--- a/uspace/srv/hid/s3c24xx_ts/s3c24xx_ts.c
+++ b/uspace/srv/hid/s3c24xx_ts/s3c24xx_ts.c
@@ -377,7 +377,7 @@ static void s3c24xx_ts_connection(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			if (ts->client_sess != NULL) {
 				async_hangup(ts->client_sess);
 				ts->client_sess = NULL;

--- a/uspace/srv/loader/main.c
+++ b/uspace/srv/loader/main.c
@@ -352,7 +352,7 @@ static __attribute__((noreturn)) void ldr_run(ipc_call_t *req)
 	 * unanswered IPC_M_PHONE_HUNGUP messages behind.
 	 */
 	async_get_call(req);
-	assert(!IPC_GET_IMETHOD(req));
+	assert(!ipc_get_imethod(req));
 	async_answer_0(req, EOK);
 
 	DPRINTF("Jump to entry point at %p\n", pcb.entry);
@@ -391,12 +391,12 @@ static void ldr_connection(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			exit(0);
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case LOADER_GET_TASKID:
 			ldr_get_taskid(&call);
 			continue;

--- a/uspace/srv/loader/main.c
+++ b/uspace/srv/loader/main.c
@@ -352,7 +352,7 @@ static __attribute__((noreturn)) void ldr_run(ipc_call_t *req)
 	 * unanswered IPC_M_PHONE_HUNGUP messages behind.
 	 */
 	async_get_call(req);
-	assert(!IPC_GET_IMETHOD(*req));
+	assert(!IPC_GET_IMETHOD(req));
 	async_answer_0(req, EOK);
 
 	DPRINTF("Jump to entry point at %p\n", pcb.entry);
@@ -391,12 +391,12 @@ static void ldr_connection(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			exit(0);
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case LOADER_GET_TASKID:
 			ldr_get_taskid(&call);
 			continue;

--- a/uspace/srv/locsrv/locsrv.c
+++ b/uspace/srv/locsrv/locsrv.c
@@ -341,7 +341,7 @@ static loc_server_t *loc_server_register(void)
 	ipc_call_t icall;
 	async_get_call(&icall);
 
-	if (IPC_GET_IMETHOD(&icall) != LOC_SERVER_REGISTER) {
+	if (ipc_get_imethod(&icall) != LOC_SERVER_REGISTER) {
 		async_answer_0(&icall, EREFUSED);
 		return NULL;
 	}
@@ -546,7 +546,7 @@ static void loc_service_unregister(ipc_call_t *icall, loc_server_t *server)
 	loc_service_t *svc;
 
 	fibril_mutex_lock(&services_list_mutex);
-	svc = loc_service_find_id(IPC_GET_ARG1(icall));
+	svc = loc_service_find_id(ipc_get_arg1(icall));
 	if (svc == NULL) {
 		fibril_mutex_unlock(&services_list_mutex);
 		async_answer_0(icall, ENOENT);
@@ -582,7 +582,7 @@ static void loc_category_get_name(ipc_call_t *icall)
 
 	fibril_mutex_lock(&cdir.mutex);
 
-	cat = category_get(&cdir, IPC_GET_ARG1(icall));
+	cat = category_get(&cdir, ipc_get_arg1(icall));
 	if (cat == NULL) {
 		fibril_mutex_unlock(&cdir.mutex);
 		async_answer_0(&call, ENOENT);
@@ -622,7 +622,7 @@ static void loc_service_get_name(ipc_call_t *icall)
 
 	fibril_mutex_lock(&services_list_mutex);
 
-	svc = loc_service_find_id(IPC_GET_ARG1(icall));
+	svc = loc_service_find_id(ipc_get_arg1(icall));
 	if (svc == NULL) {
 		fibril_mutex_unlock(&services_list_mutex);
 		async_answer_0(&call, ENOENT);
@@ -670,7 +670,7 @@ static void loc_service_get_server_name(ipc_call_t *icall)
 
 	fibril_mutex_lock(&services_list_mutex);
 
-	svc = loc_service_find_id(IPC_GET_ARG1(icall));
+	svc = loc_service_find_id(ipc_get_arg1(icall));
 	if (svc == NULL) {
 		fibril_mutex_unlock(&services_list_mutex);
 		async_answer_0(&call, ENOENT);
@@ -714,8 +714,8 @@ static void loc_forward(ipc_call_t *call, void *arg)
 	/*
 	 * Get ID from request
 	 */
-	iface_t iface = IPC_GET_ARG1(call);
-	service_id_t id = IPC_GET_ARG2(call);
+	iface_t iface = ipc_get_arg1(call);
+	service_id_t id = ipc_get_arg2(call);
 	loc_service_t *svc = loc_service_find_id(id);
 
 	if ((svc == NULL) || (svc->server == NULL) || (!svc->server->sess)) {
@@ -773,7 +773,7 @@ recheck:
 	 * Device was not found.
 	 */
 	if (svc == NULL) {
-		if (IPC_GET_ARG1(icall) & IPC_FLAG_BLOCKING) {
+		if (ipc_get_arg1(icall) & IPC_FLAG_BLOCKING) {
 			/* Blocking lookup */
 			fibril_condvar_wait(&services_list_cv,
 			    &services_list_mutex);
@@ -826,7 +826,7 @@ recheck:
 	 * Namespace was not found.
 	 */
 	if (namespace == NULL) {
-		if (IPC_GET_ARG1(icall) & IPC_FLAG_BLOCKING) {
+		if (ipc_get_arg1(icall) & IPC_FLAG_BLOCKING) {
 			/* Blocking lookup */
 			fibril_condvar_wait(&services_list_cv,
 			    &services_list_mutex);
@@ -931,10 +931,10 @@ static void loc_id_probe(ipc_call_t *icall)
 	fibril_mutex_lock(&services_list_mutex);
 
 	loc_namespace_t *namespace =
-	    loc_namespace_find_id(IPC_GET_ARG1(icall));
+	    loc_namespace_find_id(ipc_get_arg1(icall));
 	if (namespace == NULL) {
 		loc_service_t *svc =
-		    loc_service_find_id(IPC_GET_ARG1(icall));
+		    loc_service_find_id(ipc_get_arg1(icall));
 		if (svc == NULL)
 			async_answer_1(icall, EOK, LOC_OBJECT_NONE);
 		else
@@ -957,7 +957,7 @@ static void loc_get_service_count(ipc_call_t *icall)
 	fibril_mutex_lock(&services_list_mutex);
 
 	loc_namespace_t *namespace =
-	    loc_namespace_find_id(IPC_GET_ARG1(icall));
+	    loc_namespace_find_id(ipc_get_arg1(icall));
 	if (namespace == NULL)
 		async_answer_0(icall, EEXIST);
 	else
@@ -1078,7 +1078,7 @@ static void loc_get_services(ipc_call_t *icall)
 	fibril_mutex_lock(&services_list_mutex);
 
 	loc_namespace_t *namespace =
-	    loc_namespace_find_id(IPC_GET_ARG1(icall));
+	    loc_namespace_find_id(ipc_get_arg1(icall));
 	if (namespace == NULL) {
 		fibril_mutex_unlock(&services_list_mutex);
 		async_answer_0(&call, ENOENT);
@@ -1134,7 +1134,7 @@ static void loc_category_get_svcs(ipc_call_t *icall)
 
 	fibril_mutex_lock(&cdir.mutex);
 
-	category_t *cat = category_get(&cdir, IPC_GET_ARG1(icall));
+	category_t *cat = category_get(&cdir, ipc_get_arg1(icall));
 	if (cat == NULL) {
 		fibril_mutex_unlock(&cdir.mutex);
 		async_answer_0(&call, ENOENT);
@@ -1246,7 +1246,7 @@ static void loc_null_create(ipc_call_t *icall)
 
 static void loc_null_destroy(ipc_call_t *icall)
 {
-	sysarg_t i = IPC_GET_ARG1(icall);
+	sysarg_t i = ipc_get_arg1(icall);
 	if (i >= NULL_SERVICES) {
 		async_answer_0(icall, ELIMIT);
 		return;
@@ -1280,8 +1280,8 @@ static void loc_service_add_to_cat(ipc_call_t *icall)
 	service_id_t svc_id;
 	errno_t retval;
 
-	svc_id = IPC_GET_ARG1(icall);
-	cat_id = IPC_GET_ARG2(icall);
+	svc_id = ipc_get_arg1(icall);
+	cat_id = ipc_get_arg2(icall);
 
 	fibril_mutex_lock(&services_list_mutex);
 	fibril_mutex_lock(&cdir.mutex);
@@ -1418,12 +1418,12 @@ static void loc_connection_supplier(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case LOC_SERVER_UNREGISTER:
 			if (server == NULL)
 				async_answer_0(&call, ENOENT);
@@ -1474,12 +1474,12 @@ static void loc_connection_consumer(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case LOC_SERVICE_GET_ID:
 			loc_service_get_id(&call);
 			break;

--- a/uspace/srv/locsrv/locsrv.c
+++ b/uspace/srv/locsrv/locsrv.c
@@ -341,7 +341,7 @@ static loc_server_t *loc_server_register(void)
 	ipc_call_t icall;
 	async_get_call(&icall);
 
-	if (IPC_GET_IMETHOD(icall) != LOC_SERVER_REGISTER) {
+	if (IPC_GET_IMETHOD(&icall) != LOC_SERVER_REGISTER) {
 		async_answer_0(&icall, EREFUSED);
 		return NULL;
 	}
@@ -546,7 +546,7 @@ static void loc_service_unregister(ipc_call_t *icall, loc_server_t *server)
 	loc_service_t *svc;
 
 	fibril_mutex_lock(&services_list_mutex);
-	svc = loc_service_find_id(IPC_GET_ARG1(*icall));
+	svc = loc_service_find_id(IPC_GET_ARG1(icall));
 	if (svc == NULL) {
 		fibril_mutex_unlock(&services_list_mutex);
 		async_answer_0(icall, ENOENT);
@@ -582,7 +582,7 @@ static void loc_category_get_name(ipc_call_t *icall)
 
 	fibril_mutex_lock(&cdir.mutex);
 
-	cat = category_get(&cdir, IPC_GET_ARG1(*icall));
+	cat = category_get(&cdir, IPC_GET_ARG1(icall));
 	if (cat == NULL) {
 		fibril_mutex_unlock(&cdir.mutex);
 		async_answer_0(&call, ENOENT);
@@ -622,7 +622,7 @@ static void loc_service_get_name(ipc_call_t *icall)
 
 	fibril_mutex_lock(&services_list_mutex);
 
-	svc = loc_service_find_id(IPC_GET_ARG1(*icall));
+	svc = loc_service_find_id(IPC_GET_ARG1(icall));
 	if (svc == NULL) {
 		fibril_mutex_unlock(&services_list_mutex);
 		async_answer_0(&call, ENOENT);
@@ -670,7 +670,7 @@ static void loc_service_get_server_name(ipc_call_t *icall)
 
 	fibril_mutex_lock(&services_list_mutex);
 
-	svc = loc_service_find_id(IPC_GET_ARG1(*icall));
+	svc = loc_service_find_id(IPC_GET_ARG1(icall));
 	if (svc == NULL) {
 		fibril_mutex_unlock(&services_list_mutex);
 		async_answer_0(&call, ENOENT);
@@ -714,8 +714,8 @@ static void loc_forward(ipc_call_t *call, void *arg)
 	/*
 	 * Get ID from request
 	 */
-	iface_t iface = IPC_GET_ARG1(*call);
-	service_id_t id = IPC_GET_ARG2(*call);
+	iface_t iface = IPC_GET_ARG1(call);
+	service_id_t id = IPC_GET_ARG2(call);
 	loc_service_t *svc = loc_service_find_id(id);
 
 	if ((svc == NULL) || (svc->server == NULL) || (!svc->server->sess)) {
@@ -773,7 +773,7 @@ recheck:
 	 * Device was not found.
 	 */
 	if (svc == NULL) {
-		if (IPC_GET_ARG1(*icall) & IPC_FLAG_BLOCKING) {
+		if (IPC_GET_ARG1(icall) & IPC_FLAG_BLOCKING) {
 			/* Blocking lookup */
 			fibril_condvar_wait(&services_list_cv,
 			    &services_list_mutex);
@@ -826,7 +826,7 @@ recheck:
 	 * Namespace was not found.
 	 */
 	if (namespace == NULL) {
-		if (IPC_GET_ARG1(*icall) & IPC_FLAG_BLOCKING) {
+		if (IPC_GET_ARG1(icall) & IPC_FLAG_BLOCKING) {
 			/* Blocking lookup */
 			fibril_condvar_wait(&services_list_cv,
 			    &services_list_mutex);
@@ -931,10 +931,10 @@ static void loc_id_probe(ipc_call_t *icall)
 	fibril_mutex_lock(&services_list_mutex);
 
 	loc_namespace_t *namespace =
-	    loc_namespace_find_id(IPC_GET_ARG1(*icall));
+	    loc_namespace_find_id(IPC_GET_ARG1(icall));
 	if (namespace == NULL) {
 		loc_service_t *svc =
-		    loc_service_find_id(IPC_GET_ARG1(*icall));
+		    loc_service_find_id(IPC_GET_ARG1(icall));
 		if (svc == NULL)
 			async_answer_1(icall, EOK, LOC_OBJECT_NONE);
 		else
@@ -957,7 +957,7 @@ static void loc_get_service_count(ipc_call_t *icall)
 	fibril_mutex_lock(&services_list_mutex);
 
 	loc_namespace_t *namespace =
-	    loc_namespace_find_id(IPC_GET_ARG1(*icall));
+	    loc_namespace_find_id(IPC_GET_ARG1(icall));
 	if (namespace == NULL)
 		async_answer_0(icall, EEXIST);
 	else
@@ -1078,7 +1078,7 @@ static void loc_get_services(ipc_call_t *icall)
 	fibril_mutex_lock(&services_list_mutex);
 
 	loc_namespace_t *namespace =
-	    loc_namespace_find_id(IPC_GET_ARG1(*icall));
+	    loc_namespace_find_id(IPC_GET_ARG1(icall));
 	if (namespace == NULL) {
 		fibril_mutex_unlock(&services_list_mutex);
 		async_answer_0(&call, ENOENT);
@@ -1134,7 +1134,7 @@ static void loc_category_get_svcs(ipc_call_t *icall)
 
 	fibril_mutex_lock(&cdir.mutex);
 
-	category_t *cat = category_get(&cdir, IPC_GET_ARG1(*icall));
+	category_t *cat = category_get(&cdir, IPC_GET_ARG1(icall));
 	if (cat == NULL) {
 		fibril_mutex_unlock(&cdir.mutex);
 		async_answer_0(&call, ENOENT);
@@ -1246,7 +1246,7 @@ static void loc_null_create(ipc_call_t *icall)
 
 static void loc_null_destroy(ipc_call_t *icall)
 {
-	sysarg_t i = IPC_GET_ARG1(*icall);
+	sysarg_t i = IPC_GET_ARG1(icall);
 	if (i >= NULL_SERVICES) {
 		async_answer_0(icall, ELIMIT);
 		return;
@@ -1280,8 +1280,8 @@ static void loc_service_add_to_cat(ipc_call_t *icall)
 	service_id_t svc_id;
 	errno_t retval;
 
-	svc_id = IPC_GET_ARG1(*icall);
-	cat_id = IPC_GET_ARG2(*icall);
+	svc_id = IPC_GET_ARG1(icall);
+	cat_id = IPC_GET_ARG2(icall);
 
 	fibril_mutex_lock(&services_list_mutex);
 	fibril_mutex_lock(&cdir.mutex);
@@ -1418,12 +1418,12 @@ static void loc_connection_supplier(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case LOC_SERVER_UNREGISTER:
 			if (server == NULL)
 				async_answer_0(&call, ENOENT);
@@ -1474,12 +1474,12 @@ static void loc_connection_consumer(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case LOC_SERVICE_GET_ID:
 			loc_service_get_id(&call);
 			break;

--- a/uspace/srv/logger/ctl.c
+++ b/uspace/srv/logger/ctl.c
@@ -74,18 +74,18 @@ void logger_connection_handler_control(ipc_call_t *icall)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case LOGGER_CONTROL_SET_DEFAULT_LEVEL:
-			rc = set_default_logging_level(IPC_GET_ARG1(call));
+			rc = set_default_logging_level(IPC_GET_ARG1(&call));
 			async_answer_0(&call, rc);
 			break;
 		case LOGGER_CONTROL_SET_LOG_LEVEL:
-			rc = handle_log_level_change(IPC_GET_ARG1(call));
+			rc = handle_log_level_change(IPC_GET_ARG1(&call));
 			async_answer_0(&call, rc);
 			break;
 		case LOGGER_CONTROL_SET_ROOT:

--- a/uspace/srv/logger/ctl.c
+++ b/uspace/srv/logger/ctl.c
@@ -74,18 +74,18 @@ void logger_connection_handler_control(ipc_call_t *icall)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case LOGGER_CONTROL_SET_DEFAULT_LEVEL:
-			rc = set_default_logging_level(IPC_GET_ARG1(&call));
+			rc = set_default_logging_level(ipc_get_arg1(&call));
 			async_answer_0(&call, rc);
 			break;
 		case LOGGER_CONTROL_SET_LOG_LEVEL:
-			rc = handle_log_level_change(IPC_GET_ARG1(&call));
+			rc = handle_log_level_change(ipc_get_arg1(&call));
 			async_answer_0(&call, rc);
 			break;
 		case LOGGER_CONTROL_SET_ROOT:

--- a/uspace/srv/logger/writer.c
+++ b/uspace/srv/logger/writer.c
@@ -108,14 +108,14 @@ void logger_connection_handler_writer(ipc_call_t *icall)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case LOGGER_WRITER_CREATE_LOG:
-			log = handle_create_log(IPC_GET_ARG1(&call));
+			log = handle_create_log(ipc_get_arg1(&call));
 			if (log == NULL) {
 				async_answer_0(&call, ENOMEM);
 				break;
@@ -129,8 +129,8 @@ void logger_connection_handler_writer(ipc_call_t *icall)
 			async_answer_1(&call, EOK, (sysarg_t) log);
 			break;
 		case LOGGER_WRITER_MESSAGE:
-			rc = handle_receive_message(IPC_GET_ARG1(&call),
-			    IPC_GET_ARG2(&call));
+			rc = handle_receive_message(ipc_get_arg1(&call),
+			    ipc_get_arg2(&call));
 			async_answer_0(&call, rc);
 			break;
 		default:

--- a/uspace/srv/logger/writer.c
+++ b/uspace/srv/logger/writer.c
@@ -108,14 +108,14 @@ void logger_connection_handler_writer(ipc_call_t *icall)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case LOGGER_WRITER_CREATE_LOG:
-			log = handle_create_log(IPC_GET_ARG1(call));
+			log = handle_create_log(IPC_GET_ARG1(&call));
 			if (log == NULL) {
 				async_answer_0(&call, ENOMEM);
 				break;
@@ -129,8 +129,8 @@ void logger_connection_handler_writer(ipc_call_t *icall)
 			async_answer_1(&call, EOK, (sysarg_t) log);
 			break;
 		case LOGGER_WRITER_MESSAGE:
-			rc = handle_receive_message(IPC_GET_ARG1(call),
-			    IPC_GET_ARG2(call));
+			rc = handle_receive_message(IPC_GET_ARG1(&call),
+			    IPC_GET_ARG2(&call));
 			async_answer_0(&call, rc);
 			break;
 		default:

--- a/uspace/srv/net/dhcp/main.c
+++ b/uspace/srv/net/dhcp/main.c
@@ -90,7 +90,7 @@ static void dhcp_link_add_srv(ipc_call_t *call)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "dhcp_link_add_srv()");
 
-	link_id = IPC_GET_ARG1(*call);
+	link_id = IPC_GET_ARG1(call);
 
 	rc = dhcpsrv_link_add(link_id);
 	async_answer_0(call, rc);
@@ -103,7 +103,7 @@ static void dhcp_link_remove_srv(ipc_call_t *call)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "dhcp_link_remove_srv()");
 
-	link_id = IPC_GET_ARG1(*call);
+	link_id = IPC_GET_ARG1(call);
 
 	rc = dhcpsrv_link_remove(link_id);
 	async_answer_0(call, rc);
@@ -116,7 +116,7 @@ static void dhcp_discover_srv(ipc_call_t *call)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "dhcp_discover_srv()");
 
-	link_id = IPC_GET_ARG1(*call);
+	link_id = IPC_GET_ARG1(call);
 
 	rc = dhcpsrv_discover(link_id);
 	async_answer_0(call, rc);
@@ -132,7 +132,7 @@ static void dhcp_client_conn(ipc_call_t *icall, void *arg)
 	while (true) {
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(call);
+		sysarg_t method = IPC_GET_IMETHOD(&call);
 
 		if (!method) {
 			/* The other side has hung up */

--- a/uspace/srv/net/dhcp/main.c
+++ b/uspace/srv/net/dhcp/main.c
@@ -90,7 +90,7 @@ static void dhcp_link_add_srv(ipc_call_t *call)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "dhcp_link_add_srv()");
 
-	link_id = IPC_GET_ARG1(call);
+	link_id = ipc_get_arg1(call);
 
 	rc = dhcpsrv_link_add(link_id);
 	async_answer_0(call, rc);
@@ -103,7 +103,7 @@ static void dhcp_link_remove_srv(ipc_call_t *call)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "dhcp_link_remove_srv()");
 
-	link_id = IPC_GET_ARG1(call);
+	link_id = ipc_get_arg1(call);
 
 	rc = dhcpsrv_link_remove(link_id);
 	async_answer_0(call, rc);
@@ -116,7 +116,7 @@ static void dhcp_discover_srv(ipc_call_t *call)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "dhcp_discover_srv()");
 
-	link_id = IPC_GET_ARG1(call);
+	link_id = ipc_get_arg1(call);
 
 	rc = dhcpsrv_discover(link_id);
 	async_answer_0(call, rc);
@@ -132,7 +132,7 @@ static void dhcp_client_conn(ipc_call_t *icall, void *arg)
 	while (true) {
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(&call);
+		sysarg_t method = ipc_get_imethod(&call);
 
 		if (!method) {
 			/* The other side has hung up */

--- a/uspace/srv/net/dnsrsrv/dnsrsrv.c
+++ b/uspace/srv/net/dnsrsrv/dnsrsrv.c
@@ -89,7 +89,7 @@ static void dnsr_name2host_srv(dnsr_client_t *client, ipc_call_t *icall)
 {
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "inet_get_srvaddr_srv()");
 
-	ip_ver_t ver = IPC_GET_ARG1(*icall);
+	ip_ver_t ver = IPC_GET_ARG1(icall);
 
 	char *name;
 	errno_t rc = async_data_write_accept((void **) &name, true, 0,
@@ -218,7 +218,7 @@ static void dnsr_client_conn(ipc_call_t *icall, void *arg)
 	while (true) {
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(call);
+		sysarg_t method = IPC_GET_IMETHOD(&call);
 
 		if (!method) {
 			/* The other side has hung up */

--- a/uspace/srv/net/dnsrsrv/dnsrsrv.c
+++ b/uspace/srv/net/dnsrsrv/dnsrsrv.c
@@ -89,7 +89,7 @@ static void dnsr_name2host_srv(dnsr_client_t *client, ipc_call_t *icall)
 {
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "inet_get_srvaddr_srv()");
 
-	ip_ver_t ver = IPC_GET_ARG1(icall);
+	ip_ver_t ver = ipc_get_arg1(icall);
 
 	char *name;
 	errno_t rc = async_data_write_accept((void **) &name, true, 0,
@@ -218,7 +218,7 @@ static void dnsr_client_conn(ipc_call_t *icall, void *arg)
 	while (true) {
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(&call);
+		sysarg_t method = ipc_get_imethod(&call);
 
 		if (!method) {
 			/* The other side has hung up */

--- a/uspace/srv/net/ethip/ethip.c
+++ b/uspace/srv/net/ethip/ethip.c
@@ -146,7 +146,7 @@ static void ethip_client_conn(ipc_call_t *icall, void *arg)
 	ethip_nic_t *nic;
 	service_id_t sid;
 
-	sid = (service_id_t) IPC_GET_ARG2(icall);
+	sid = (service_id_t) ipc_get_arg2(icall);
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "ethip_client_conn(%u)", (unsigned)sid);
 	nic = ethip_nic_find_by_iplink_sid(sid);
 	if (nic == NULL) {

--- a/uspace/srv/net/ethip/ethip.c
+++ b/uspace/srv/net/ethip/ethip.c
@@ -146,7 +146,7 @@ static void ethip_client_conn(ipc_call_t *icall, void *arg)
 	ethip_nic_t *nic;
 	service_id_t sid;
 
-	sid = (service_id_t) IPC_GET_ARG2(*icall);
+	sid = (service_id_t) IPC_GET_ARG2(icall);
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "ethip_client_conn(%u)", (unsigned)sid);
 	nic = ethip_nic_find_by_iplink_sid(sid);
 	if (nic == NULL) {

--- a/uspace/srv/net/ethip/ethip_nic.c
+++ b/uspace/srv/net/ethip/ethip_nic.c
@@ -298,12 +298,12 @@ static void ethip_nic_cb_conn(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case NIC_EV_ADDR_CHANGED:
 			ethip_nic_addr_changed(nic, &call);
 			break;
@@ -314,7 +314,7 @@ static void ethip_nic_cb_conn(ipc_call_t *icall, void *arg)
 			ethip_nic_device_state(nic, &call);
 			break;
 		default:
-			log_msg(LOG_DEFAULT, LVL_DEBUG, "unknown IPC method: %" PRIun, IPC_GET_IMETHOD(&call));
+			log_msg(LOG_DEFAULT, LVL_DEBUG, "unknown IPC method: %" PRIun, ipc_get_imethod(&call));
 			async_answer_0(&call, ENOTSUP);
 		}
 	}

--- a/uspace/srv/net/ethip/ethip_nic.c
+++ b/uspace/srv/net/ethip/ethip_nic.c
@@ -298,12 +298,12 @@ static void ethip_nic_cb_conn(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			return;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case NIC_EV_ADDR_CHANGED:
 			ethip_nic_addr_changed(nic, &call);
 			break;
@@ -314,7 +314,7 @@ static void ethip_nic_cb_conn(ipc_call_t *icall, void *arg)
 			ethip_nic_device_state(nic, &call);
 			break;
 		default:
-			log_msg(LOG_DEFAULT, LVL_DEBUG, "unknown IPC method: %" PRIun, IPC_GET_IMETHOD(call));
+			log_msg(LOG_DEFAULT, LVL_DEBUG, "unknown IPC method: %" PRIun, IPC_GET_IMETHOD(&call));
 			async_answer_0(&call, ENOTSUP);
 		}
 	}

--- a/uspace/srv/net/inetsrv/inetcfg.c
+++ b/uspace/srv/net/inetsrv/inetcfg.c
@@ -256,7 +256,7 @@ static void inetcfg_addr_create_static_srv(ipc_call_t *icall)
 {
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "inetcfg_addr_create_static_srv()");
 
-	sysarg_t link_id = IPC_GET_ARG1(*icall);
+	sysarg_t link_id = IPC_GET_ARG1(icall);
 
 	ipc_call_t call;
 	size_t size;
@@ -301,7 +301,7 @@ static void inetcfg_addr_delete_srv(ipc_call_t *call)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "inetcfg_addr_delete_srv()");
 
-	addr_id = IPC_GET_ARG1(*call);
+	addr_id = IPC_GET_ARG1(call);
 
 	rc = inetcfg_addr_delete(addr_id);
 	async_answer_0(call, rc);
@@ -311,7 +311,7 @@ static void inetcfg_addr_get_srv(ipc_call_t *icall)
 {
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "inetcfg_addr_get_srv()");
 
-	sysarg_t addr_id = IPC_GET_ARG1(*icall);
+	sysarg_t addr_id = IPC_GET_ARG1(icall);
 
 	inet_addr_info_t ainfo;
 
@@ -374,7 +374,7 @@ static void inetcfg_addr_get_id_srv(ipc_call_t *call)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "inetcfg_addr_get_id_srv()");
 
-	link_id = IPC_GET_ARG1(*call);
+	link_id = IPC_GET_ARG1(call);
 
 	rc = async_data_write_accept((void **) &name, true, 0, LOC_NAME_MAXLEN,
 	    0, NULL);
@@ -498,7 +498,7 @@ static void inetcfg_link_add_srv(ipc_call_t *call)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "inetcfg_link_add_srv()");
 
-	link_id = IPC_GET_ARG1(*call);
+	link_id = IPC_GET_ARG1(call);
 
 	rc = inetcfg_link_add(link_id);
 	async_answer_0(call, rc);
@@ -515,7 +515,7 @@ static void inetcfg_link_get_srv(ipc_call_t *call)
 	inet_link_info_t linfo;
 	errno_t rc;
 
-	link_id = IPC_GET_ARG1(*call);
+	link_id = IPC_GET_ARG1(call);
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "inetcfg_link_get_srv()");
 
 	linfo.name = NULL;
@@ -565,7 +565,7 @@ static void inetcfg_link_remove_srv(ipc_call_t *call)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "inetcfg_link_remove_srv()");
 
-	link_id = IPC_GET_ARG1(*call);
+	link_id = IPC_GET_ARG1(call);
 
 	rc = inetcfg_link_remove(link_id);
 	async_answer_0(call, rc);
@@ -638,7 +638,7 @@ static void inetcfg_sroute_delete_srv(ipc_call_t *call)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "inetcfg_sroute_delete_srv()");
 
-	sroute_id = IPC_GET_ARG1(*call);
+	sroute_id = IPC_GET_ARG1(call);
 
 	rc = inetcfg_sroute_delete(sroute_id);
 	async_answer_0(call, rc);
@@ -648,7 +648,7 @@ static void inetcfg_sroute_get_srv(ipc_call_t *icall)
 {
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "inetcfg_sroute_get_srv()");
 
-	sysarg_t sroute_id = IPC_GET_ARG1(*icall);
+	sysarg_t sroute_id = IPC_GET_ARG1(icall);
 
 	inet_sroute_info_t srinfo;
 
@@ -746,7 +746,7 @@ void inet_cfg_conn(ipc_call_t *icall, void *arg)
 	while (true) {
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(call);
+		sysarg_t method = IPC_GET_IMETHOD(&call);
 
 		log_msg(LOG_DEFAULT, LVL_DEBUG, "method %d", (int)method);
 		if (!method) {

--- a/uspace/srv/net/inetsrv/inetcfg.c
+++ b/uspace/srv/net/inetsrv/inetcfg.c
@@ -256,7 +256,7 @@ static void inetcfg_addr_create_static_srv(ipc_call_t *icall)
 {
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "inetcfg_addr_create_static_srv()");
 
-	sysarg_t link_id = IPC_GET_ARG1(icall);
+	sysarg_t link_id = ipc_get_arg1(icall);
 
 	ipc_call_t call;
 	size_t size;
@@ -301,7 +301,7 @@ static void inetcfg_addr_delete_srv(ipc_call_t *call)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "inetcfg_addr_delete_srv()");
 
-	addr_id = IPC_GET_ARG1(call);
+	addr_id = ipc_get_arg1(call);
 
 	rc = inetcfg_addr_delete(addr_id);
 	async_answer_0(call, rc);
@@ -311,7 +311,7 @@ static void inetcfg_addr_get_srv(ipc_call_t *icall)
 {
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "inetcfg_addr_get_srv()");
 
-	sysarg_t addr_id = IPC_GET_ARG1(icall);
+	sysarg_t addr_id = ipc_get_arg1(icall);
 
 	inet_addr_info_t ainfo;
 
@@ -374,7 +374,7 @@ static void inetcfg_addr_get_id_srv(ipc_call_t *call)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "inetcfg_addr_get_id_srv()");
 
-	link_id = IPC_GET_ARG1(call);
+	link_id = ipc_get_arg1(call);
 
 	rc = async_data_write_accept((void **) &name, true, 0, LOC_NAME_MAXLEN,
 	    0, NULL);
@@ -498,7 +498,7 @@ static void inetcfg_link_add_srv(ipc_call_t *call)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "inetcfg_link_add_srv()");
 
-	link_id = IPC_GET_ARG1(call);
+	link_id = ipc_get_arg1(call);
 
 	rc = inetcfg_link_add(link_id);
 	async_answer_0(call, rc);
@@ -515,7 +515,7 @@ static void inetcfg_link_get_srv(ipc_call_t *call)
 	inet_link_info_t linfo;
 	errno_t rc;
 
-	link_id = IPC_GET_ARG1(call);
+	link_id = ipc_get_arg1(call);
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "inetcfg_link_get_srv()");
 
 	linfo.name = NULL;
@@ -565,7 +565,7 @@ static void inetcfg_link_remove_srv(ipc_call_t *call)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "inetcfg_link_remove_srv()");
 
-	link_id = IPC_GET_ARG1(call);
+	link_id = ipc_get_arg1(call);
 
 	rc = inetcfg_link_remove(link_id);
 	async_answer_0(call, rc);
@@ -638,7 +638,7 @@ static void inetcfg_sroute_delete_srv(ipc_call_t *call)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "inetcfg_sroute_delete_srv()");
 
-	sroute_id = IPC_GET_ARG1(call);
+	sroute_id = ipc_get_arg1(call);
 
 	rc = inetcfg_sroute_delete(sroute_id);
 	async_answer_0(call, rc);
@@ -648,7 +648,7 @@ static void inetcfg_sroute_get_srv(ipc_call_t *icall)
 {
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "inetcfg_sroute_get_srv()");
 
-	sysarg_t sroute_id = IPC_GET_ARG1(icall);
+	sysarg_t sroute_id = ipc_get_arg1(icall);
 
 	inet_sroute_info_t srinfo;
 
@@ -746,7 +746,7 @@ void inet_cfg_conn(ipc_call_t *icall, void *arg)
 	while (true) {
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(&call);
+		sysarg_t method = ipc_get_imethod(&call);
 
 		log_msg(LOG_DEFAULT, LVL_DEBUG, "method %d", (int)method);
 		if (!method) {

--- a/uspace/srv/net/inetsrv/inetping.c
+++ b/uspace/srv/net/inetsrv/inetping.c
@@ -142,7 +142,7 @@ static void inetping_send_srv(inetping_client_t *client, ipc_call_t *icall)
 	inetping_sdu_t sdu;
 	errno_t rc;
 
-	sdu.seq_no = IPC_GET_ARG1(icall);
+	sdu.seq_no = ipc_get_arg1(icall);
 
 	ipc_call_t call;
 	size_t size;
@@ -293,7 +293,7 @@ void inetping_conn(ipc_call_t *icall, void *arg)
 	while (true) {
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(&call);
+		sysarg_t method = ipc_get_imethod(&call);
 
 		if (!method) {
 			/* The other side has hung up */

--- a/uspace/srv/net/inetsrv/inetping.c
+++ b/uspace/srv/net/inetsrv/inetping.c
@@ -142,7 +142,7 @@ static void inetping_send_srv(inetping_client_t *client, ipc_call_t *icall)
 	inetping_sdu_t sdu;
 	errno_t rc;
 
-	sdu.seq_no = IPC_GET_ARG1(*icall);
+	sdu.seq_no = IPC_GET_ARG1(icall);
 
 	ipc_call_t call;
 	size_t size;
@@ -293,7 +293,7 @@ void inetping_conn(ipc_call_t *icall, void *arg)
 	while (true) {
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(call);
+		sysarg_t method = IPC_GET_IMETHOD(&call);
 
 		if (!method) {
 			/* The other side has hung up */

--- a/uspace/srv/net/inetsrv/inetsrv.c
+++ b/uspace/srv/net/inetsrv/inetsrv.c
@@ -232,7 +232,7 @@ static void inet_get_srcaddr_srv(inet_client_t *client, ipc_call_t *icall)
 {
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "inet_get_srcaddr_srv()");
 
-	uint8_t tos = IPC_GET_ARG1(icall);
+	uint8_t tos = ipc_get_arg1(icall);
 
 	ipc_call_t call;
 	size_t size;
@@ -290,11 +290,11 @@ static void inet_send_srv(inet_client_t *client, ipc_call_t *icall)
 
 	inet_dgram_t dgram;
 
-	dgram.iplink = IPC_GET_ARG1(icall);
-	dgram.tos = IPC_GET_ARG2(icall);
+	dgram.iplink = ipc_get_arg1(icall);
+	dgram.tos = ipc_get_arg2(icall);
 
-	uint8_t ttl = IPC_GET_ARG3(icall);
-	int df = IPC_GET_ARG4(icall);
+	uint8_t ttl = ipc_get_arg3(icall);
+	int df = ipc_get_arg4(icall);
 
 	ipc_call_t call;
 	size_t size;
@@ -351,7 +351,7 @@ static void inet_set_proto_srv(inet_client_t *client, ipc_call_t *call)
 {
 	sysarg_t proto;
 
-	proto = IPC_GET_ARG1(call);
+	proto = ipc_get_arg1(call);
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "inet_set_proto_srv(%lu)", (unsigned long) proto);
 
 	if (proto > UINT8_MAX) {
@@ -396,7 +396,7 @@ static void inet_default_conn(ipc_call_t *icall, void *arg)
 	while (true) {
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(&call);
+		sysarg_t method = ipc_get_imethod(&call);
 
 		if (!method) {
 			/* The other side has hung up */

--- a/uspace/srv/net/inetsrv/inetsrv.c
+++ b/uspace/srv/net/inetsrv/inetsrv.c
@@ -232,7 +232,7 @@ static void inet_get_srcaddr_srv(inet_client_t *client, ipc_call_t *icall)
 {
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "inet_get_srcaddr_srv()");
 
-	uint8_t tos = IPC_GET_ARG1(*icall);
+	uint8_t tos = IPC_GET_ARG1(icall);
 
 	ipc_call_t call;
 	size_t size;
@@ -290,11 +290,11 @@ static void inet_send_srv(inet_client_t *client, ipc_call_t *icall)
 
 	inet_dgram_t dgram;
 
-	dgram.iplink = IPC_GET_ARG1(*icall);
-	dgram.tos = IPC_GET_ARG2(*icall);
+	dgram.iplink = IPC_GET_ARG1(icall);
+	dgram.tos = IPC_GET_ARG2(icall);
 
-	uint8_t ttl = IPC_GET_ARG3(*icall);
-	int df = IPC_GET_ARG4(*icall);
+	uint8_t ttl = IPC_GET_ARG3(icall);
+	int df = IPC_GET_ARG4(icall);
 
 	ipc_call_t call;
 	size_t size;
@@ -351,7 +351,7 @@ static void inet_set_proto_srv(inet_client_t *client, ipc_call_t *call)
 {
 	sysarg_t proto;
 
-	proto = IPC_GET_ARG1(*call);
+	proto = IPC_GET_ARG1(call);
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "inet_set_proto_srv(%lu)", (unsigned long) proto);
 
 	if (proto > UINT8_MAX) {
@@ -396,7 +396,7 @@ static void inet_default_conn(ipc_call_t *icall, void *arg)
 	while (true) {
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(call);
+		sysarg_t method = IPC_GET_IMETHOD(&call);
 
 		if (!method) {
 			/* The other side has hung up */

--- a/uspace/srv/net/tcp/service.c
+++ b/uspace/srv/net/tcp/service.c
@@ -805,7 +805,7 @@ static void tcp_conn_destroy_srv(tcp_client_t *client, ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "tcp_conn_destroy_srv()");
 
-	conn_id = IPC_GET_ARG1(*icall);
+	conn_id = IPC_GET_ARG1(icall);
 	rc = tcp_conn_destroy_impl(client, conn_id);
 	async_answer_0(icall, rc);
 }
@@ -871,7 +871,7 @@ static void tcp_listener_destroy_srv(tcp_client_t *client, ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "tcp_listener_destroy_srv()");
 
-	lst_id = IPC_GET_ARG1(*icall);
+	lst_id = IPC_GET_ARG1(icall);
 	rc = tcp_listener_destroy_impl(client, lst_id);
 	async_answer_0(icall, rc);
 }
@@ -891,7 +891,7 @@ static void tcp_conn_send_fin_srv(tcp_client_t *client, ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "tcp_conn_send_fin_srv()");
 
-	conn_id = IPC_GET_ARG1(*icall);
+	conn_id = IPC_GET_ARG1(icall);
 	rc = tcp_conn_send_fin_impl(client, conn_id);
 	async_answer_0(icall, rc);
 }
@@ -911,7 +911,7 @@ static void tcp_conn_push_srv(tcp_client_t *client, ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "tcp_conn_push_srv()");
 
-	conn_id = IPC_GET_ARG1(*icall);
+	conn_id = IPC_GET_ARG1(icall);
 	rc = tcp_conn_push_impl(client, conn_id);
 	async_answer_0(icall, rc);
 }
@@ -931,7 +931,7 @@ static void tcp_conn_reset_srv(tcp_client_t *client, ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "tcp_conn_reset_srv()");
 
-	conn_id = IPC_GET_ARG1(*icall);
+	conn_id = IPC_GET_ARG1(icall);
 	rc = tcp_conn_reset_impl(client, conn_id);
 	async_answer_0(icall, rc);
 }
@@ -983,7 +983,7 @@ static void tcp_conn_send_srv(tcp_client_t *client, ipc_call_t *icall)
 		return;
 	}
 
-	conn_id = IPC_GET_ARG1(*icall);
+	conn_id = IPC_GET_ARG1(icall);
 
 	rc = tcp_conn_send_impl(client, conn_id, data, size);
 	if (rc != EOK) {
@@ -1014,7 +1014,7 @@ static void tcp_conn_recv_srv(tcp_client_t *client, ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "tcp_conn_recv_srv()");
 
-	conn_id = IPC_GET_ARG1(*icall);
+	conn_id = IPC_GET_ARG1(icall);
 
 	if (!async_data_read_receive(&call, &size)) {
 		async_answer_0(&call, EREFUSED);
@@ -1069,7 +1069,7 @@ static void tcp_conn_recv_wait_srv(tcp_client_t *client, ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "tcp_conn_recv_wait_srv()");
 
-	conn_id = IPC_GET_ARG1(*icall);
+	conn_id = IPC_GET_ARG1(icall);
 
 	if (!async_data_read_receive(&call, &size)) {
 		log_msg(LOG_DEFAULT, LVL_DEBUG, "tcp_conn_recv_wait_srv - data_receive failed");
@@ -1179,7 +1179,7 @@ static void tcp_client_conn(ipc_call_t *icall, void *arg)
 		log_msg(LOG_DEFAULT, LVL_DEBUG, "tcp_client_conn: wait req");
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(call);
+		sysarg_t method = IPC_GET_IMETHOD(&call);
 
 		log_msg(LOG_DEFAULT, LVL_DEBUG, "tcp_client_conn: method=%d",
 		    (int)method);

--- a/uspace/srv/net/tcp/service.c
+++ b/uspace/srv/net/tcp/service.c
@@ -805,7 +805,7 @@ static void tcp_conn_destroy_srv(tcp_client_t *client, ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "tcp_conn_destroy_srv()");
 
-	conn_id = IPC_GET_ARG1(icall);
+	conn_id = ipc_get_arg1(icall);
 	rc = tcp_conn_destroy_impl(client, conn_id);
 	async_answer_0(icall, rc);
 }
@@ -871,7 +871,7 @@ static void tcp_listener_destroy_srv(tcp_client_t *client, ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "tcp_listener_destroy_srv()");
 
-	lst_id = IPC_GET_ARG1(icall);
+	lst_id = ipc_get_arg1(icall);
 	rc = tcp_listener_destroy_impl(client, lst_id);
 	async_answer_0(icall, rc);
 }
@@ -891,7 +891,7 @@ static void tcp_conn_send_fin_srv(tcp_client_t *client, ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "tcp_conn_send_fin_srv()");
 
-	conn_id = IPC_GET_ARG1(icall);
+	conn_id = ipc_get_arg1(icall);
 	rc = tcp_conn_send_fin_impl(client, conn_id);
 	async_answer_0(icall, rc);
 }
@@ -911,7 +911,7 @@ static void tcp_conn_push_srv(tcp_client_t *client, ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "tcp_conn_push_srv()");
 
-	conn_id = IPC_GET_ARG1(icall);
+	conn_id = ipc_get_arg1(icall);
 	rc = tcp_conn_push_impl(client, conn_id);
 	async_answer_0(icall, rc);
 }
@@ -931,7 +931,7 @@ static void tcp_conn_reset_srv(tcp_client_t *client, ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "tcp_conn_reset_srv()");
 
-	conn_id = IPC_GET_ARG1(icall);
+	conn_id = ipc_get_arg1(icall);
 	rc = tcp_conn_reset_impl(client, conn_id);
 	async_answer_0(icall, rc);
 }
@@ -983,7 +983,7 @@ static void tcp_conn_send_srv(tcp_client_t *client, ipc_call_t *icall)
 		return;
 	}
 
-	conn_id = IPC_GET_ARG1(icall);
+	conn_id = ipc_get_arg1(icall);
 
 	rc = tcp_conn_send_impl(client, conn_id, data, size);
 	if (rc != EOK) {
@@ -1014,7 +1014,7 @@ static void tcp_conn_recv_srv(tcp_client_t *client, ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "tcp_conn_recv_srv()");
 
-	conn_id = IPC_GET_ARG1(icall);
+	conn_id = ipc_get_arg1(icall);
 
 	if (!async_data_read_receive(&call, &size)) {
 		async_answer_0(&call, EREFUSED);
@@ -1069,7 +1069,7 @@ static void tcp_conn_recv_wait_srv(tcp_client_t *client, ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "tcp_conn_recv_wait_srv()");
 
-	conn_id = IPC_GET_ARG1(icall);
+	conn_id = ipc_get_arg1(icall);
 
 	if (!async_data_read_receive(&call, &size)) {
 		log_msg(LOG_DEFAULT, LVL_DEBUG, "tcp_conn_recv_wait_srv - data_receive failed");
@@ -1179,7 +1179,7 @@ static void tcp_client_conn(ipc_call_t *icall, void *arg)
 		log_msg(LOG_DEFAULT, LVL_DEBUG, "tcp_client_conn: wait req");
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(&call);
+		sysarg_t method = ipc_get_imethod(&call);
 
 		log_msg(LOG_DEFAULT, LVL_DEBUG, "tcp_client_conn: method=%d",
 		    (int)method);

--- a/uspace/srv/net/udp/service.c
+++ b/uspace/srv/net/udp/service.c
@@ -404,7 +404,7 @@ static void udp_assoc_destroy_srv(udp_client_t *client, ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "udp_assoc_destroy_srv()");
 
-	assoc_id = IPC_GET_ARG1(icall);
+	assoc_id = ipc_get_arg1(icall);
 	rc = udp_assoc_destroy_impl(client, assoc_id);
 	async_answer_0(icall, rc);
 }
@@ -424,7 +424,7 @@ static void udp_assoc_set_nolocal_srv(udp_client_t *client, ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_NOTE, "udp_assoc_set_nolocal_srv()");
 
-	assoc_id = IPC_GET_ARG1(icall);
+	assoc_id = ipc_get_arg1(icall);
 	rc = udp_assoc_set_nolocal_impl(client, assoc_id);
 	async_answer_0(icall, rc);
 }
@@ -497,7 +497,7 @@ static void udp_assoc_send_msg_srv(udp_client_t *client, ipc_call_t *icall)
 		return;
 	}
 
-	assoc_id = IPC_GET_ARG1(icall);
+	assoc_id = ipc_get_arg1(icall);
 
 	rc = udp_assoc_send_msg_impl(client, assoc_id, &dest, data, size);
 	if (rc != EOK) {
@@ -591,7 +591,7 @@ static void udp_rmsg_read_srv(udp_client_t *client, ipc_call_t *icall)
 	errno_t rc;
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "udp_rmsg_read_srv()");
-	off = IPC_GET_ARG1(icall);
+	off = ipc_get_arg1(icall);
 
 	enext = udp_rmsg_get_next(client);
 
@@ -678,7 +678,7 @@ static void udp_client_conn(ipc_call_t *icall, void *arg)
 		log_msg(LOG_DEFAULT, LVL_DEBUG, "udp_client_conn: wait req");
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(&call);
+		sysarg_t method = ipc_get_imethod(&call);
 
 		log_msg(LOG_DEFAULT, LVL_DEBUG, "udp_client_conn: method=%d",
 		    (int)method);

--- a/uspace/srv/net/udp/service.c
+++ b/uspace/srv/net/udp/service.c
@@ -404,7 +404,7 @@ static void udp_assoc_destroy_srv(udp_client_t *client, ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "udp_assoc_destroy_srv()");
 
-	assoc_id = IPC_GET_ARG1(*icall);
+	assoc_id = IPC_GET_ARG1(icall);
 	rc = udp_assoc_destroy_impl(client, assoc_id);
 	async_answer_0(icall, rc);
 }
@@ -424,7 +424,7 @@ static void udp_assoc_set_nolocal_srv(udp_client_t *client, ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_NOTE, "udp_assoc_set_nolocal_srv()");
 
-	assoc_id = IPC_GET_ARG1(*icall);
+	assoc_id = IPC_GET_ARG1(icall);
 	rc = udp_assoc_set_nolocal_impl(client, assoc_id);
 	async_answer_0(icall, rc);
 }
@@ -497,7 +497,7 @@ static void udp_assoc_send_msg_srv(udp_client_t *client, ipc_call_t *icall)
 		return;
 	}
 
-	assoc_id = IPC_GET_ARG1(*icall);
+	assoc_id = IPC_GET_ARG1(icall);
 
 	rc = udp_assoc_send_msg_impl(client, assoc_id, &dest, data, size);
 	if (rc != EOK) {
@@ -591,7 +591,7 @@ static void udp_rmsg_read_srv(udp_client_t *client, ipc_call_t *icall)
 	errno_t rc;
 
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "udp_rmsg_read_srv()");
-	off = IPC_GET_ARG1(*icall);
+	off = IPC_GET_ARG1(icall);
 
 	enext = udp_rmsg_get_next(client);
 
@@ -678,7 +678,7 @@ static void udp_client_conn(ipc_call_t *icall, void *arg)
 		log_msg(LOG_DEFAULT, LVL_DEBUG, "udp_client_conn: wait req");
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(call);
+		sysarg_t method = IPC_GET_IMETHOD(&call);
 
 		log_msg(LOG_DEFAULT, LVL_DEBUG, "udp_client_conn: method=%d",
 		    (int)method);

--- a/uspace/srv/ns/clonable.c
+++ b/uspace/srv/ns/clonable.c
@@ -94,7 +94,7 @@ void ns_clonable_register(ipc_call_t *call)
 
 	async_exch_t *exch = async_exchange_begin(sess);
 	async_forward_1(&csr->call, exch, csr->iface,
-	    IPC_GET_ARG3(&csr->call), IPC_FF_NONE);
+	    ipc_get_arg3(&csr->call), IPC_FF_NONE);
 	async_exchange_end(exch);
 
 	free(csr);

--- a/uspace/srv/ns/clonable.c
+++ b/uspace/srv/ns/clonable.c
@@ -94,7 +94,7 @@ void ns_clonable_register(ipc_call_t *call)
 
 	async_exch_t *exch = async_exchange_begin(sess);
 	async_forward_1(&csr->call, exch, csr->iface,
-	    IPC_GET_ARG3(csr->call), IPC_FF_NONE);
+	    IPC_GET_ARG3(&csr->call), IPC_FF_NONE);
 	async_exchange_end(exch);
 
 	free(csr);

--- a/uspace/srv/ns/ns.c
+++ b/uspace/srv/ns/ns.c
@@ -54,8 +54,8 @@ static void ns_connection(ipc_call_t *icall, void *arg)
 	iface_t iface;
 	service_t service;
 
-	iface = IPC_GET_ARG1(icall);
-	service = IPC_GET_ARG2(icall);
+	iface = ipc_get_arg1(icall);
+	service = ipc_get_arg2(icall);
 	if (service != 0) {
 		/*
 		 * Client requests to be connected to a service.
@@ -75,7 +75,7 @@ static void ns_connection(ipc_call_t *icall, void *arg)
 		ns_pending_conn_process();
 
 		async_get_call(&call);
-		if (!IPC_GET_IMETHOD(&call))
+		if (!ipc_get_imethod(&call))
 			break;
 
 		task_id_t id;
@@ -83,10 +83,10 @@ static void ns_connection(ipc_call_t *icall, void *arg)
 
 		service_t service;
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case NS_REGISTER:
-			service = IPC_GET_ARG1(&call);
-			iface = IPC_GET_ARG2(&call);
+			service = ipc_get_arg1(&call);
+			iface = ipc_get_arg2(&call);
 
 			/*
 			 * Server requests service registration.
@@ -100,7 +100,7 @@ static void ns_connection(ipc_call_t *icall, void *arg)
 
 			break;
 		case NS_REGISTER_BROKER:
-			service = IPC_GET_ARG1(&call);
+			service = ipc_get_arg1(&call);
 			retval = ns_service_register_broker(service);
 			break;
 		case NS_PING:
@@ -108,7 +108,7 @@ static void ns_connection(ipc_call_t *icall, void *arg)
 			break;
 		case NS_TASK_WAIT:
 			id = (task_id_t)
-			    MERGE_LOUP32(IPC_GET_ARG1(&call), IPC_GET_ARG2(&call));
+			    MERGE_LOUP32(ipc_get_arg1(&call), ipc_get_arg2(&call));
 			wait_for_task(id, &call);
 			continue;
 		case NS_ID_INTRO:
@@ -119,7 +119,7 @@ static void ns_connection(ipc_call_t *icall, void *arg)
 			break;
 		default:
 			printf("%s: Method not supported (%" PRIun ")\n",
-			    NAME, IPC_GET_IMETHOD(&call));
+			    NAME, ipc_get_imethod(&call));
 			retval = ENOTSUP;
 			break;
 		}

--- a/uspace/srv/ns/ns.c
+++ b/uspace/srv/ns/ns.c
@@ -54,8 +54,8 @@ static void ns_connection(ipc_call_t *icall, void *arg)
 	iface_t iface;
 	service_t service;
 
-	iface = IPC_GET_ARG1(*icall);
-	service = IPC_GET_ARG2(*icall);
+	iface = IPC_GET_ARG1(icall);
+	service = IPC_GET_ARG2(icall);
 	if (service != 0) {
 		/*
 		 * Client requests to be connected to a service.
@@ -75,7 +75,7 @@ static void ns_connection(ipc_call_t *icall, void *arg)
 		ns_pending_conn_process();
 
 		async_get_call(&call);
-		if (!IPC_GET_IMETHOD(call))
+		if (!IPC_GET_IMETHOD(&call))
 			break;
 
 		task_id_t id;
@@ -83,10 +83,10 @@ static void ns_connection(ipc_call_t *icall, void *arg)
 
 		service_t service;
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case NS_REGISTER:
-			service = IPC_GET_ARG1(call);
-			iface = IPC_GET_ARG2(call);
+			service = IPC_GET_ARG1(&call);
+			iface = IPC_GET_ARG2(&call);
 
 			/*
 			 * Server requests service registration.
@@ -100,7 +100,7 @@ static void ns_connection(ipc_call_t *icall, void *arg)
 
 			break;
 		case NS_REGISTER_BROKER:
-			service = IPC_GET_ARG1(call);
+			service = IPC_GET_ARG1(&call);
 			retval = ns_service_register_broker(service);
 			break;
 		case NS_PING:
@@ -108,7 +108,7 @@ static void ns_connection(ipc_call_t *icall, void *arg)
 			break;
 		case NS_TASK_WAIT:
 			id = (task_id_t)
-			    MERGE_LOUP32(IPC_GET_ARG1(call), IPC_GET_ARG2(call));
+			    MERGE_LOUP32(IPC_GET_ARG1(&call), IPC_GET_ARG2(&call));
 			wait_for_task(id, &call);
 			continue;
 		case NS_ID_INTRO:
@@ -119,7 +119,7 @@ static void ns_connection(ipc_call_t *icall, void *arg)
 			break;
 		default:
 			printf("%s: Method not supported (%" PRIun ")\n",
-			    NAME, IPC_GET_IMETHOD(call));
+			    NAME, IPC_GET_IMETHOD(&call));
 			retval = ENOTSUP;
 			break;
 		}

--- a/uspace/srv/ns/service.c
+++ b/uspace/srv/ns/service.c
@@ -153,7 +153,7 @@ errno_t ns_service_init(void)
 static void ns_forward(async_sess_t *sess, ipc_call_t *call, iface_t iface)
 {
 	async_exch_t *exch = async_exchange_begin(sess);
-	async_forward_1(call, exch, iface, IPC_GET_ARG3(call), IPC_FF_NONE);
+	async_forward_1(call, exch, iface, ipc_get_arg3(call), IPC_FF_NONE);
 	async_exchange_end(exch);
 }
 
@@ -365,7 +365,7 @@ static errno_t ns_pending_conn_add(service_t service, iface_t iface,
  */
 void ns_service_forward(service_t service, iface_t iface, ipc_call_t *call)
 {
-	sysarg_t flags = IPC_GET_ARG4(call);
+	sysarg_t flags = ipc_get_arg4(call);
 	errno_t retval;
 
 	ht_link_t *link = hash_table_find(&service_hash_table, &service);

--- a/uspace/srv/ns/service.c
+++ b/uspace/srv/ns/service.c
@@ -153,7 +153,7 @@ errno_t ns_service_init(void)
 static void ns_forward(async_sess_t *sess, ipc_call_t *call, iface_t iface)
 {
 	async_exch_t *exch = async_exchange_begin(sess);
-	async_forward_1(call, exch, iface, IPC_GET_ARG3(*call), IPC_FF_NONE);
+	async_forward_1(call, exch, iface, IPC_GET_ARG3(call), IPC_FF_NONE);
 	async_exchange_end(exch);
 }
 
@@ -365,7 +365,7 @@ static errno_t ns_pending_conn_add(service_t service, iface_t iface,
  */
 void ns_service_forward(service_t service, iface_t iface, ipc_call_t *call)
 {
-	sysarg_t flags = IPC_GET_ARG4(*call);
+	sysarg_t flags = IPC_GET_ARG4(call);
 	errno_t retval;
 
 	ht_link_t *link = hash_table_find(&service_hash_table, &service);

--- a/uspace/srv/ns/task.c
+++ b/uspace/srv/ns/task.c
@@ -224,7 +224,7 @@ void wait_for_task(task_id_t id, ipc_call_t *call)
 
 errno_t ns_task_id_intro(ipc_call_t *call)
 {
-	task_id_t id = MERGE_LOUP32(IPC_GET_ARG1(*call), IPC_GET_ARG2(*call));
+	task_id_t id = MERGE_LOUP32(IPC_GET_ARG1(call), IPC_GET_ARG2(call));
 
 	ht_link_t *link = hash_table_find(&phone_to_id, &call->request_label);
 	if (link != NULL)
@@ -288,7 +288,7 @@ errno_t ns_task_retval(ipc_call_t *call)
 
 	ht->finished = true;
 	ht->have_rval = true;
-	ht->retval = IPC_GET_ARG1(*call);
+	ht->retval = IPC_GET_ARG1(call);
 
 	process_pending_wait();
 

--- a/uspace/srv/ns/task.c
+++ b/uspace/srv/ns/task.c
@@ -224,7 +224,7 @@ void wait_for_task(task_id_t id, ipc_call_t *call)
 
 errno_t ns_task_id_intro(ipc_call_t *call)
 {
-	task_id_t id = MERGE_LOUP32(IPC_GET_ARG1(call), IPC_GET_ARG2(call));
+	task_id_t id = MERGE_LOUP32(ipc_get_arg1(call), ipc_get_arg2(call));
 
 	ht_link_t *link = hash_table_find(&phone_to_id, &call->request_label);
 	if (link != NULL)
@@ -288,7 +288,7 @@ errno_t ns_task_retval(ipc_call_t *call)
 
 	ht->finished = true;
 	ht->have_rval = true;
-	ht->retval = IPC_GET_ARG1(call);
+	ht->retval = ipc_get_arg1(call);
 
 	process_pending_wait();
 

--- a/uspace/srv/taskmon/taskmon.c
+++ b/uspace/srv/taskmon/taskmon.c
@@ -60,8 +60,8 @@ static void fault_event(ipc_call_t *call, void *arg)
 	task_id_t taskid;
 	uintptr_t thread;
 
-	taskid = MERGE_LOUP32(IPC_GET_ARG1(*call), IPC_GET_ARG2(*call));
-	thread = IPC_GET_ARG3(*call);
+	taskid = MERGE_LOUP32(IPC_GET_ARG1(call), IPC_GET_ARG2(call));
+	thread = IPC_GET_ARG3(call);
 
 	if (asprintf(&s_taskid, "%" PRIu64, taskid) < 0) {
 		printf("Memory allocation failed.\n");
@@ -100,7 +100,7 @@ static void corecfg_get_enable_srv(ipc_call_t *icall)
 
 static void corecfg_set_enable_srv(ipc_call_t *icall)
 {
-	write_core_files = IPC_GET_ARG1(*icall);
+	write_core_files = IPC_GET_ARG1(icall);
 	async_answer_0(icall, EOK);
 }
 
@@ -112,7 +112,7 @@ static void corecfg_client_conn(ipc_call_t *icall, void *arg)
 	while (true) {
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(call);
+		sysarg_t method = IPC_GET_IMETHOD(&call);
 
 		if (!method) {
 			/* The other side has hung up */

--- a/uspace/srv/taskmon/taskmon.c
+++ b/uspace/srv/taskmon/taskmon.c
@@ -60,8 +60,8 @@ static void fault_event(ipc_call_t *call, void *arg)
 	task_id_t taskid;
 	uintptr_t thread;
 
-	taskid = MERGE_LOUP32(IPC_GET_ARG1(call), IPC_GET_ARG2(call));
-	thread = IPC_GET_ARG3(call);
+	taskid = MERGE_LOUP32(ipc_get_arg1(call), ipc_get_arg2(call));
+	thread = ipc_get_arg3(call);
 
 	if (asprintf(&s_taskid, "%" PRIu64, taskid) < 0) {
 		printf("Memory allocation failed.\n");
@@ -100,7 +100,7 @@ static void corecfg_get_enable_srv(ipc_call_t *icall)
 
 static void corecfg_set_enable_srv(ipc_call_t *icall)
 {
-	write_core_files = IPC_GET_ARG1(icall);
+	write_core_files = ipc_get_arg1(icall);
 	async_answer_0(icall, EOK);
 }
 
@@ -112,7 +112,7 @@ static void corecfg_client_conn(ipc_call_t *icall, void *arg)
 	while (true) {
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(&call);
+		sysarg_t method = ipc_get_imethod(&call);
 
 		if (!method) {
 			/* The other side has hung up */

--- a/uspace/srv/test/chardev-test/main.c
+++ b/uspace/srv/test/chardev-test/main.c
@@ -99,7 +99,7 @@ static void chardev_test_connection(ipc_call_t *icall, void *arg)
 	chardev_srvs_t *svc;
 	sysarg_t svcid;
 
-	svcid = IPC_GET_ARG2(icall);
+	svcid = ipc_get_arg2(icall);
 	if (svcid == smallx_svc_id) {
 		svc = &smallx_srvs;
 	} else if (svcid == largex_svc_id) {

--- a/uspace/srv/test/chardev-test/main.c
+++ b/uspace/srv/test/chardev-test/main.c
@@ -99,7 +99,7 @@ static void chardev_test_connection(ipc_call_t *icall, void *arg)
 	chardev_srvs_t *svc;
 	sysarg_t svcid;
 
-	svcid = IPC_GET_ARG2(*icall);
+	svcid = IPC_GET_ARG2(icall);
 	if (svcid == smallx_svc_id) {
 		svc = &smallx_srvs;
 	} else if (svcid == largex_svc_id) {

--- a/uspace/srv/test/ipc-test/main.c
+++ b/uspace/srv/test/ipc-test/main.c
@@ -190,12 +190,12 @@ static void ipc_test_connection(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case IPC_TEST_PING:
 			async_answer_0(&call, EOK);
 			break;

--- a/uspace/srv/test/ipc-test/main.c
+++ b/uspace/srv/test/ipc-test/main.c
@@ -190,12 +190,12 @@ static void ipc_test_connection(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case IPC_TEST_PING:
 			async_answer_0(&call, EOK);
 			break;

--- a/uspace/srv/vfs/vfs.c
+++ b/uspace/srv/vfs/vfs.c
@@ -61,12 +61,12 @@ static void vfs_pager(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case IPC_M_PAGE_IN:
 			vfs_page_in(&call);
 			break;
@@ -79,11 +79,11 @@ static void vfs_pager(ipc_call_t *icall, void *arg)
 
 static void notification_handler(ipc_call_t *call, void *arg)
 {
-	if (IPC_GET_ARG1(*call) == VFS_PASS_HANDLE)
+	if (IPC_GET_ARG1(call) == VFS_PASS_HANDLE)
 		vfs_op_pass_handle(
-		    (task_id_t) MERGE_LOUP32(IPC_GET_ARG4(*call),
-		    IPC_GET_ARG5(*call)), call->task_id,
-		    (int) IPC_GET_ARG2(*call));
+		    (task_id_t) MERGE_LOUP32(IPC_GET_ARG4(call),
+		    IPC_GET_ARG5(call)), call->task_id,
+		    (int) IPC_GET_ARG2(call));
 }
 
 int main(int argc, char **argv)

--- a/uspace/srv/vfs/vfs.c
+++ b/uspace/srv/vfs/vfs.c
@@ -61,12 +61,12 @@ static void vfs_pager(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case IPC_M_PAGE_IN:
 			vfs_page_in(&call);
 			break;
@@ -79,11 +79,11 @@ static void vfs_pager(ipc_call_t *icall, void *arg)
 
 static void notification_handler(ipc_call_t *call, void *arg)
 {
-	if (IPC_GET_ARG1(call) == VFS_PASS_HANDLE)
+	if (ipc_get_arg1(call) == VFS_PASS_HANDLE)
 		vfs_op_pass_handle(
-		    (task_id_t) MERGE_LOUP32(IPC_GET_ARG4(call),
-		    IPC_GET_ARG5(call)), call->task_id,
-		    (int) IPC_GET_ARG2(call));
+		    (task_id_t) MERGE_LOUP32(ipc_get_arg4(call),
+		    ipc_get_arg5(call)), call->task_id,
+		    (int) ipc_get_arg2(call));
 }
 
 int main(int argc, char **argv)

--- a/uspace/srv/vfs/vfs_file.c
+++ b/uspace/srv/vfs/vfs_file.c
@@ -147,7 +147,7 @@ static errno_t vfs_file_close_remote(vfs_file_t *file)
 	errno_t rc;
 	async_wait_for(msg, &rc);
 
-	return IPC_GET_RETVAL(&answer);
+	return ipc_get_retval(&answer);
 }
 
 /** Increment reference count of VFS file structure.

--- a/uspace/srv/vfs/vfs_file.c
+++ b/uspace/srv/vfs/vfs_file.c
@@ -147,7 +147,7 @@ static errno_t vfs_file_close_remote(vfs_file_t *file)
 	errno_t rc;
 	async_wait_for(msg, &rc);
 
-	return IPC_GET_RETVAL(answer);
+	return IPC_GET_RETVAL(&answer);
 }
 
 /** Increment reference count of VFS file structure.

--- a/uspace/srv/vfs/vfs_ipc.c
+++ b/uspace/srv/vfs/vfs_ipc.c
@@ -36,9 +36,9 @@
 
 static void vfs_in_clone(ipc_call_t *req)
 {
-	int oldfd = IPC_GET_ARG1(req);
-	int newfd = IPC_GET_ARG2(req);
-	bool desc = IPC_GET_ARG3(req);
+	int oldfd = ipc_get_arg1(req);
+	int newfd = ipc_get_arg2(req);
+	bool desc = ipc_get_arg3(req);
 
 	int outfd = -1;
 	errno_t rc = vfs_op_clone(oldfd, newfd, desc, &outfd);
@@ -47,7 +47,7 @@ static void vfs_in_clone(ipc_call_t *req)
 
 static void vfs_in_fsprobe(ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
+	service_id_t service_id = (service_id_t) ipc_get_arg1(req);
 	char *fs_name = NULL;
 	vfs_fs_probe_info_t info;
 	errno_t rc;
@@ -112,17 +112,17 @@ out:
 
 static void vfs_in_mount(ipc_call_t *req)
 {
-	int mpfd = IPC_GET_ARG1(req);
+	int mpfd = ipc_get_arg1(req);
 
 	/*
 	 * We expect the library to do the device-name to device-handle
 	 * translation for us, thus the device handle will arrive as ARG1
 	 * in the request.
 	 */
-	service_id_t service_id = (service_id_t) IPC_GET_ARG2(req);
+	service_id_t service_id = (service_id_t) ipc_get_arg2(req);
 
-	unsigned int flags = (unsigned int) IPC_GET_ARG3(req);
-	unsigned int instance = IPC_GET_ARG4(req);
+	unsigned int flags = (unsigned int) ipc_get_arg3(req);
+	unsigned int instance = ipc_get_arg4(req);
 
 	char *opts = NULL;
 	char *fs_name = NULL;
@@ -158,8 +158,8 @@ static void vfs_in_mount(ipc_call_t *req)
 
 static void vfs_in_open(ipc_call_t *req)
 {
-	int fd = IPC_GET_ARG1(req);
-	int mode = IPC_GET_ARG2(req);
+	int fd = ipc_get_arg1(req);
+	int mode = ipc_get_arg2(req);
 
 	errno_t rc = vfs_op_open(fd, mode);
 	async_answer_0(req, rc);
@@ -167,16 +167,16 @@ static void vfs_in_open(ipc_call_t *req)
 
 static void vfs_in_put(ipc_call_t *req)
 {
-	int fd = IPC_GET_ARG1(req);
+	int fd = ipc_get_arg1(req);
 	errno_t rc = vfs_op_put(fd);
 	async_answer_0(req, rc);
 }
 
 static void vfs_in_read(ipc_call_t *req)
 {
-	int fd = IPC_GET_ARG1(req);
-	aoff64_t pos = MERGE_LOUP32(IPC_GET_ARG2(req),
-	    IPC_GET_ARG3(req));
+	int fd = ipc_get_arg1(req);
+	aoff64_t pos = MERGE_LOUP32(ipc_get_arg2(req),
+	    ipc_get_arg3(req));
 
 	size_t bytes = 0;
 	errno_t rc = vfs_op_read(fd, pos, &bytes);
@@ -191,7 +191,7 @@ static void vfs_in_rename(ipc_call_t *req)
 	char *new = NULL;
 	errno_t rc;
 
-	basefd = IPC_GET_ARG1(req);
+	basefd = ipc_get_arg1(req);
 
 	/* Retrieve the old path. */
 	rc = async_data_write_accept((void **) &old, true, 0, 0, 0, NULL);
@@ -229,22 +229,22 @@ out:
 
 static void vfs_in_resize(ipc_call_t *req)
 {
-	int fd = IPC_GET_ARG1(req);
-	int64_t size = MERGE_LOUP32(IPC_GET_ARG2(req), IPC_GET_ARG3(req));
+	int fd = ipc_get_arg1(req);
+	int64_t size = MERGE_LOUP32(ipc_get_arg2(req), ipc_get_arg3(req));
 	errno_t rc = vfs_op_resize(fd, size);
 	async_answer_0(req, rc);
 }
 
 static void vfs_in_stat(ipc_call_t *req)
 {
-	int fd = IPC_GET_ARG1(req);
+	int fd = ipc_get_arg1(req);
 	errno_t rc = vfs_op_stat(fd);
 	async_answer_0(req, rc);
 }
 
 static void vfs_in_statfs(ipc_call_t *req)
 {
-	int fd = (int) IPC_GET_ARG1(req);
+	int fd = (int) ipc_get_arg1(req);
 
 	errno_t rc = vfs_op_statfs(fd);
 	async_answer_0(req, rc);
@@ -252,15 +252,15 @@ static void vfs_in_statfs(ipc_call_t *req)
 
 static void vfs_in_sync(ipc_call_t *req)
 {
-	int fd = IPC_GET_ARG1(req);
+	int fd = ipc_get_arg1(req);
 	errno_t rc = vfs_op_sync(fd);
 	async_answer_0(req, rc);
 }
 
 static void vfs_in_unlink(ipc_call_t *req)
 {
-	int parentfd = IPC_GET_ARG1(req);
-	int expectfd = IPC_GET_ARG2(req);
+	int parentfd = ipc_get_arg1(req);
+	int expectfd = ipc_get_arg2(req);
 
 	char *path;
 	errno_t rc = async_data_write_accept((void **) &path, true, 0, 0, 0, NULL);
@@ -272,14 +272,14 @@ static void vfs_in_unlink(ipc_call_t *req)
 
 static void vfs_in_unmount(ipc_call_t *req)
 {
-	int mpfd = IPC_GET_ARG1(req);
+	int mpfd = ipc_get_arg1(req);
 	errno_t rc = vfs_op_unmount(mpfd);
 	async_answer_0(req, rc);
 }
 
 static void vfs_in_wait_handle(ipc_call_t *req)
 {
-	bool high_fd = IPC_GET_ARG1(req);
+	bool high_fd = ipc_get_arg1(req);
 	int fd = -1;
 	errno_t rc = vfs_op_wait_handle(high_fd, &fd);
 	async_answer_1(req, rc, fd);
@@ -291,8 +291,8 @@ static void vfs_in_walk(ipc_call_t *req)
 	 * Parent is our relative root for file lookup.
 	 * For defined flags, see <ipc/vfs.h>.
 	 */
-	int parentfd = IPC_GET_ARG1(req);
-	int flags = IPC_GET_ARG2(req);
+	int parentfd = ipc_get_arg1(req);
+	int flags = ipc_get_arg2(req);
 
 	int fd = 0;
 	char *path;
@@ -306,9 +306,9 @@ static void vfs_in_walk(ipc_call_t *req)
 
 static void vfs_in_write(ipc_call_t *req)
 {
-	int fd = IPC_GET_ARG1(req);
-	aoff64_t pos = MERGE_LOUP32(IPC_GET_ARG2(req),
-	    IPC_GET_ARG3(req));
+	int fd = ipc_get_arg1(req);
+	aoff64_t pos = MERGE_LOUP32(ipc_get_arg2(req),
+	    ipc_get_arg3(req));
 
 	size_t bytes = 0;
 	errno_t rc = vfs_op_write(fd, pos, &bytes);
@@ -329,12 +329,12 @@ void vfs_connection(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(&call)) {
+		if (!ipc_get_imethod(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(&call)) {
+		switch (ipc_get_imethod(&call)) {
 		case VFS_IN_CLONE:
 			vfs_in_clone(&call);
 			break;

--- a/uspace/srv/vfs/vfs_ipc.c
+++ b/uspace/srv/vfs/vfs_ipc.c
@@ -36,9 +36,9 @@
 
 static void vfs_in_clone(ipc_call_t *req)
 {
-	int oldfd = IPC_GET_ARG1(*req);
-	int newfd = IPC_GET_ARG2(*req);
-	bool desc = IPC_GET_ARG3(*req);
+	int oldfd = IPC_GET_ARG1(req);
+	int newfd = IPC_GET_ARG2(req);
+	bool desc = IPC_GET_ARG3(req);
 
 	int outfd = -1;
 	errno_t rc = vfs_op_clone(oldfd, newfd, desc, &outfd);
@@ -47,7 +47,7 @@ static void vfs_in_clone(ipc_call_t *req)
 
 static void vfs_in_fsprobe(ipc_call_t *req)
 {
-	service_id_t service_id = (service_id_t) IPC_GET_ARG1(*req);
+	service_id_t service_id = (service_id_t) IPC_GET_ARG1(req);
 	char *fs_name = NULL;
 	vfs_fs_probe_info_t info;
 	errno_t rc;
@@ -112,17 +112,17 @@ out:
 
 static void vfs_in_mount(ipc_call_t *req)
 {
-	int mpfd = IPC_GET_ARG1(*req);
+	int mpfd = IPC_GET_ARG1(req);
 
 	/*
 	 * We expect the library to do the device-name to device-handle
 	 * translation for us, thus the device handle will arrive as ARG1
 	 * in the request.
 	 */
-	service_id_t service_id = (service_id_t) IPC_GET_ARG2(*req);
+	service_id_t service_id = (service_id_t) IPC_GET_ARG2(req);
 
-	unsigned int flags = (unsigned int) IPC_GET_ARG3(*req);
-	unsigned int instance = IPC_GET_ARG4(*req);
+	unsigned int flags = (unsigned int) IPC_GET_ARG3(req);
+	unsigned int instance = IPC_GET_ARG4(req);
 
 	char *opts = NULL;
 	char *fs_name = NULL;
@@ -158,8 +158,8 @@ static void vfs_in_mount(ipc_call_t *req)
 
 static void vfs_in_open(ipc_call_t *req)
 {
-	int fd = IPC_GET_ARG1(*req);
-	int mode = IPC_GET_ARG2(*req);
+	int fd = IPC_GET_ARG1(req);
+	int mode = IPC_GET_ARG2(req);
 
 	errno_t rc = vfs_op_open(fd, mode);
 	async_answer_0(req, rc);
@@ -167,16 +167,16 @@ static void vfs_in_open(ipc_call_t *req)
 
 static void vfs_in_put(ipc_call_t *req)
 {
-	int fd = IPC_GET_ARG1(*req);
+	int fd = IPC_GET_ARG1(req);
 	errno_t rc = vfs_op_put(fd);
 	async_answer_0(req, rc);
 }
 
 static void vfs_in_read(ipc_call_t *req)
 {
-	int fd = IPC_GET_ARG1(*req);
-	aoff64_t pos = MERGE_LOUP32(IPC_GET_ARG2(*req),
-	    IPC_GET_ARG3(*req));
+	int fd = IPC_GET_ARG1(req);
+	aoff64_t pos = MERGE_LOUP32(IPC_GET_ARG2(req),
+	    IPC_GET_ARG3(req));
 
 	size_t bytes = 0;
 	errno_t rc = vfs_op_read(fd, pos, &bytes);
@@ -191,7 +191,7 @@ static void vfs_in_rename(ipc_call_t *req)
 	char *new = NULL;
 	errno_t rc;
 
-	basefd = IPC_GET_ARG1(*req);
+	basefd = IPC_GET_ARG1(req);
 
 	/* Retrieve the old path. */
 	rc = async_data_write_accept((void **) &old, true, 0, 0, 0, NULL);
@@ -229,22 +229,22 @@ out:
 
 static void vfs_in_resize(ipc_call_t *req)
 {
-	int fd = IPC_GET_ARG1(*req);
-	int64_t size = MERGE_LOUP32(IPC_GET_ARG2(*req), IPC_GET_ARG3(*req));
+	int fd = IPC_GET_ARG1(req);
+	int64_t size = MERGE_LOUP32(IPC_GET_ARG2(req), IPC_GET_ARG3(req));
 	errno_t rc = vfs_op_resize(fd, size);
 	async_answer_0(req, rc);
 }
 
 static void vfs_in_stat(ipc_call_t *req)
 {
-	int fd = IPC_GET_ARG1(*req);
+	int fd = IPC_GET_ARG1(req);
 	errno_t rc = vfs_op_stat(fd);
 	async_answer_0(req, rc);
 }
 
 static void vfs_in_statfs(ipc_call_t *req)
 {
-	int fd = (int) IPC_GET_ARG1(*req);
+	int fd = (int) IPC_GET_ARG1(req);
 
 	errno_t rc = vfs_op_statfs(fd);
 	async_answer_0(req, rc);
@@ -252,15 +252,15 @@ static void vfs_in_statfs(ipc_call_t *req)
 
 static void vfs_in_sync(ipc_call_t *req)
 {
-	int fd = IPC_GET_ARG1(*req);
+	int fd = IPC_GET_ARG1(req);
 	errno_t rc = vfs_op_sync(fd);
 	async_answer_0(req, rc);
 }
 
 static void vfs_in_unlink(ipc_call_t *req)
 {
-	int parentfd = IPC_GET_ARG1(*req);
-	int expectfd = IPC_GET_ARG2(*req);
+	int parentfd = IPC_GET_ARG1(req);
+	int expectfd = IPC_GET_ARG2(req);
 
 	char *path;
 	errno_t rc = async_data_write_accept((void **) &path, true, 0, 0, 0, NULL);
@@ -272,14 +272,14 @@ static void vfs_in_unlink(ipc_call_t *req)
 
 static void vfs_in_unmount(ipc_call_t *req)
 {
-	int mpfd = IPC_GET_ARG1(*req);
+	int mpfd = IPC_GET_ARG1(req);
 	errno_t rc = vfs_op_unmount(mpfd);
 	async_answer_0(req, rc);
 }
 
 static void vfs_in_wait_handle(ipc_call_t *req)
 {
-	bool high_fd = IPC_GET_ARG1(*req);
+	bool high_fd = IPC_GET_ARG1(req);
 	int fd = -1;
 	errno_t rc = vfs_op_wait_handle(high_fd, &fd);
 	async_answer_1(req, rc, fd);
@@ -291,8 +291,8 @@ static void vfs_in_walk(ipc_call_t *req)
 	 * Parent is our relative root for file lookup.
 	 * For defined flags, see <ipc/vfs.h>.
 	 */
-	int parentfd = IPC_GET_ARG1(*req);
-	int flags = IPC_GET_ARG2(*req);
+	int parentfd = IPC_GET_ARG1(req);
+	int flags = IPC_GET_ARG2(req);
 
 	int fd = 0;
 	char *path;
@@ -306,9 +306,9 @@ static void vfs_in_walk(ipc_call_t *req)
 
 static void vfs_in_write(ipc_call_t *req)
 {
-	int fd = IPC_GET_ARG1(*req);
-	aoff64_t pos = MERGE_LOUP32(IPC_GET_ARG2(*req),
-	    IPC_GET_ARG3(*req));
+	int fd = IPC_GET_ARG1(req);
+	aoff64_t pos = MERGE_LOUP32(IPC_GET_ARG2(req),
+	    IPC_GET_ARG3(req));
 
 	size_t bytes = 0;
 	errno_t rc = vfs_op_write(fd, pos, &bytes);
@@ -329,12 +329,12 @@ void vfs_connection(ipc_call_t *icall, void *arg)
 		ipc_call_t call;
 		async_get_call(&call);
 
-		if (!IPC_GET_IMETHOD(call)) {
+		if (!IPC_GET_IMETHOD(&call)) {
 			async_answer_0(&call, EOK);
 			break;
 		}
 
-		switch (IPC_GET_IMETHOD(call)) {
+		switch (IPC_GET_IMETHOD(&call)) {
 		case VFS_IN_CLONE:
 			vfs_in_clone(&call);
 			break;

--- a/uspace/srv/vfs/vfs_lookup.c
+++ b/uspace/srv/vfs/vfs_lookup.c
@@ -225,14 +225,14 @@ static errno_t out_lookup(vfs_triplet_t *base, size_t *pfirst, size_t *plen,
 		return rc;
 
 	unsigned last = *pfirst + *plen;
-	*pfirst = IPC_GET_ARG3(answer) & 0xffff;
+	*pfirst = IPC_GET_ARG3(&answer) & 0xffff;
 	*plen = last - *pfirst;
 
-	result->triplet.fs_handle = (fs_handle_t) IPC_GET_ARG1(answer);
+	result->triplet.fs_handle = (fs_handle_t) IPC_GET_ARG1(&answer);
 	result->triplet.service_id = base->service_id;
-	result->triplet.index = (fs_index_t) IPC_GET_ARG2(answer);
-	result->size = MERGE_LOUP32(IPC_GET_ARG4(answer), IPC_GET_ARG5(answer));
-	result->type = (IPC_GET_ARG3(answer) >> 16) ?
+	result->triplet.index = (fs_index_t) IPC_GET_ARG2(&answer);
+	result->size = MERGE_LOUP32(IPC_GET_ARG4(&answer), IPC_GET_ARG5(&answer));
+	result->type = (IPC_GET_ARG3(&answer) >> 16) ?
 	    VFS_NODE_DIRECTORY : VFS_NODE_FILE;
 	return EOK;
 }

--- a/uspace/srv/vfs/vfs_lookup.c
+++ b/uspace/srv/vfs/vfs_lookup.c
@@ -225,14 +225,14 @@ static errno_t out_lookup(vfs_triplet_t *base, size_t *pfirst, size_t *plen,
 		return rc;
 
 	unsigned last = *pfirst + *plen;
-	*pfirst = IPC_GET_ARG3(&answer) & 0xffff;
+	*pfirst = ipc_get_arg3(&answer) & 0xffff;
 	*plen = last - *pfirst;
 
-	result->triplet.fs_handle = (fs_handle_t) IPC_GET_ARG1(&answer);
+	result->triplet.fs_handle = (fs_handle_t) ipc_get_arg1(&answer);
 	result->triplet.service_id = base->service_id;
-	result->triplet.index = (fs_index_t) IPC_GET_ARG2(&answer);
-	result->size = MERGE_LOUP32(IPC_GET_ARG4(&answer), IPC_GET_ARG5(&answer));
-	result->type = (IPC_GET_ARG3(&answer) >> 16) ?
+	result->triplet.index = (fs_index_t) ipc_get_arg2(&answer);
+	result->size = MERGE_LOUP32(ipc_get_arg4(&answer), ipc_get_arg5(&answer));
+	result->type = (ipc_get_arg3(&answer) >> 16) ?
 	    VFS_NODE_DIRECTORY : VFS_NODE_FILE;
 	return EOK;
 }

--- a/uspace/srv/vfs/vfs_ops.c
+++ b/uspace/srv/vfs/vfs_ops.c
@@ -167,9 +167,9 @@ static errno_t vfs_connect_internal(service_id_t service_id, unsigned flags,
 	vfs_lookup_res_t res;
 	res.triplet.fs_handle = fs_handle;
 	res.triplet.service_id = service_id;
-	res.triplet.index = (fs_index_t) IPC_GET_ARG1(answer);
-	res.size = (int64_t) MERGE_LOUP32(IPC_GET_ARG2(answer),
-	    IPC_GET_ARG3(answer));
+	res.triplet.index = (fs_index_t) IPC_GET_ARG1(&answer);
+	res.size = (int64_t) MERGE_LOUP32(IPC_GET_ARG2(&answer),
+	    IPC_GET_ARG3(&answer));
 	res.type = VFS_NODE_DIRECTORY;
 
 	/* Add reference to the mounted root. */
@@ -373,7 +373,7 @@ static errno_t rdwr_ipc_client(async_exch_t *exch, vfs_file_t *file, aoff64_t po
 		    LOWER32(pos), UPPER32(pos), answer);
 	}
 
-	*bytes = IPC_GET_ARG1(*answer);
+	*bytes = IPC_GET_ARG1(answer);
 	return rc;
 }
 
@@ -400,7 +400,7 @@ static errno_t rdwr_ipc_internal(async_exch_t *exch, vfs_file_t *file, aoff64_t 
 	errno_t rc;
 	async_wait_for(msg, &rc);
 
-	chunk->size = IPC_GET_ARG1(*answer);
+	chunk->size = IPC_GET_ARG1(answer);
 
 	return (errno_t) rc;
 }
@@ -487,8 +487,8 @@ static errno_t vfs_rdwr(int fd, aoff64_t pos, bool read, rdwr_ipc_cb_t ipc_cb,
 	} else {
 		/* Update the cached version of node's size. */
 		if (rc == EOK) {
-			file->node->size = MERGE_LOUP32(IPC_GET_ARG2(answer),
-			    IPC_GET_ARG3(answer));
+			file->node->size = MERGE_LOUP32(IPC_GET_ARG2(&answer),
+			    IPC_GET_ARG3(&answer));
 		}
 		fibril_rwlock_write_unlock(&file->node->contents_rwlock);
 	}

--- a/uspace/srv/vfs/vfs_ops.c
+++ b/uspace/srv/vfs/vfs_ops.c
@@ -167,9 +167,9 @@ static errno_t vfs_connect_internal(service_id_t service_id, unsigned flags,
 	vfs_lookup_res_t res;
 	res.triplet.fs_handle = fs_handle;
 	res.triplet.service_id = service_id;
-	res.triplet.index = (fs_index_t) IPC_GET_ARG1(&answer);
-	res.size = (int64_t) MERGE_LOUP32(IPC_GET_ARG2(&answer),
-	    IPC_GET_ARG3(&answer));
+	res.triplet.index = (fs_index_t) ipc_get_arg1(&answer);
+	res.size = (int64_t) MERGE_LOUP32(ipc_get_arg2(&answer),
+	    ipc_get_arg3(&answer));
 	res.type = VFS_NODE_DIRECTORY;
 
 	/* Add reference to the mounted root. */
@@ -373,7 +373,7 @@ static errno_t rdwr_ipc_client(async_exch_t *exch, vfs_file_t *file, aoff64_t po
 		    LOWER32(pos), UPPER32(pos), answer);
 	}
 
-	*bytes = IPC_GET_ARG1(answer);
+	*bytes = ipc_get_arg1(answer);
 	return rc;
 }
 
@@ -400,7 +400,7 @@ static errno_t rdwr_ipc_internal(async_exch_t *exch, vfs_file_t *file, aoff64_t 
 	errno_t rc;
 	async_wait_for(msg, &rc);
 
-	chunk->size = IPC_GET_ARG1(answer);
+	chunk->size = ipc_get_arg1(answer);
 
 	return (errno_t) rc;
 }
@@ -487,8 +487,8 @@ static errno_t vfs_rdwr(int fd, aoff64_t pos, bool read, rdwr_ipc_cb_t ipc_cb,
 	} else {
 		/* Update the cached version of node's size. */
 		if (rc == EOK) {
-			file->node->size = MERGE_LOUP32(IPC_GET_ARG2(&answer),
-			    IPC_GET_ARG3(&answer));
+			file->node->size = MERGE_LOUP32(ipc_get_arg2(&answer),
+			    ipc_get_arg3(&answer));
 		}
 		fibril_rwlock_write_unlock(&file->node->contents_rwlock);
 	}

--- a/uspace/srv/vfs/vfs_pager.c
+++ b/uspace/srv/vfs/vfs_pager.c
@@ -43,9 +43,9 @@
 
 void vfs_page_in(ipc_call_t *req)
 {
-	aoff64_t offset = IPC_GET_ARG1(req);
-	size_t page_size = IPC_GET_ARG2(req);
-	int fd = IPC_GET_ARG3(req);
+	aoff64_t offset = ipc_get_arg1(req);
+	size_t page_size = ipc_get_arg2(req);
+	int fd = ipc_get_arg3(req);
 	void *page;
 	errno_t rc;
 

--- a/uspace/srv/vfs/vfs_pager.c
+++ b/uspace/srv/vfs/vfs_pager.c
@@ -43,9 +43,9 @@
 
 void vfs_page_in(ipc_call_t *req)
 {
-	aoff64_t offset = IPC_GET_ARG1(*req);
-	size_t page_size = IPC_GET_ARG2(*req);
-	int fd = IPC_GET_ARG3(*req);
+	aoff64_t offset = IPC_GET_ARG1(req);
+	size_t page_size = IPC_GET_ARG2(req);
+	int fd = IPC_GET_ARG3(req);
 	void *page;
 	errno_t rc;
 

--- a/uspace/srv/volsrv/volsrv.c
+++ b/uspace/srv/volsrv/volsrv.c
@@ -137,7 +137,7 @@ static void vol_part_add_srv(vol_parts_t *parts, ipc_call_t *icall)
 	service_id_t sid;
 	errno_t rc;
 
-	sid = IPC_GET_ARG1(*icall);
+	sid = IPC_GET_ARG1(icall);
 
 	rc = vol_part_add_part(parts, sid);
 	if (rc != EOK) {
@@ -155,7 +155,7 @@ static void vol_part_info_srv(vol_parts_t *parts, ipc_call_t *icall)
 	vol_part_info_t pinfo;
 	errno_t rc;
 
-	sid = IPC_GET_ARG1(*icall);
+	sid = IPC_GET_ARG1(icall);
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vol_part_info_srv(%zu)",
 	    sid);
 	rc = vol_part_find_by_id_ref(parts, sid, &part);
@@ -203,7 +203,7 @@ static void vol_part_eject_srv(vol_parts_t *parts, ipc_call_t *icall)
 	vol_part_t *part;
 	errno_t rc;
 
-	sid = IPC_GET_ARG1(*icall);
+	sid = IPC_GET_ARG1(icall);
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vol_part_eject_srv(%zu)", sid);
 
 	rc = vol_part_find_by_id_ref(parts, sid, &part);
@@ -229,7 +229,7 @@ static void vol_part_insert_srv(vol_parts_t *parts, ipc_call_t *icall)
 	vol_part_t *part;
 	errno_t rc;
 
-	sid = IPC_GET_ARG1(*icall);
+	sid = IPC_GET_ARG1(icall);
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vol_part_insert_srv(%zu)", sid);
 
 	rc = vol_part_find_by_id_ref(parts, sid, &part);
@@ -293,7 +293,7 @@ static void vol_part_empty_srv(vol_parts_t *parts, ipc_call_t *icall)
 	vol_part_t *part;
 	errno_t rc;
 
-	sid = IPC_GET_ARG1(*icall);
+	sid = IPC_GET_ARG1(icall);
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vol_part_empty_srv(%zu)", sid);
 
 	rc = vol_part_find_by_id_ref(parts, sid, &part);
@@ -319,7 +319,7 @@ static void vol_part_get_lsupp_srv(vol_parts_t *parts, ipc_call_t *icall)
 	vol_label_supp_t vlsupp;
 	errno_t rc;
 
-	fstype = IPC_GET_ARG1(*icall);
+	fstype = IPC_GET_ARG1(icall);
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vol_part_get_lsupp_srv(%u)",
 	    fstype);
 
@@ -361,8 +361,8 @@ static void vol_part_mkfs_srv(vol_parts_t *parts, ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_NOTE, "vol_part_mkfs_srv()");
 
-	sid = IPC_GET_ARG1(*icall);
-	fstype = IPC_GET_ARG2(*icall);
+	sid = IPC_GET_ARG1(icall);
+	fstype = IPC_GET_ARG2(icall);
 
 	rc = async_data_write_accept((void **)&label, true, 0, VOL_LABEL_MAXLEN,
 	    0, NULL);
@@ -423,7 +423,7 @@ static void vol_part_set_mountp_srv(vol_parts_t *parts,
 
 	log_msg(LOG_DEFAULT, LVL_NOTE, "vol_part_set_mountp_srv()");
 
-	sid = IPC_GET_ARG1(*icall);
+	sid = IPC_GET_ARG1(icall);
 
 	rc = async_data_write_accept((void **)&mountp, true, 0,
 	    VOL_MOUNTP_MAXLEN, 0, NULL);
@@ -498,7 +498,7 @@ static void vol_info_srv(vol_parts_t *parts, ipc_call_t *icall)
 	vol_info_t vinfo;
 	errno_t rc;
 
-	vid.id = IPC_GET_ARG1(*icall);
+	vid.id = IPC_GET_ARG1(icall);
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vol_info_srv(%zu)", vid.id);
 
 	rc = vol_volume_find_by_id_ref(parts->volumes, vid, &volume);
@@ -555,7 +555,7 @@ static void vol_client_conn(ipc_call_t *icall, void *arg)
 	while (true) {
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(call);
+		sysarg_t method = IPC_GET_IMETHOD(&call);
 
 		if (!method) {
 			/* The other side has hung up */

--- a/uspace/srv/volsrv/volsrv.c
+++ b/uspace/srv/volsrv/volsrv.c
@@ -137,7 +137,7 @@ static void vol_part_add_srv(vol_parts_t *parts, ipc_call_t *icall)
 	service_id_t sid;
 	errno_t rc;
 
-	sid = IPC_GET_ARG1(icall);
+	sid = ipc_get_arg1(icall);
 
 	rc = vol_part_add_part(parts, sid);
 	if (rc != EOK) {
@@ -155,7 +155,7 @@ static void vol_part_info_srv(vol_parts_t *parts, ipc_call_t *icall)
 	vol_part_info_t pinfo;
 	errno_t rc;
 
-	sid = IPC_GET_ARG1(icall);
+	sid = ipc_get_arg1(icall);
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vol_part_info_srv(%zu)",
 	    sid);
 	rc = vol_part_find_by_id_ref(parts, sid, &part);
@@ -203,7 +203,7 @@ static void vol_part_eject_srv(vol_parts_t *parts, ipc_call_t *icall)
 	vol_part_t *part;
 	errno_t rc;
 
-	sid = IPC_GET_ARG1(icall);
+	sid = ipc_get_arg1(icall);
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vol_part_eject_srv(%zu)", sid);
 
 	rc = vol_part_find_by_id_ref(parts, sid, &part);
@@ -229,7 +229,7 @@ static void vol_part_insert_srv(vol_parts_t *parts, ipc_call_t *icall)
 	vol_part_t *part;
 	errno_t rc;
 
-	sid = IPC_GET_ARG1(icall);
+	sid = ipc_get_arg1(icall);
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vol_part_insert_srv(%zu)", sid);
 
 	rc = vol_part_find_by_id_ref(parts, sid, &part);
@@ -293,7 +293,7 @@ static void vol_part_empty_srv(vol_parts_t *parts, ipc_call_t *icall)
 	vol_part_t *part;
 	errno_t rc;
 
-	sid = IPC_GET_ARG1(icall);
+	sid = ipc_get_arg1(icall);
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vol_part_empty_srv(%zu)", sid);
 
 	rc = vol_part_find_by_id_ref(parts, sid, &part);
@@ -319,7 +319,7 @@ static void vol_part_get_lsupp_srv(vol_parts_t *parts, ipc_call_t *icall)
 	vol_label_supp_t vlsupp;
 	errno_t rc;
 
-	fstype = IPC_GET_ARG1(icall);
+	fstype = ipc_get_arg1(icall);
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vol_part_get_lsupp_srv(%u)",
 	    fstype);
 
@@ -361,8 +361,8 @@ static void vol_part_mkfs_srv(vol_parts_t *parts, ipc_call_t *icall)
 
 	log_msg(LOG_DEFAULT, LVL_NOTE, "vol_part_mkfs_srv()");
 
-	sid = IPC_GET_ARG1(icall);
-	fstype = IPC_GET_ARG2(icall);
+	sid = ipc_get_arg1(icall);
+	fstype = ipc_get_arg2(icall);
 
 	rc = async_data_write_accept((void **)&label, true, 0, VOL_LABEL_MAXLEN,
 	    0, NULL);
@@ -423,7 +423,7 @@ static void vol_part_set_mountp_srv(vol_parts_t *parts,
 
 	log_msg(LOG_DEFAULT, LVL_NOTE, "vol_part_set_mountp_srv()");
 
-	sid = IPC_GET_ARG1(icall);
+	sid = ipc_get_arg1(icall);
 
 	rc = async_data_write_accept((void **)&mountp, true, 0,
 	    VOL_MOUNTP_MAXLEN, 0, NULL);
@@ -498,7 +498,7 @@ static void vol_info_srv(vol_parts_t *parts, ipc_call_t *icall)
 	vol_info_t vinfo;
 	errno_t rc;
 
-	vid.id = IPC_GET_ARG1(icall);
+	vid.id = ipc_get_arg1(icall);
 	log_msg(LOG_DEFAULT, LVL_DEBUG, "vol_info_srv(%zu)", vid.id);
 
 	rc = vol_volume_find_by_id_ref(parts->volumes, vid, &volume);
@@ -555,7 +555,7 @@ static void vol_client_conn(ipc_call_t *icall, void *arg)
 	while (true) {
 		ipc_call_t call;
 		async_get_call(&call);
-		sysarg_t method = IPC_GET_IMETHOD(&call);
+		sysarg_t method = ipc_get_imethod(&call);
 
 		if (!method) {
 			/* The other side has hung up */


### PR DESCRIPTION
This is part of a more extensive effort to reduce use of preprocessor defines, in order for our headers to play nicer with code analysis tools and with C++.

Note that it's somewhat easier to review the changes commit by commit, than it is to review the whole pull request in one diff.