### PR TITLE
Indicate and enforce constness of hash table key in certain functions

### DIFF
--- a/kernel/genarch/src/mm/page_ht.c
+++ b/kernel/genarch/src/mm/page_ht.c
@@ -53,8 +53,8 @@
 #include <align.h>
 
 static size_t ht_hash(const ht_link_t *);
-static size_t ht_key_hash(void *);
-static bool ht_key_equal(void *, const ht_link_t *);
+static size_t ht_key_hash(const void *);
+static bool ht_key_equal(const void *, const ht_link_t *);
 static void ht_remove_callback(ht_link_t *);
 
 static void ht_mapping_insert(as_t *, uintptr_t, uintptr_t, unsigned int);
@@ -108,9 +108,9 @@ size_t ht_hash(const ht_link_t *item)
 }
 
 /** Return the hash of the key. */
-size_t ht_key_hash(void *arg)
+size_t ht_key_hash(const void *arg)
 {
-	uintptr_t *key = (uintptr_t *) arg;
+	const uintptr_t *key = arg;
 	size_t hash = 0;
 	hash = hash_combine(hash, key[KEY_AS]);
 	hash = hash_combine(hash, key[KEY_PAGE] >> PAGE_WIDTH);
@@ -118,9 +118,9 @@ size_t ht_key_hash(void *arg)
 }
 
 /** Return true if the key is equal to the item's lookup key. */
-bool ht_key_equal(void *arg, const ht_link_t *item)
+bool ht_key_equal(const void *arg, const ht_link_t *item)
 {
-	uintptr_t *key = (uintptr_t *) arg;
+	const uintptr_t *key = arg;
 	pte_t *pte = hash_table_get_inst(item, pte_t, link);
 	return (key[KEY_AS] == (uintptr_t) pte->as) &&
 	    (key[KEY_PAGE] == pte->page);

--- a/kernel/generic/include/adt/hash_table.h
+++ b/kernel/generic/include/adt/hash_table.h
@@ -52,13 +52,13 @@ typedef struct {
 	size_t (*hash)(const ht_link_t *item);
 
 	/** Returns the hash of the key. */
-	size_t (*key_hash)(void *key);
+	size_t (*key_hash)(const void *key);
 
 	/** True if the items are equal (have the same lookup keys). */
 	bool (*equal)(const ht_link_t *item1, const ht_link_t *item2);
 
 	/** Returns true if the key is equal to the item's lookup key. */
-	bool (*key_equal)(void *key, const ht_link_t *item);
+	bool (*key_equal)(const void *key, const ht_link_t *item);
 
 	/** Hash table item removal callback.
 	 *
@@ -93,10 +93,10 @@ extern size_t hash_table_size(hash_table_t *);
 extern void hash_table_clear(hash_table_t *);
 extern void hash_table_insert(hash_table_t *, ht_link_t *);
 extern bool hash_table_insert_unique(hash_table_t *, ht_link_t *);
-extern ht_link_t *hash_table_find(const hash_table_t *, void *);
+extern ht_link_t *hash_table_find(const hash_table_t *, const void *);
 extern ht_link_t *hash_table_find_next(const hash_table_t *, ht_link_t *,
     ht_link_t *);
-extern size_t hash_table_remove(hash_table_t *, void *);
+extern size_t hash_table_remove(hash_table_t *, const void *);
 extern void hash_table_remove_item(hash_table_t *, ht_link_t *);
 extern void hash_table_apply(hash_table_t *, bool (*)(ht_link_t *, void *),
     void *);

--- a/kernel/generic/src/adt/hash_table.c
+++ b/kernel/generic/src/adt/hash_table.c
@@ -50,8 +50,8 @@
 
 #include <adt/hash_table.h>
 #include <adt/list.h>
-#include <stdlib.h>
 #include <assert.h>
+#include <stdlib.h>
 #include <str.h>
 
 /* Optimal initial bucket count. See comment above. */
@@ -244,7 +244,7 @@ bool hash_table_insert_unique(hash_table_t *h, ht_link_t *item)
  * @return Matching item on success, NULL if there is no such item.
  *
  */
-ht_link_t *hash_table_find(const hash_table_t *h, void *key)
+ht_link_t *hash_table_find(const hash_table_t *h, const void *key)
 {
 	assert(h && h->bucket);
 
@@ -305,7 +305,7 @@ hash_table_find_next(const hash_table_t *h, ht_link_t *first, ht_link_t *item)
  *
  * @return Returns the number of removed items.
  */
-size_t hash_table_remove(hash_table_t *h, void *key)
+size_t hash_table_remove(hash_table_t *h, const void *key)
 {
 	assert(h && h->bucket);
 	assert(!h->apply_ongoing);

--- a/kernel/generic/src/cap/cap.c
+++ b/kernel/generic/src/cap/cap.c
@@ -100,15 +100,15 @@ static size_t caps_hash(const ht_link_t *item)
 	return hash_mix(cap_handle_raw(cap->handle));
 }
 
-static size_t caps_key_hash(void *key)
+static size_t caps_key_hash(const void *key)
 {
-	cap_handle_t *handle = (cap_handle_t *) key;
+	const cap_handle_t *handle = key;
 	return hash_mix(cap_handle_raw(*handle));
 }
 
-static bool caps_key_equal(void *key, const ht_link_t *item)
+static bool caps_key_equal(const void *key, const ht_link_t *item)
 {
-	cap_handle_t *handle = (cap_handle_t *) key;
+	const cap_handle_t *handle = key;
 	cap_t *cap = hash_table_get_inst(item, cap_t, caps_link);
 	return *handle == cap->handle;
 }

--- a/kernel/generic/src/ddi/irq.c
+++ b/kernel/generic/src/ddi/irq.c
@@ -72,9 +72,9 @@ IRQ_SPINLOCK_INITIALIZE(irq_uspace_hash_table_lock);
 hash_table_t irq_uspace_hash_table;
 
 static size_t irq_ht_hash(const ht_link_t *);
-static size_t irq_ht_key_hash(void *);
+static size_t irq_ht_key_hash(const void *);
 static bool irq_ht_equal(const ht_link_t *, const ht_link_t *);
-static bool irq_ht_key_equal(void *, const ht_link_t *);
+static bool irq_ht_key_equal(const void *, const ht_link_t *);
 
 static hash_table_ops_t irq_ht_ops = {
 	.hash = irq_ht_hash,
@@ -207,9 +207,9 @@ size_t irq_ht_hash(const ht_link_t *item)
 }
 
 /** Return the hash of the key. */
-size_t irq_ht_key_hash(void *key)
+size_t irq_ht_key_hash(const void *key)
 {
-	inr_t *inr = (inr_t *) key;
+	const inr_t *inr = key;
 	return hash_mix(*inr);
 }
 
@@ -222,9 +222,9 @@ bool irq_ht_equal(const ht_link_t *item1, const ht_link_t *item2)
 }
 
 /** Return true if the key is equal to the item's lookup key. */
-bool irq_ht_key_equal(void *key, const ht_link_t *item)
+bool irq_ht_key_equal(const void *key, const ht_link_t *item)
 {
-	inr_t *inr = (inr_t *) key;
+	const inr_t *inr = key;
 	irq_t *irq = hash_table_get_inst(item, irq_t, link);
 	return irq->inr == *inr;
 }

--- a/kernel/generic/src/lib/ra.c
+++ b/kernel/generic/src/lib/ra.c
@@ -66,16 +66,16 @@ static size_t used_hash(const ht_link_t *item)
 }
 
 /** Return the hash of the key */
-static size_t used_key_hash(void *key)
+static size_t used_key_hash(const void *key)
 {
-	uintptr_t *base = (uintptr_t *) key;
+	const uintptr_t *base = key;
 	return hash_mix(*base);
 }
 
 /** Return true if the key is equal to the item's lookup key */
-static bool used_key_equal(void *key, const ht_link_t *item)
+static bool used_key_equal(const void *key, const ht_link_t *item)
 {
-	uintptr_t *base = (uintptr_t *) key;
+	const uintptr_t *base = key;
 	ra_segment_t *seg = hash_table_get_inst(item, ra_segment_t, uh_link);
 	return seg->base == *base;
 }

--- a/uspace/app/hbench/env.c
+++ b/uspace/app/hbench/env.c
@@ -51,16 +51,16 @@ static size_t param_hash(const ht_link_t *item)
 	return str_size(param->key);
 }
 
-static size_t param_key_hash(void *key)
+static size_t param_key_hash(const void *key)
 {
-	char *key_str = key;
+	const char *key_str = key;
 	return str_size(key_str);
 }
 
-static bool param_key_equal(void *key, const ht_link_t *item)
+static bool param_key_equal(const void *key, const ht_link_t *item)
 {
 	param_t *param = hash_table_get_inst(item, param_t, link);
-	char *key_str = key;
+	const char *key_str = key;
 
 	return str_cmp(param->key, key_str) == 0;
 }

--- a/uspace/app/trace/ipcp.c
+++ b/uspace/app/trace/ipcp.c
@@ -71,9 +71,9 @@ static hash_table_t pending_calls;
 proto_t *proto_system;		/**< Protocol describing system IPC methods. */
 proto_t	*proto_unknown;		/**< Protocol with no known methods. */
 
-static size_t pending_call_key_hash(void *key)
+static size_t pending_call_key_hash(const void *key)
 {
-	cap_call_handle_t *chandle = (cap_call_handle_t *) key;
+	const cap_call_handle_t *chandle = key;
 	return cap_handle_raw(*chandle);
 }
 
@@ -83,9 +83,9 @@ static size_t pending_call_hash(const ht_link_t *item)
 	return cap_handle_raw(hs->call_handle);
 }
 
-static bool pending_call_key_equal(void *key, const ht_link_t *item)
+static bool pending_call_key_equal(const void *key, const ht_link_t *item)
 {
-	cap_call_handle_t *chandle = (cap_call_handle_t *) key;
+	const cap_call_handle_t *chandle = key;
 	pending_call_t *hs = hash_table_get_inst(item, pending_call_t, link);
 
 	return *chandle == hs->call_handle;

--- a/uspace/app/trace/proto.c
+++ b/uspace/app/trace/proto.c
@@ -56,9 +56,10 @@ typedef struct {
 
 /* Hash table operations. */
 
-static size_t srv_proto_key_hash(void *key)
+static size_t srv_proto_key_hash(const void *key)
 {
-	return *(int *)key;
+	const int *n = key;
+	return *n;
 }
 
 static size_t srv_proto_hash(const ht_link_t *item)
@@ -67,10 +68,11 @@ static size_t srv_proto_hash(const ht_link_t *item)
 	return sp->srv;
 }
 
-static bool srv_proto_key_equal(void *key, const ht_link_t *item)
+static bool srv_proto_key_equal(const void *key, const ht_link_t *item)
 {
+	const int *n = key;
 	srv_proto_t *sp = hash_table_get_inst(item, srv_proto_t, link);
-	return sp->srv == *(int *)key;
+	return sp->srv == *n;
 }
 
 static hash_table_ops_t srv_proto_ops = {
@@ -81,9 +83,10 @@ static hash_table_ops_t srv_proto_ops = {
 	.remove_callback = NULL
 };
 
-static size_t method_oper_key_hash(void *key)
+static size_t method_oper_key_hash(const void *key)
 {
-	return *(int *)key;
+	const int *n = key;
+	return *n;
 }
 
 static size_t method_oper_hash(const ht_link_t *item)
@@ -92,10 +95,11 @@ static size_t method_oper_hash(const ht_link_t *item)
 	return mo->method;
 }
 
-static bool method_oper_key_equal(void *key, const ht_link_t *item)
+static bool method_oper_key_equal(const void *key, const ht_link_t *item)
 {
+	const int *n = key;
 	method_oper_t *mo = hash_table_get_inst(item, method_oper_t, link);
-	return mo->method == *(int *)key;
+	return mo->method == *n;
 }
 
 static hash_table_ops_t method_oper_ops = {

--- a/uspace/lib/block/block.c
+++ b/uspace/lib/block/block.c
@@ -240,9 +240,9 @@ void *block_bb_get(service_id_t service_id)
 	return devcon->bb_buf;
 }
 
-static size_t cache_key_hash(void *key)
+static size_t cache_key_hash(const void *key)
 {
-	aoff64_t *lba = (aoff64_t *)key;
+	const aoff64_t *lba = key;
 	return *lba;
 }
 
@@ -252,9 +252,9 @@ static size_t cache_hash(const ht_link_t *item)
 	return b->lba;
 }
 
-static bool cache_key_equal(void *key, const ht_link_t *item)
+static bool cache_key_equal(const void *key, const ht_link_t *item)
 {
-	aoff64_t *lba = (aoff64_t *)key;
+	const aoff64_t *lba = key;
 	block_t *b = hash_table_get_inst(item, block_t, hash_link);
 	return b->lba == *lba;
 }

--- a/uspace/lib/c/generic/adt/hash_table.c
+++ b/uspace/lib/c/generic/adt/hash_table.c
@@ -244,7 +244,7 @@ bool hash_table_insert_unique(hash_table_t *h, ht_link_t *item)
  * @return Matching item on success, NULL if there is no such item.
  *
  */
-ht_link_t *hash_table_find(const hash_table_t *h, void *key)
+ht_link_t *hash_table_find(const hash_table_t *h, const void *key)
 {
 	assert(h && h->bucket);
 
@@ -306,7 +306,7 @@ hash_table_find_next(const hash_table_t *h, ht_link_t *first, ht_link_t *item)
  *
  * @return Returns the number of removed items.
  */
-size_t hash_table_remove(hash_table_t *h, void *key)
+size_t hash_table_remove(hash_table_t *h, const void *key)
 {
 	assert(h && h->bucket);
 	assert(!h->apply_ongoing);

--- a/uspace/lib/c/generic/adt/hash_table.c
+++ b/uspace/lib/c/generic/adt/hash_table.c
@@ -302,7 +302,6 @@ hash_table_find_next(const hash_table_t *h, ht_link_t *first, ht_link_t *item)
  * @param h    Hash table.
  * @param key  Array of keys that will be compared against items of
  *             the hash table.
- * @param keys Number of keys in the 'key' array.
  *
  * @return Returns the number of removed items.
  */

--- a/uspace/lib/c/generic/async/ports.c
+++ b/uspace/lib/c/generic/async/ports.c
@@ -102,10 +102,10 @@ static void *fallback_port_data = NULL;
 static fibril_rmutex_t interface_mutex;
 static hash_table_t interface_hash_table;
 
-static size_t interface_key_hash(void *key)
+static size_t interface_key_hash(const void *key)
 {
-	iface_t iface = *(iface_t *) key;
-	return iface;
+	const iface_t *iface = key;
+	return *iface;
 }
 
 static size_t interface_hash(const ht_link_t *item)
@@ -114,11 +114,11 @@ static size_t interface_hash(const ht_link_t *item)
 	return interface_key_hash(&interface->iface);
 }
 
-static bool interface_key_equal(void *key, const ht_link_t *item)
+static bool interface_key_equal(const void *key, const ht_link_t *item)
 {
-	iface_t iface = *(iface_t *) key;
+	const iface_t *iface = key;
 	interface_t *interface = hash_table_get_inst(item, interface_t, link);
-	return iface == interface->iface;
+	return *iface == interface->iface;
 }
 
 /** Operations for the port hash table. */
@@ -130,10 +130,10 @@ static hash_table_ops_t interface_hash_table_ops = {
 	.remove_callback = NULL
 };
 
-static size_t port_key_hash(void *key)
+static size_t port_key_hash(const void *key)
 {
-	port_id_t port_id = *(port_id_t *) key;
-	return port_id;
+	const port_id_t *port_id = key;
+	return *port_id;
 }
 
 static size_t port_hash(const ht_link_t *item)
@@ -142,11 +142,11 @@ static size_t port_hash(const ht_link_t *item)
 	return port_key_hash(&port->id);
 }
 
-static bool port_key_equal(void *key, const ht_link_t *item)
+static bool port_key_equal(const void *key, const ht_link_t *item)
 {
-	port_id_t port_id = *(port_id_t *) key;
+	const port_id_t *port_id = key;
 	port_t *port = hash_table_get_inst(item, port_t, link);
-	return port_id == port->id;
+	return *port_id == port->id;
 }
 
 /** Operations for the port hash table. */

--- a/uspace/lib/c/generic/async/server.c
+++ b/uspace/lib/c/generic/async/server.c
@@ -230,10 +230,10 @@ static long notification_freelist_used = 0;
 
 static sysarg_t notification_avail = 0;
 
-static size_t client_key_hash(void *key)
+static size_t client_key_hash(const void *key)
 {
-	task_id_t in_task_id = *(task_id_t *) key;
-	return in_task_id;
+	const task_id_t *in_task_id = key;
+	return *in_task_id;
 }
 
 static size_t client_hash(const ht_link_t *item)
@@ -242,11 +242,11 @@ static size_t client_hash(const ht_link_t *item)
 	return client_key_hash(&client->in_task_id);
 }
 
-static bool client_key_equal(void *key, const ht_link_t *item)
+static bool client_key_equal(const void *key, const ht_link_t *item)
 {
-	task_id_t in_task_id = *(task_id_t *) key;
+	const task_id_t *in_task_id = key;
 	client_t *client = hash_table_get_inst(item, client_t, link);
-	return in_task_id == client->in_task_id;
+	return *in_task_id == client->in_task_id;
 }
 
 /** Operations for the client hash table. */
@@ -489,10 +489,10 @@ errno_t async_create_callback_port(async_exch_t *exch, iface_t iface, sysarg_t a
 	return EOK;
 }
 
-static size_t notification_key_hash(void *key)
+static size_t notification_key_hash(const void *key)
 {
-	sysarg_t id = *(sysarg_t *) key;
-	return id;
+	const sysarg_t *id = key;
+	return *id;
 }
 
 static size_t notification_hash(const ht_link_t *item)
@@ -502,12 +502,12 @@ static size_t notification_hash(const ht_link_t *item)
 	return notification_key_hash(&notification->imethod);
 }
 
-static bool notification_key_equal(void *key, const ht_link_t *item)
+static bool notification_key_equal(const void *key, const ht_link_t *item)
 {
-	sysarg_t id = *(sysarg_t *) key;
+	const sysarg_t *id = key;
 	notification_t *notification =
 	    hash_table_get_inst(item, notification_t, htlink);
-	return id == notification->imethod;
+	return *id == notification->imethod;
 }
 
 /** Operations for the notification hash table. */

--- a/uspace/lib/c/include/adt/hash_table.h
+++ b/uspace/lib/c/include/adt/hash_table.h
@@ -52,13 +52,13 @@ typedef struct {
 	size_t (*hash)(const ht_link_t *item);
 
 	/** Returns the hash of the key. */
-	size_t (*key_hash)(void *key);
+	size_t (*key_hash)(const void *key);
 
 	/** True if the items are equal (have the same lookup keys). */
 	bool (*equal)(const ht_link_t *item1, const ht_link_t *item2);
 
 	/** Returns true if the key is equal to the item's lookup key. */
-	bool (*key_equal)(void *key, const ht_link_t *item);
+	bool (*key_equal)(const void *key, const ht_link_t *item);
 
 	/** Hash table item removal callback.
 	 *
@@ -93,10 +93,10 @@ extern size_t hash_table_size(hash_table_t *);
 extern void hash_table_clear(hash_table_t *);
 extern void hash_table_insert(hash_table_t *, ht_link_t *);
 extern bool hash_table_insert_unique(hash_table_t *, ht_link_t *);
-extern ht_link_t *hash_table_find(const hash_table_t *, void *);
+extern ht_link_t *hash_table_find(const hash_table_t *, const void *);
 extern ht_link_t *hash_table_find_next(const hash_table_t *, ht_link_t *,
     ht_link_t *);
-extern size_t hash_table_remove(hash_table_t *, void *);
+extern size_t hash_table_remove(hash_table_t *, const void *);
 extern void hash_table_remove_item(hash_table_t *, ht_link_t *);
 extern void hash_table_apply(hash_table_t *, bool (*)(ht_link_t *, void *),
     void *);

--- a/uspace/lib/ext4/src/ops.c
+++ b/uspace/lib/ext4/src/ops.c
@@ -100,9 +100,9 @@ typedef struct {
 	fs_index_t index;
 } node_key_t;
 
-static size_t open_nodes_key_hash(void *key_arg)
+static size_t open_nodes_key_hash(const void *key_arg)
 {
-	node_key_t *key = (node_key_t *)key_arg;
+	const node_key_t *key = key_arg;
 	return hash_combine(key->service_id, key->index);
 }
 
@@ -112,9 +112,9 @@ static size_t open_nodes_hash(const ht_link_t *item)
 	return hash_combine(enode->instance->service_id, enode->inode_ref->index);
 }
 
-static bool open_nodes_key_equal(void *key_arg, const ht_link_t *item)
+static bool open_nodes_key_equal(const void *key_arg, const ht_link_t *item)
 {
-	node_key_t *key = (node_key_t *)key_arg;
+	const node_key_t *key = key_arg;
 	ext4_node_t *enode = hash_table_get_inst(item, ext4_node_t, link);
 
 	return key->service_id == enode->instance->service_id &&

--- a/uspace/lib/nic/src/nic_addr_db.c
+++ b/uspace/lib/nic/src/nic_addr_db.c
@@ -61,9 +61,9 @@ typedef struct {
 	const uint8_t *addr;
 } addr_key_t;
 
-static bool nic_addr_key_equal(void *key_arg, const ht_link_t *item)
+static bool nic_addr_key_equal(const void *key_arg, const ht_link_t *item)
 {
-	addr_key_t *key = (addr_key_t *)key_arg;
+	const addr_key_t *key = key_arg;
 	nic_addr_entry_t *entry = member_to_inst(item, nic_addr_entry_t, link);
 
 	return memcmp(entry->addr, key->addr, entry->len) == 0;
@@ -80,9 +80,9 @@ static size_t addr_hash(size_t len, const uint8_t *addr)
 	return hash;
 }
 
-static size_t nic_addr_key_hash(void *k)
+static size_t nic_addr_key_hash(const void *k)
 {
-	addr_key_t *key = (addr_key_t *)k;
+	const addr_key_t *key = k;
 	return addr_hash(key->len, key->addr);
 }
 

--- a/uspace/lib/nic/src/nic_wol_virtues.c
+++ b/uspace/lib/nic/src/nic_wol_virtues.c
@@ -44,9 +44,10 @@
  * Hash table helper functions
  */
 
-static size_t nic_wv_key_hash(void *key)
+static size_t nic_wv_key_hash(const void *key)
 {
-	return *(nic_wv_id_t *) key;
+	const nic_wv_id_t *k = key;
+	return *k;
 }
 
 static size_t nic_wv_hash(const ht_link_t *item)
@@ -55,10 +56,11 @@ static size_t nic_wv_hash(const ht_link_t *item)
 	return virtue->id;
 }
 
-static bool nic_wv_key_equal(void *key, const ht_link_t *item)
+static bool nic_wv_key_equal(const void *key, const ht_link_t *item)
 {
-	nic_wol_virtue_t *virtue = (nic_wol_virtue_t *) item;
-	return (virtue->id == *(nic_wv_id_t *) key);
+	const nic_wv_id_t *k = key;
+	const nic_wol_virtue_t *virtue = (const nic_wol_virtue_t *) item;
+	return (virtue->id == *k);
 }
 
 /**

--- a/uspace/srv/devman/devtree.c
+++ b/uspace/srv/devman/devtree.c
@@ -41,10 +41,10 @@
 
 /* hash table operations */
 
-static inline size_t handle_key_hash(void *key)
+static inline size_t handle_key_hash(const void *key)
 {
-	devman_handle_t handle = *(devman_handle_t *)key;
-	return handle;
+	const devman_handle_t *handle = key;
+	return *handle;
 }
 
 static size_t devman_devices_hash(const ht_link_t *item)
@@ -59,24 +59,24 @@ static size_t devman_functions_hash(const ht_link_t *item)
 	return handle_key_hash(&fun->handle);
 }
 
-static bool devman_devices_key_equal(void *key, const ht_link_t *item)
+static bool devman_devices_key_equal(const void *key, const ht_link_t *item)
 {
-	devman_handle_t handle = *(devman_handle_t *)key;
+	const devman_handle_t *handle = key;
 	dev_node_t *dev = hash_table_get_inst(item, dev_node_t, devman_dev);
-	return dev->handle == handle;
+	return dev->handle == *handle;
 }
 
-static bool devman_functions_key_equal(void *key, const ht_link_t *item)
+static bool devman_functions_key_equal(const void *key, const ht_link_t *item)
 {
-	devman_handle_t handle = *(devman_handle_t *)key;
+	const devman_handle_t *handle = key;
 	fun_node_t *fun = hash_table_get_inst(item, fun_node_t, devman_fun);
-	return fun->handle == handle;
+	return fun->handle == *handle;
 }
 
-static inline size_t service_id_key_hash(void *key)
+static inline size_t service_id_key_hash(const void *key)
 {
-	service_id_t service_id = *(service_id_t *)key;
-	return service_id;
+	const service_id_t *service_id = key;
+	return *service_id;
 }
 
 static size_t loc_functions_hash(const ht_link_t *item)
@@ -85,11 +85,11 @@ static size_t loc_functions_hash(const ht_link_t *item)
 	return service_id_key_hash(&fun->service_id);
 }
 
-static bool loc_functions_key_equal(void *key, const ht_link_t *item)
+static bool loc_functions_key_equal(const void *key, const ht_link_t *item)
 {
-	service_id_t service_id = *(service_id_t *)key;
+	const service_id_t *service_id = key;
 	fun_node_t *fun = hash_table_get_inst(item, fun_node_t, loc_fun);
-	return fun->service_id == service_id;
+	return fun->service_id == *service_id;
 }
 
 static hash_table_ops_t devman_devices_ops = {

--- a/uspace/srv/fs/cdfs/cdfs_ops.c
+++ b/uspace/srv/fs/cdfs/cdfs_ops.c
@@ -284,9 +284,9 @@ typedef struct {
 	fs_index_t index;
 } ht_key_t;
 
-static size_t nodes_key_hash(void *k)
+static size_t nodes_key_hash(const void *k)
 {
-	ht_key_t *key = (ht_key_t *)k;
+	const ht_key_t *key = k;
 	return hash_combine(key->service_id, key->index);
 }
 
@@ -296,10 +296,10 @@ static size_t nodes_hash(const ht_link_t *item)
 	return hash_combine(node->fs->service_id, node->index);
 }
 
-static bool nodes_key_equal(void *k, const ht_link_t *item)
+static bool nodes_key_equal(const void *k, const ht_link_t *item)
 {
 	cdfs_node_t *node = hash_table_get_inst(item, cdfs_node_t, nh_link);
-	ht_key_t *key = (ht_key_t *)k;
+	const ht_key_t *key = k;
 
 	return key->service_id == node->fs->service_id && key->index == node->index;
 }

--- a/uspace/srv/fs/exfat/exfat_idx.c
+++ b/uspace/srv/fs/exfat/exfat_idx.c
@@ -116,9 +116,9 @@ typedef struct {
 	unsigned pdi;
 } pos_key_t;
 
-static inline size_t pos_key_hash(void *key)
+static inline size_t pos_key_hash(const void *key)
 {
-	pos_key_t *pos = (pos_key_t *)key;
+	const pos_key_t *pos = key;
 
 	size_t hash = 0;
 	hash = hash_combine(pos->pfc, pos->pdi);
@@ -138,9 +138,9 @@ static size_t pos_hash(const ht_link_t *item)
 	return pos_key_hash(&pkey);
 }
 
-static bool pos_key_equal(void *key, const ht_link_t *item)
+static bool pos_key_equal(const void *key, const ht_link_t *item)
 {
-	pos_key_t *pos = (pos_key_t *)key;
+	const pos_key_t *pos = key;
 	exfat_idx_t *fidx = hash_table_get_inst(item, exfat_idx_t, uph_link);
 
 	return pos->service_id == fidx->service_id &&
@@ -167,9 +167,9 @@ typedef struct {
 	fs_index_t index;
 } idx_key_t;
 
-static size_t idx_key_hash(void *key_arg)
+static size_t idx_key_hash(const void *key_arg)
 {
-	idx_key_t *key = (idx_key_t *)key_arg;
+	const idx_key_t *key = key_arg;
 	return hash_combine(key->service_id, key->index);
 }
 
@@ -179,10 +179,10 @@ static size_t idx_hash(const ht_link_t *item)
 	return hash_combine(fidx->service_id, fidx->index);
 }
 
-static bool idx_key_equal(void *key_arg, const ht_link_t *item)
+static bool idx_key_equal(const void *key_arg, const ht_link_t *item)
 {
 	exfat_idx_t *fidx = hash_table_get_inst(item, exfat_idx_t, uih_link);
-	idx_key_t *key = (idx_key_t *)key_arg;
+	const idx_key_t *key = key_arg;
 
 	return key->index == fidx->index && key->service_id == fidx->service_id;
 }

--- a/uspace/srv/fs/fat/fat_idx.c
+++ b/uspace/srv/fs/fat/fat_idx.c
@@ -116,9 +116,9 @@ typedef struct {
 	unsigned pdi;
 } pos_key_t;
 
-static inline size_t pos_key_hash(void *key)
+static inline size_t pos_key_hash(const void *key)
 {
-	pos_key_t *pos = (pos_key_t *)key;
+	const pos_key_t *pos = key;
 
 	size_t hash = 0;
 	hash = hash_combine(pos->pfc, pos->pdi);
@@ -138,9 +138,9 @@ static size_t pos_hash(const ht_link_t *item)
 	return pos_key_hash(&pkey);
 }
 
-static bool pos_key_equal(void *key, const ht_link_t *item)
+static bool pos_key_equal(const void *key, const ht_link_t *item)
 {
-	pos_key_t *pos = (pos_key_t *)key;
+	const pos_key_t *pos = key;
 	fat_idx_t *fidx = hash_table_get_inst(item, fat_idx_t, uph_link);
 
 	return pos->service_id == fidx->service_id &&
@@ -167,9 +167,9 @@ typedef struct {
 	fs_index_t index;
 } idx_key_t;
 
-static size_t idx_key_hash(void *key_arg)
+static size_t idx_key_hash(const void *key_arg)
 {
-	idx_key_t *key = (idx_key_t *)key_arg;
+	const idx_key_t *key = key_arg;
 	return hash_combine(key->service_id, key->index);
 }
 
@@ -179,10 +179,10 @@ static size_t idx_hash(const ht_link_t *item)
 	return hash_combine(fidx->service_id, fidx->index);
 }
 
-static bool idx_key_equal(void *key_arg, const ht_link_t *item)
+static bool idx_key_equal(const void *key_arg, const ht_link_t *item)
 {
 	fat_idx_t *fidx = hash_table_get_inst(item, fat_idx_t, uih_link);
-	idx_key_t *key = (idx_key_t *)key_arg;
+	const idx_key_t *key = key_arg;
 
 	return key->index == fidx->index && key->service_id == fidx->service_id;
 }

--- a/uspace/srv/fs/locfs/locfs_ops.c
+++ b/uspace/srv/fs/locfs/locfs_ops.c
@@ -70,9 +70,10 @@ static FIBRIL_MUTEX_INITIALIZE(services_mutex);
 
 /* Implementation of hash table interface for the nodes hash table. */
 
-static size_t services_key_hash(void *key)
+static size_t services_key_hash(const void *key)
 {
-	return *(service_id_t *)key;
+	const service_id_t *k = key;
+	return *k;
 }
 
 static size_t services_hash(const ht_link_t *item)
@@ -81,10 +82,11 @@ static size_t services_hash(const ht_link_t *item)
 	return dev->service_id;
 }
 
-static bool services_key_equal(void *key, const ht_link_t *item)
+static bool services_key_equal(const void *key, const ht_link_t *item)
 {
+	const service_id_t *k = key;
 	service_t *dev = hash_table_get_inst(item, service_t, link);
-	return (dev->service_id == *(service_id_t *)key);
+	return (dev->service_id == *k);
 }
 
 static void services_remove_callback(ht_link_t *item)

--- a/uspace/srv/fs/mfs/mfs_ops.c
+++ b/uspace/srv/fs/mfs/mfs_ops.c
@@ -99,9 +99,9 @@ typedef struct {
 } node_key_t;
 
 static size_t
-open_nodes_key_hash(void *key)
+open_nodes_key_hash(const void *key)
 {
-	node_key_t *node_key = (node_key_t *)key;
+	const node_key_t *node_key = key;
 	return hash_combine(node_key->service_id, node_key->index);
 }
 
@@ -113,9 +113,9 @@ open_nodes_hash(const ht_link_t *item)
 }
 
 static bool
-open_nodes_key_equal(void *key, const ht_link_t *item)
+open_nodes_key_equal(const void *key, const ht_link_t *item)
 {
-	node_key_t *node_key = (node_key_t *)key;
+	const node_key_t *node_key = key;
 	struct mfs_node *mnode = hash_table_get_inst(item, struct mfs_node, link);
 
 	return node_key->service_id == mnode->instance->service_id &&

--- a/uspace/srv/fs/tmpfs/tmpfs_ops.c
+++ b/uspace/srv/fs/tmpfs/tmpfs_ops.c
@@ -146,9 +146,9 @@ typedef struct {
 	fs_index_t index;
 } node_key_t;
 
-static size_t nodes_key_hash(void *k)
+static size_t nodes_key_hash(const void *k)
 {
-	node_key_t *key = (node_key_t *)k;
+	const node_key_t *key = k;
 	return hash_combine(key->service_id, key->index);
 }
 
@@ -158,10 +158,10 @@ static size_t nodes_hash(const ht_link_t *item)
 	return hash_combine(nodep->service_id, nodep->index);
 }
 
-static bool nodes_key_equal(void *key_arg, const ht_link_t *item)
+static bool nodes_key_equal(const void *key_arg, const ht_link_t *item)
 {
 	tmpfs_node_t *node = hash_table_get_inst(item, tmpfs_node_t, nh_link);
-	node_key_t *key = (node_key_t *)key_arg;
+	const node_key_t *key = key_arg;
 
 	return key->service_id == node->service_id && key->index == node->index;
 }

--- a/uspace/srv/fs/udf/udf_idx.c
+++ b/uspace/srv/fs/udf/udf_idx.c
@@ -62,15 +62,15 @@ static size_t udf_idx_hash(const ht_link_t *item)
 	return hash_combine(node->instance->service_id, node->index);
 }
 
-static size_t udf_idx_key_hash(void *k)
+static size_t udf_idx_key_hash(const void *k)
 {
-	udf_ht_key_t *key = (udf_ht_key_t *) k;
+	const udf_ht_key_t *key = k;
 	return hash_combine(key->service_id, key->index);
 }
 
-static bool udf_idx_key_equal(void *k, const ht_link_t *item)
+static bool udf_idx_key_equal(const void *k, const ht_link_t *item)
 {
-	udf_ht_key_t *key = (udf_ht_key_t *) k;
+	const udf_ht_key_t *key = k;
 	udf_node_t *node = hash_table_get_inst(item, udf_node_t, link);
 
 	return (key->service_id == node->instance->service_id) &&

--- a/uspace/srv/hid/input/gsp.c
+++ b/uspace/srv/hid/input/gsp.c
@@ -63,9 +63,9 @@ typedef struct {
 	int input;
 } trans_key_t;
 
-static size_t trans_key_hash(void *key)
+static size_t trans_key_hash(const void *key)
 {
-	trans_key_t *trans_key = (trans_key_t *)key;
+	const trans_key_t *trans_key = key;
 	return hash_combine(trans_key->input, trans_key->old_state);
 }
 
@@ -75,9 +75,9 @@ static size_t trans_hash(const ht_link_t *item)
 	return hash_combine(t->input, t->old_state);
 }
 
-static bool trans_key_equal(void *key, const ht_link_t *item)
+static bool trans_key_equal(const void *key, const ht_link_t *item)
 {
-	trans_key_t *trans_key = (trans_key_t *)key;
+	const trans_key_t *trans_key = key;
 	gsp_trans_t *t = hash_table_get_inst(item, gsp_trans_t, link);
 
 	return trans_key->input == t->input && trans_key->old_state == t->old_state;

--- a/uspace/srv/ns/service.c
+++ b/uspace/srv/ns/service.c
@@ -64,9 +64,10 @@ typedef struct {
 	async_sess_t *sess;
 } hashed_iface_t;
 
-static size_t service_key_hash(void *key)
+static size_t service_key_hash(const void *key)
 {
-	return *(service_t *) key;
+	const service_t *srv = key;
+	return *srv;
 }
 
 static size_t service_hash(const ht_link_t *item)
@@ -77,17 +78,19 @@ static size_t service_hash(const ht_link_t *item)
 	return service->service;
 }
 
-static bool service_key_equal(void *key, const ht_link_t *item)
+static bool service_key_equal(const void *key, const ht_link_t *item)
 {
+	const service_t *srv = key;
 	hashed_service_t *service =
 	    hash_table_get_inst(item, hashed_service_t, link);
 
-	return service->service == *(service_t *) key;
+	return service->service == *srv;
 }
 
-static size_t iface_key_hash(void *key)
+static size_t iface_key_hash(const void *key)
 {
-	return *(iface_t *) key;
+	const iface_t *iface = key;
+	return *iface;
 }
 
 static size_t iface_hash(const ht_link_t *item)
@@ -98,12 +101,13 @@ static size_t iface_hash(const ht_link_t *item)
 	return iface->iface;
 }
 
-static bool iface_key_equal(void *key, const ht_link_t *item)
+static bool iface_key_equal(const void *key, const ht_link_t *item)
 {
+	const iface_t *kiface = key;
 	hashed_iface_t *iface =
 	    hash_table_get_inst(item, hashed_iface_t, link);
 
-	return iface->iface == *(iface_t *) key;
+	return iface->iface == *kiface;
 }
 
 /** Operations for service hash table. */

--- a/uspace/srv/ns/task.c
+++ b/uspace/srv/ns/task.c
@@ -53,21 +53,23 @@ typedef struct {
 	int retval;      /**< The return value. */
 } hashed_task_t;
 
-static size_t task_key_hash(void *key)
+static size_t task_key_hash(const void *key)
 {
-	return *(task_id_t *)key;
+	const task_id_t *tid = key;
+	return *tid;
 }
 
-static size_t task_hash(const ht_link_t  *item)
+static size_t task_hash(const ht_link_t *item)
 {
 	hashed_task_t *ht = hash_table_get_inst(item, hashed_task_t, link);
 	return ht->id;
 }
 
-static bool task_key_equal(void *key, const ht_link_t *item)
+static bool task_key_equal(const void *key, const ht_link_t *item)
 {
+	const task_id_t *tid = key;
 	hashed_task_t *ht = hash_table_get_inst(item, hashed_task_t, link);
-	return ht->id == *(task_id_t *)key;
+	return ht->id == *tid;
 }
 
 /** Perform actions after removal of item from the hash table. */
@@ -96,10 +98,10 @@ typedef struct {
 
 /* label-to-id hash table operations */
 
-static size_t p2i_key_hash(void *key)
+static size_t p2i_key_hash(const void *key)
 {
-	sysarg_t label = *(sysarg_t *)key;
-	return label;
+	const sysarg_t *label = key;
+	return *label;
 }
 
 static size_t p2i_hash(const ht_link_t *item)
@@ -108,12 +110,12 @@ static size_t p2i_hash(const ht_link_t *item)
 	return entry->label;
 }
 
-static bool p2i_key_equal(void *key, const ht_link_t *item)
+static bool p2i_key_equal(const void *key, const ht_link_t *item)
 {
-	sysarg_t label = *(sysarg_t *)key;
+	const sysarg_t *label = key;
 	p2i_entry_t *entry = hash_table_get_inst(item, p2i_entry_t, link);
 
-	return (label == entry->label);
+	return (*label == entry->label);
 }
 
 /** Perform actions after removal of item from the hash table.

--- a/uspace/srv/vfs/vfs_node.c
+++ b/uspace/srv/vfs/vfs_node.c
@@ -59,9 +59,9 @@ hash_table_t nodes;
 #define KEY_DEV_HANDLE	1
 #define KEY_INDEX	2
 
-static size_t nodes_key_hash(void *);
+static size_t nodes_key_hash(const void *);
 static size_t nodes_hash(const ht_link_t *);
-static bool nodes_key_equal(void *, const ht_link_t *);
+static bool nodes_key_equal(const void *, const ht_link_t *);
 static vfs_triplet_t node_triplet(vfs_node_t *node);
 
 /** VFS node hash table operations. */
@@ -279,9 +279,9 @@ errno_t vfs_open_node_remote(vfs_node_t *node)
 	return rc;
 }
 
-static size_t nodes_key_hash(void *key)
+static size_t nodes_key_hash(const void *key)
 {
-	vfs_triplet_t *tri = key;
+	const vfs_triplet_t *tri = key;
 	size_t hash = hash_combine(tri->fs_handle, tri->index);
 	return hash_combine(hash, tri->service_id);
 }
@@ -293,9 +293,9 @@ static size_t nodes_hash(const ht_link_t *item)
 	return nodes_key_hash(&tri);
 }
 
-static bool nodes_key_equal(void *key, const ht_link_t *item)
+static bool nodes_key_equal(const void *key, const ht_link_t *item)
 {
-	vfs_triplet_t *tri = key;
+	const vfs_triplet_t *tri = key;
 	vfs_node_t *node = hash_table_get_inst(item, vfs_node_t, nh_link);
 	return node->fs_handle == tri->fs_handle &&
 	    node->service_id == tri->service_id && node->index == tri->index;


### PR DESCRIPTION
The assumption here is that modifying key in the hash/equal functions in something completely unexpected, and not something you would ever want to do intentionally, so it makes sense to disallow it entirely to get that extra level of checking.