### PR TITLE
Avoid using ambiguous terminology in str.h/str.c

### DIFF
--- a/boot/generic/include/str.h
+++ b/boot/generic/include/str.h
@@ -47,9 +47,9 @@
 extern wchar_t str_decode(const char *str, size_t *offset, size_t sz);
 extern errno_t chr_encode(wchar_t ch, char *str, size_t *offset, size_t sz);
 
-extern size_t str_size(const char *str);
-extern size_t str_lsize(const char *str, size_t max_len);
-extern size_t str_length(const char *str);
+extern size_t str_bytes(const char *str);
+extern size_t str_lbytes(const char *str, size_t max_len);
+extern size_t str_code_points(const char *str);
 
 extern bool ascii_check(wchar_t ch);
 extern bool chr_check(wchar_t ch);

--- a/boot/generic/src/printf_core.c
+++ b/boot/generic/src/printf_core.c
@@ -137,9 +137,9 @@ static int printf_putnchars(const char *buf, size_t size,
 static int printf_putstr(const char *str, printf_spec_t *ps)
 {
 	if (str == NULL)
-		return printf_putnchars(nullstr, str_size(nullstr), ps);
+		return printf_putnchars(nullstr, str_bytes(nullstr), ps);
 
-	return ps->str_write((void *) str, str_size(str), ps->data);
+	return ps->str_write((void *) str, str_bytes(str), ps->data);
 }
 
 /** Print one ASCII character.
@@ -212,7 +212,7 @@ static int print_str(char *str, int width, unsigned int precision,
 		return printf_putstr(nullstr, ps);
 
 	/* Print leading spaces. */
-	size_t strw = str_length(str);
+	size_t strw = str_code_points(str);
 	if ((precision == 0) || (precision > strw))
 		precision = strw;
 
@@ -228,7 +228,7 @@ static int print_str(char *str, int width, unsigned int precision,
 
 	/* Part of @a str fitting into the alloted space. */
 	int retval;
-	size_t size = str_lsize(str, precision);
+	size_t size = str_lbytes(str, precision);
 	if ((retval = printf_putnchars(str, size, ps)) < 0)
 		return -counter;
 

--- a/boot/generic/src/str.c
+++ b/boot/generic/src/str.c
@@ -278,7 +278,7 @@ errno_t chr_encode(const wchar_t ch, char *str, size_t *offset, size_t size)
  * @return Number of bytes used by the string
  *
  */
-size_t str_size(const char *str)
+size_t str_bytes(const char *str)
 {
 	size_t size = 0;
 
@@ -301,7 +301,7 @@ size_t str_size(const char *str)
  * @return Number of bytes used by the characters.
  *
  */
-size_t str_lsize(const char *str, size_t max_len)
+size_t str_lbytes(const char *str, size_t max_len)
 {
 	size_t len = 0;
 	size_t offset = 0;
@@ -323,7 +323,7 @@ size_t str_lsize(const char *str, size_t max_len)
  * @return Number of characters in string.
  *
  */
-size_t str_length(const char *str)
+size_t str_code_points(const char *str)
 {
 	size_t len = 0;
 	size_t offset = 0;

--- a/boot/generic/src/str.c
+++ b/boot/generic/src/str.c
@@ -36,7 +36,7 @@
  *
  * Strings and characters use the Universal Character Set (UCS). The standard
  * strings, called just strings are encoded in UTF-8. Wide strings (encoded
- * in UTF-32) are supported to a limited degree. A single character is
+ * in UTF-32) are supported to a limited degree. A single code point is
  * represented as wchar_t.@n
  *
  * Overview of the terminology:@n
@@ -45,7 +45,7 @@
  *  --------------------  ----------------------------------------------------
  *  byte                  8 bits stored in uint8_t (unsigned 8 bit integer)
  *
- *  character             UTF-32 encoded Unicode character, stored in wchar_t
+ *  character             UTF-32 encoded Unicode code point, stored in wchar_t
  *                        (signed 32 bit integer), code points 0 .. 1114111
  *                        are valid
  *
@@ -61,7 +61,7 @@
  *  [wide] string size    number of BYTES in a [wide] string (excluding
  *                        the NULL-terminator), size_t
  *
- *  [wide] string length  number of CHARACTERS in a [wide] string (excluding
+ *  [wide] string length  number of CODE POINTS in a [wide] string (excluding
  *                        the NULL-terminator), size_t
  *
  *  [wide] string width   number of display cells on a monospace display taken
@@ -75,7 +75,7 @@
  *  size    n        size_t   number of BYTES in a string (excluding the
  *                            NULL-terminator)
  *
- *  length  l        size_t   number of CHARACTERS in a string (excluding the
+ *  length  l        size_t   number of CODE POINTS in a string (excluding the
  *                            null terminator)
  *
  *  width  w         size_t   number of display cells on a monospace display
@@ -84,7 +84,7 @@
  *
  * Function naming prefixes:@n
  *
- *  chr_    operate on characters
+ *  chr_    operate on code points
  *  ascii_  operate on ASCII characters
  *  str_    operate on strings
  *  wstr_   operate on wide strings
@@ -97,7 +97,7 @@
  *
  *  pointer (char *, wchar_t *)
  *  byte offset (size_t)
- *  character index (size_t)
+ *  code point index (size_t)
  *
  */
 
@@ -127,18 +127,18 @@
 /** Number of data bits in a UTF-8 continuation byte */
 #define CONT_BITS  6
 
-/** Decode a single character from a string.
+/** Decode a single code point from an UTF-8 encoded string.
  *
- * Decode a single character from a string of size @a size. Decoding starts
+ * Decode a single code point from a string of size @a size. Decoding starts
  * at @a offset and this offset is moved to the beginning of the next
- * character. In case of decoding error, offset generally advances at least
+ * code point. In case of decoding error, offset generally advances at least
  * by one. However, offset is never moved beyond size.
  *
  * @param str    String (not necessarily NULL-terminated).
  * @param offset Byte offset in string where to start decoding.
  * @param size   Size of the string (in bytes).
  *
- * @return Value of decoded character, U_SPECIAL on decoding error or
+ * @return Value of decoded code point, U_SPECIAL on decoding error or
  *         NULL if attempt to decode beyond @a size.
  *
  */
@@ -197,19 +197,19 @@ wchar_t str_decode(const char *str, size_t *offset, size_t size)
 	return ch;
 }
 
-/** Encode a single character to string representation.
+/** Encode a single code point to a UTF-8 string representation.
  *
- * Encode a single character to string representation (i.e. UTF-8) and store
+ * Encode a single code point to a UTF-8 string representation and store
  * it into a buffer at @a offset. Encoding starts at @a offset and this offset
- * is moved to the position where the next character can be written to.
+ * is moved to the position where the next code point can be written to.
  *
- * @param ch     Input character.
+ * @param ch     Input code point.
  * @param str    Output buffer.
  * @param offset Byte offset where to start writing.
  * @param size   Size of the output buffer (in bytes).
  *
- * @return EOK if the character was encoded successfully, EOVERFLOW if there
- *         was not enough space in the output buffer or EINVAL if the character
+ * @return EOK if the code point was encoded successfully, EOVERFLOW if there
+ *         was not enough space in the output buffer or EINVAL if the code point
  *         code was invalid.
  */
 errno_t chr_encode(const wchar_t ch, char *str, size_t *offset, size_t size)
@@ -288,17 +288,17 @@ size_t str_bytes(const char *str)
 	return size;
 }
 
-/** Get size of string with length limit.
+/** Get size of string with code point count limit.
  *
  * Get the number of bytes which are used by up to @a max_len first
- * characters in the string @a str. If @a max_len is greater than
- * the length of @a str, the entire string is measured (excluding the
- * NULL-terminator).
+ * code points in the string @a str. If @a max_len is greater than
+ * the number of code points in @a str, the entire string is measured
+ * (excluding the NULL-terminator).
  *
  * @param str     String to consider.
- * @param max_len Maximum number of characters to measure.
+ * @param max_len Maximum number of code points to measure.
  *
- * @return Number of bytes used by the characters.
+ * @return Number of bytes used by the code points.
  *
  */
 size_t str_lbytes(const char *str, size_t max_len)
@@ -316,11 +316,11 @@ size_t str_lbytes(const char *str, size_t max_len)
 	return offset;
 }
 
-/** Get number of characters in a string.
+/** Get number of unicode code points in a UTF-8 encoded string.
  *
- * @param str NULL-terminated string.
+ * @param str NULL-terminated UTF-8 string.
  *
- * @return Number of characters in string.
+ * @return Number of code points in the string.
  *
  */
 size_t str_code_points(const char *str)
@@ -334,9 +334,9 @@ size_t str_code_points(const char *str)
 	return len;
 }
 
-/** Check whether character is plain ASCII.
+/** Check whether code point is plain ASCII.
  *
- * @return True if character is plain ASCII.
+ * @return True if code point is plain ASCII.
  *
  */
 bool ascii_check(wchar_t ch)
@@ -347,9 +347,9 @@ bool ascii_check(wchar_t ch)
 	return false;
 }
 
-/** Check whether character is valid
+/** Check whether code point is valid
  *
- * @return True if character is a valid Unicode code point.
+ * @return True if code point is a valid Unicode code point.
  *
  */
 bool chr_check(wchar_t ch)
@@ -364,12 +364,12 @@ bool chr_check(wchar_t ch)
  *
  * Do a char-by-char comparison of two NULL-terminated strings.
  * The strings are considered equal iff their length is equal
- * and both strings consist of the same sequence of characters.
+ * and both strings consist of the same sequence of code points.
  *
- * A string S1 is less than another string S2 if it has a character with
- * lower value at the first character position where the strings differ.
+ * A string S1 is less than another string S2 if it has a code point with
+ * lower value at the first code point position where the strings differ.
  * If the strings differ in length, the shorter one is treated as if
- * padded by characters with a value of zero.
+ * padded by code points with a value of zero.
  *
  * @param s1 First string to compare.
  * @param s2 Second string to compare.
@@ -408,7 +408,7 @@ int str_cmp(const char *s1, const char *s2)
  * Copy source string @a src to destination buffer @a dest.
  * No more than @a size bytes are written. If the size of the output buffer
  * is at least one byte, the output string will always be well-formed, i.e.
- * null-terminated and containing only complete characters.
+ * null-terminated and containing only complete code points.
  *
  * @param dest  Destination buffer.
  * @param count Size of the destination buffer (must be > 0).

--- a/kernel/arch/amd64/src/amd64.c
+++ b/kernel/arch/amd64/src/amd64.c
@@ -184,7 +184,7 @@ void amd64_post_smp_init(void)
 	static const char *platform = "pc";
 
 	sysinfo_set_item_data("platform", NULL, (void *) platform,
-	    str_size(platform));
+	    str_bytes(platform));
 
 #ifdef CONFIG_PC_KBD
 	/*

--- a/kernel/arch/arm32/src/arm32.c
+++ b/kernel/arch/arm32/src/arm32.c
@@ -112,7 +112,7 @@ void arm32_post_smp_init(void)
 	const char *platform = machine_get_platform_name();
 
 	sysinfo_set_item_data("platform", NULL, (void *) platform,
-	    str_size(platform));
+	    str_bytes(platform));
 }
 
 /** Performs arm32 specific tasks needed before the new task is run. */

--- a/kernel/arch/ia32/src/ia32.c
+++ b/kernel/arch/ia32/src/ia32.c
@@ -169,7 +169,7 @@ void ia32_post_smp_init(void)
 	static const char *platform = "pc";
 
 	sysinfo_set_item_data("platform", NULL, (void *) platform,
-	    str_size(platform));
+	    str_bytes(platform));
 
 #ifdef CONFIG_PC_KBD
 	/*

--- a/kernel/arch/ia64/src/ia64.c
+++ b/kernel/arch/ia64/src/ia64.c
@@ -155,7 +155,7 @@ void ia64_post_smp_init(void)
 	platform = "pc";
 #endif
 	sysinfo_set_item_data("platform", NULL, (void *) platform,
-	    str_size(platform));
+	    str_bytes(platform));
 
 #ifdef MACHINE_ski
 	ski_instance_t *ski_instance = skiin_init();

--- a/kernel/arch/mips32/src/mips32.c
+++ b/kernel/arch/mips32/src/mips32.c
@@ -154,7 +154,7 @@ void mips32_post_smp_init(void)
 	/* Set platform name. */
 	sysinfo_set_item_data("platform", NULL,
 	    (void *) machine_get_platform_name(),
-	    str_size(machine_get_platform_name()));
+	    str_bytes(machine_get_platform_name()));
 
 	machine_input_init();
 }

--- a/kernel/arch/ppc32/src/ppc32.c
+++ b/kernel/arch/ppc32/src/ppc32.c
@@ -280,7 +280,7 @@ void ppc32_post_smp_init(void)
 	static const char *platform = "mac";
 
 	sysinfo_set_item_data("platform", NULL, (void *) platform,
-	    str_size(platform));
+	    str_bytes(platform));
 
 	ofw_tree_walk_by_device_type("mac-io", macio_register, NULL);
 }

--- a/kernel/arch/sparc64/src/sun4u/sparc64.c
+++ b/kernel/arch/sparc64/src/sun4u/sparc64.c
@@ -126,7 +126,7 @@ void sun4u_post_smp_init(void)
 	static const char *platform = "sun4u";
 
 	sysinfo_set_item_data("platform", NULL, (void *) platform,
-	    str_size(platform));
+	    str_bytes(platform));
 
 	standalone_sparc64_console_init();
 }

--- a/kernel/arch/sparc64/src/sun4v/sparc64.c
+++ b/kernel/arch/sparc64/src/sun4v/sparc64.c
@@ -124,7 +124,7 @@ void sun4v_post_smp_init(void)
 	static const char *platform = "sun4v";
 
 	sysinfo_set_item_data("platform", NULL, (void *) platform,
-	    str_size(platform));
+	    str_bytes(platform));
 
 	niagarain_init();
 }

--- a/kernel/genarch/src/multiboot/multiboot.c
+++ b/kernel/genarch/src/multiboot/multiboot.c
@@ -50,7 +50,7 @@ void multiboot_extract_command(char *buf, size_t size, const char *cmd_line)
 	/* Find the first space. */
 	const char *end = str_chr(cmd_line, ' ');
 	if (end == NULL)
-		end = cmd_line + str_size(cmd_line);
+		end = cmd_line + str_bytes(cmd_line);
 
 	/*
 	 * Find last occurence of '/' before 'end'. If found, place start at
@@ -87,7 +87,7 @@ void multiboot_extract_argument(char *buf, size_t size, const char *cmd_line)
 		return;
 	}
 
-	const char *end = cmd_line + str_size(cmd_line);
+	const char *end = cmd_line + str_bytes(cmd_line);
 
 	/* Skip the space(s). */
 	while (start != end) {

--- a/kernel/genarch/src/ofw/ofw_tree.c
+++ b/kernel/genarch/src/ofw/ofw_tree.c
@@ -249,9 +249,9 @@ ofw_tree_node_t *ofw_tree_lookup(const char *path)
 	ofw_tree_node_t *node = ofw_root;
 	size_t j;
 
-	for (size_t i = 1; (i < str_size(path)) && (node); i = j + 1) {
+	for (size_t i = 1; (i < str_bytes(path)) && (node); i = j + 1) {
 		j = i;
-		while (j < str_size(path) && path[j] != '/')
+		while (j < str_bytes(path) && path[j] != '/')
 			j++;
 
 		/* Skip extra slashes */
@@ -341,7 +341,7 @@ static void *ofw_sysinfo_properties(struct sysinfo_item *item, size_t *size,
 	/* Compute serialized data size */
 	*size = 0;
 	for (size_t i = 0; i < node->properties; i++)
-		*size += str_size(node->property[i].name) + 1 +
+		*size += str_bytes(node->property[i].name) + 1 +
 		    sizeof(node->property[i].size) + node->property[i].size;
 
 	if (dry_run)
@@ -358,7 +358,7 @@ static void *ofw_sysinfo_properties(struct sysinfo_item *item, size_t *size,
 	for (size_t i = 0; i < node->properties; i++) {
 		/* Property name */
 		str_cpy(dump + pos, *size - pos, node->property[i].name);
-		pos += str_size(node->property[i].name) + 1;
+		pos += str_bytes(node->property[i].name) + 1;
 
 		/* Value size */
 		memcpy(dump + pos, &node->property[i].size,
@@ -392,7 +392,7 @@ static void ofw_tree_node_sysinfo(ofw_tree_node_t *node, const char *path)
 	for (ofw_tree_node_t *cur = node; cur; cur = cur->peer) {
 		if ((cur->parent) && (path))
 			snprintf(cur_path, PATH_MAX_LEN, "%s.%s", path, cur->da_name);
-		else if (!str_size(cur->da_name))
+		else if (!str_bytes(cur->da_name))
 			snprintf(cur_path, PATH_MAX_LEN, "firmware.ofw");
 		else
 			snprintf(cur_path, PATH_MAX_LEN, "firmware.%s", cur->da_name);

--- a/kernel/generic/include/str.h
+++ b/kernel/generic/include/str.h
@@ -65,7 +65,7 @@
 /** No size limit constant */
 #define STR_NO_LIMIT  ((size_t) -1)
 
-/** Maximum size of a string containing @c length characters */
+/** Maximum size of a string containing @c length code points */
 #define STR_BOUNDS(length)  ((length) << 2)
 
 extern wchar_t str_decode(const char *str, size_t *offset, size_t sz);

--- a/kernel/generic/include/str.h
+++ b/kernel/generic/include/str.h
@@ -71,17 +71,17 @@
 extern wchar_t str_decode(const char *str, size_t *offset, size_t sz);
 extern errno_t chr_encode(wchar_t ch, char *str, size_t *offset, size_t sz);
 
-extern size_t str_size(const char *str);
-extern size_t wstr_size(const wchar_t *str);
+extern size_t str_bytes(const char *str);
+extern size_t wstr_bytes(const wchar_t *str);
 
-extern size_t str_lsize(const char *str, size_t max_len);
-extern size_t wstr_lsize(const wchar_t *str, size_t max_len);
+extern size_t str_lbytes(const char *str, size_t max_len);
+extern size_t wstr_lbytes(const wchar_t *str, size_t max_len);
 
-extern size_t str_length(const char *str);
-extern size_t wstr_length(const wchar_t *wstr);
+extern size_t str_code_points(const char *str);
+extern size_t wstr_code_points(const wchar_t *wstr);
 
-extern size_t str_nlength(const char *str, size_t size);
-extern size_t wstr_nlength(const wchar_t *str, size_t size);
+extern size_t str_ncode_points(const char *str, size_t size);
+extern size_t wstr_ncode_points(const wchar_t *str, size_t size);
 
 extern bool ascii_check(wchar_t ch);
 extern bool chr_check(wchar_t ch);

--- a/kernel/generic/src/console/cmd.c
+++ b/kernel/generic/src/console/cmd.c
@@ -667,8 +667,8 @@ int cmd_help(cmd_arg_t *argv)
 	size_t len = 0;
 	list_foreach(cmd_list, link, cmd_info_t, hlp) {
 		spinlock_lock(&hlp->lock);
-		if (str_length(hlp->name) > len)
-			len = str_length(hlp->name);
+		if (str_code_points(hlp->name) > len)
+			len = str_code_points(hlp->name);
 		spinlock_unlock(&hlp->lock);
 	}
 
@@ -918,7 +918,7 @@ int cmd_desc(cmd_arg_t *argv)
 	list_foreach(cmd_list, link, cmd_info_t, hlp) {
 		spinlock_lock(&hlp->lock);
 
-		if (str_lcmp(hlp->name, (const char *) argv->buffer, str_length(hlp->name)) == 0) {
+		if (str_lcmp(hlp->name, (const char *) argv->buffer, str_code_points(hlp->name)) == 0) {
 			printf("%s - %s\n", hlp->name, hlp->description);
 			if (hlp->help)
 				hlp->help();
@@ -1485,8 +1485,8 @@ static void list_tests(void)
 	test_t *test;
 
 	for (test = tests; test->name != NULL; test++) {
-		if (str_length(test->name) > len)
-			len = str_length(test->name);
+		if (str_code_points(test->name) > len)
+			len = str_code_points(test->name);
 	}
 
 	unsigned int _len = (unsigned int) len;

--- a/kernel/generic/src/console/console.c
+++ b/kernel/generic/src/console/console.c
@@ -270,7 +270,7 @@ size_t gets(indev_t *indev, char *buf, size_t buflen)
 				putwchar('\b');
 
 				count--;
-				offset = str_lsize(buf, count);
+				offset = str_lbytes(buf, count);
 				buf[offset] = 0;
 			}
 		}

--- a/kernel/generic/src/debug/symtab.c
+++ b/kernel/generic/src/debug/symtab.c
@@ -119,7 +119,7 @@ const char *symtab_fmt_name_lookup(uintptr_t addr)
  */
 static const char *symtab_search_one(const char *name, size_t *startpos)
 {
-	size_t namelen = str_length(name);
+	size_t namelen = str_code_points(name);
 
 	size_t pos;
 	for (pos = *startpos; symbol_table[pos].address_le; pos++) {
@@ -130,12 +130,12 @@ static const char *symtab_search_one(const char *name, size_t *startpos)
 		if (colon == NULL)
 			continue;
 
-		if (str_length(curname) < namelen)
+		if (str_code_points(curname) < namelen)
 			continue;
 
 		if (str_lcmp(name, curname, namelen) == 0) {
 			*startpos = pos;
-			return (curname + str_lsize(curname, namelen));
+			return (curname + str_lbytes(curname, namelen));
 		}
 	}
 
@@ -163,7 +163,7 @@ errno_t symtab_addr_lookup(const char *name, uintptr_t *addr)
 	const char *hint;
 
 	while ((hint = symtab_search_one(name, &pos))) {
-		if (str_length(hint) == 0) {
+		if (str_code_points(hint) == 0) {
 			*addr = uint64_t_le2host(symbol_table[pos].address_le);
 			found++;
 		}
@@ -205,7 +205,7 @@ const char *symtab_hints_enum(const char *input, const char **help,
     void **ctx)
 {
 #ifdef CONFIG_SYMTAB
-	size_t len = str_length(input);
+	size_t len = str_code_points(input);
 	struct symtab_entry **entry = (struct symtab_entry **)ctx;
 
 	if (*entry == NULL)
@@ -219,14 +219,14 @@ const char *symtab_hints_enum(const char *input, const char **help,
 		if (colon == NULL)
 			continue;
 
-		if (str_length(curname) < len)
+		if (str_code_points(curname) < len)
 			continue;
 
 		if (str_lcmp(input, curname, len) == 0) {
 			(*entry)++;
 			if (help)
 				*help = NULL;
-			return (curname + str_lsize(curname, len));
+			return (curname + str_lbytes(curname, len));
 		}
 	}
 

--- a/kernel/generic/src/lib/str.c
+++ b/kernel/generic/src/lib/str.c
@@ -287,7 +287,7 @@ errno_t chr_encode(const wchar_t ch, char *str, size_t *offset, size_t size)
  * @return Number of bytes used by the string
  *
  */
-size_t str_size(const char *str)
+size_t str_bytes(const char *str)
 {
 	size_t size = 0;
 
@@ -307,9 +307,9 @@ size_t str_size(const char *str)
  * @return Number of bytes used by the wide string
  *
  */
-size_t wstr_size(const wchar_t *str)
+size_t wstr_bytes(const wchar_t *str)
 {
-	return (wstr_length(str) * sizeof(wchar_t));
+	return (wstr_code_points(str) * sizeof(wchar_t));
 }
 
 /** Get size of string with length limit.
@@ -325,7 +325,7 @@ size_t wstr_size(const wchar_t *str)
  * @return Number of bytes used by the characters.
  *
  */
-size_t str_lsize(const char *str, size_t max_len)
+size_t str_lbytes(const char *str, size_t max_len)
 {
 	size_t len = 0;
 	size_t offset = 0;
@@ -353,9 +353,9 @@ size_t str_lsize(const char *str, size_t max_len)
  * @return Number of bytes used by the wide characters.
  *
  */
-size_t wstr_lsize(const wchar_t *str, size_t max_len)
+size_t wstr_lbytes(const wchar_t *str, size_t max_len)
 {
-	return (wstr_nlength(str, max_len * sizeof(wchar_t)) * sizeof(wchar_t));
+	return (wstr_ncode_points(str, max_len * sizeof(wchar_t)) * sizeof(wchar_t));
 }
 
 /** Get number of characters in a string.
@@ -365,7 +365,7 @@ size_t wstr_lsize(const wchar_t *str, size_t max_len)
  * @return Number of characters in string.
  *
  */
-size_t str_length(const char *str)
+size_t str_code_points(const char *str)
 {
 	size_t len = 0;
 	size_t offset = 0;
@@ -383,7 +383,7 @@ size_t str_length(const char *str)
  * @return Number of characters in @a str.
  *
  */
-size_t wstr_length(const wchar_t *wstr)
+size_t wstr_code_points(const wchar_t *wstr)
 {
 	size_t len = 0;
 
@@ -401,7 +401,7 @@ size_t wstr_length(const wchar_t *wstr)
  * @return Number of characters in string.
  *
  */
-size_t str_nlength(const char *str, size_t size)
+size_t str_ncode_points(const char *str, size_t size)
 {
 	size_t len = 0;
 	size_t offset = 0;
@@ -420,7 +420,7 @@ size_t str_nlength(const char *str, size_t size)
  * @return Number of characters in string.
  *
  */
-size_t wstr_nlength(const wchar_t *str, size_t size)
+size_t wstr_ncode_points(const wchar_t *str, size_t size)
 {
 	size_t len = 0;
 	size_t limit = ALIGN_DOWN(size, sizeof(wchar_t));
@@ -507,7 +507,7 @@ int str_cmp(const char *s1, const char *s2)
  *
  * Do a char-by-char comparison of two NULL-terminated strings.
  * The strings are considered equal iff
- * min(str_length(s1), max_len) == min(str_length(s2), max_len)
+ * min(str_code_points(s1), max_len) == min(str_code_points(s2), max_len)
  * and both strings consist of the same sequence of characters,
  * up to max_len characters.
  *
@@ -689,7 +689,7 @@ char *str_chr(const char *str, wchar_t ch)
  */
 bool wstr_linsert(wchar_t *str, wchar_t ch, size_t pos, size_t max_pos)
 {
-	size_t len = wstr_length(str);
+	size_t len = wstr_code_points(str);
 
 	if ((pos > len) || (pos + 1 > max_pos))
 		return false;
@@ -717,7 +717,7 @@ bool wstr_linsert(wchar_t *str, wchar_t ch, size_t pos, size_t max_pos)
  */
 bool wstr_remove(wchar_t *str, size_t pos)
 {
-	size_t len = wstr_length(str);
+	size_t len = wstr_code_points(str);
 
 	if (pos >= len)
 		return false;
@@ -747,7 +747,7 @@ bool wstr_remove(wchar_t *str, size_t pos)
  */
 char *str_dup(const char *src)
 {
-	size_t size = str_size(src) + 1;
+	size_t size = str_bytes(src) + 1;
 	char *dest = malloc(size);
 	if (!dest)
 		return NULL;
@@ -778,7 +778,7 @@ char *str_dup(const char *src)
  */
 char *str_ndup(const char *src, size_t n)
 {
-	size_t size = str_size(src);
+	size_t size = str_bytes(src);
 	if (size > n)
 		size = n;
 

--- a/kernel/generic/src/lib/str.c
+++ b/kernel/generic/src/lib/str.c
@@ -40,7 +40,7 @@
  *
  * Strings and characters use the Universal Character Set (UCS). The standard
  * strings, called just strings are encoded in UTF-8. Wide strings (encoded
- * in UTF-32) are supported to a limited degree. A single character is
+ * in UTF-32) are supported to a limited degree. A single code point is
  * represented as wchar_t.@n
  *
  * Overview of the terminology:@n
@@ -49,7 +49,7 @@
  *  --------------------  ----------------------------------------------------
  *  byte                  8 bits stored in uint8_t (unsigned 8 bit integer)
  *
- *  character             UTF-32 encoded Unicode character, stored in wchar_t
+ *  character             UTF-32 encoded Unicode code point, stored in wchar_t
  *                        (signed 32 bit integer), code points 0 .. 1114111
  *                        are valid
  *
@@ -65,7 +65,7 @@
  *  [wide] string size    number of BYTES in a [wide] string (excluding
  *                        the NULL-terminator), size_t
  *
- *  [wide] string length  number of CHARACTERS in a [wide] string (excluding
+ *  [wide] string length  number of CODE POINTS in a [wide] string (excluding
  *                        the NULL-terminator), size_t
  *
  *  [wide] string width   number of display cells on a monospace display taken
@@ -79,7 +79,7 @@
  *  size    n        size_t   number of BYTES in a string (excluding the
  *                            NULL-terminator)
  *
- *  length  l        size_t   number of CHARACTERS in a string (excluding the
+ *  length  l        size_t   number of CODE POINTS in a string (excluding the
  *                            null terminator)
  *
  *  width  w         size_t   number of display cells on a monospace display
@@ -88,7 +88,7 @@
  *
  * Function naming prefixes:@n
  *
- *  chr_    operate on characters
+ *  chr_    operate on code points
  *  ascii_  operate on ASCII characters
  *  str_    operate on strings
  *  wstr_   operate on wide strings
@@ -101,7 +101,7 @@
  *
  *  pointer (char *, wchar_t *)
  *  byte offset (size_t)
- *  character index (size_t)
+ *  code point index (size_t)
  *
  */
 
@@ -136,18 +136,18 @@
 /** Number of data bits in a UTF-8 continuation byte */
 #define CONT_BITS  6
 
-/** Decode a single character from a string.
+/** Decode a single code point from an UTF-8 encoded string.
  *
- * Decode a single character from a string of size @a size. Decoding starts
+ * Decode a single code point from a string of size @a size. Decoding starts
  * at @a offset and this offset is moved to the beginning of the next
- * character. In case of decoding error, offset generally advances at least
+ * code point. In case of decoding error, offset generally advances at least
  * by one. However, offset is never moved beyond size.
  *
  * @param str    String (not necessarily NULL-terminated).
  * @param offset Byte offset in string where to start decoding.
  * @param size   Size of the string (in bytes).
  *
- * @return Value of decoded character, U_SPECIAL on decoding error or
+ * @return Value of decoded code point, U_SPECIAL on decoding error or
  *         NULL if attempt to decode beyond @a size.
  *
  */
@@ -206,19 +206,19 @@ wchar_t str_decode(const char *str, size_t *offset, size_t size)
 	return ch;
 }
 
-/** Encode a single character to string representation.
+/** Encode a single code point to a UTF-8 string representation.
  *
- * Encode a single character to string representation (i.e. UTF-8) and store
+ * Encode a single code point to a UTF-8 string representation and store
  * it into a buffer at @a offset. Encoding starts at @a offset and this offset
- * is moved to the position where the next character can be written to.
+ * is moved to the position where the next code point can be written to.
  *
- * @param ch     Input character.
+ * @param ch     Input code point.
  * @param str    Output buffer.
  * @param offset Byte offset where to start writing.
  * @param size   Size of the output buffer (in bytes).
  *
- * @return EOK if the character was encoded successfully, EOVERFLOW if there
- *         was not enough space in the output buffer or EINVAL if the character
+ * @return EOK if the code point was encoded successfully, EOVERFLOW if there
+ *         was not enough space in the output buffer or EINVAL if the code point
  *         code was invalid.
  */
 errno_t chr_encode(const wchar_t ch, char *str, size_t *offset, size_t size)
@@ -312,17 +312,17 @@ size_t wstr_bytes(const wchar_t *str)
 	return (wstr_code_points(str) * sizeof(wchar_t));
 }
 
-/** Get size of string with length limit.
+/** Get size of string with code point count limit.
  *
  * Get the number of bytes which are used by up to @a max_len first
- * characters in the string @a str. If @a max_len is greater than
- * the length of @a str, the entire string is measured (excluding the
- * NULL-terminator).
+ * code points in the string @a str. If @a max_len is greater than
+ * the number of code points in @a str, the entire string is measured
+ * (excluding the NULL-terminator).
  *
  * @param str     String to consider.
- * @param max_len Maximum number of characters to measure.
+ * @param max_len Maximum number of code points to measure.
  *
- * @return Number of bytes used by the characters.
+ * @return Number of bytes used by the code points.
  *
  */
 size_t str_lbytes(const char *str, size_t max_len)
@@ -343,14 +343,14 @@ size_t str_lbytes(const char *str, size_t max_len)
 /** Get size of wide string with length limit.
  *
  * Get the number of bytes which are used by up to @a max_len first
- * wide characters in the wide string @a str. If @a max_len is greater than
+ * code points in the wide string @a str. If @a max_len is greater than
  * the length of @a str, the entire wide string is measured (excluding the
  * NULL-terminator).
  *
  * @param str     Wide string to consider.
- * @param max_len Maximum number of wide characters to measure.
+ * @param max_len Maximum number of code points to measure.
  *
- * @return Number of bytes used by the wide characters.
+ * @return Number of bytes used by the code points.
  *
  */
 size_t wstr_lbytes(const wchar_t *str, size_t max_len)
@@ -358,11 +358,11 @@ size_t wstr_lbytes(const wchar_t *str, size_t max_len)
 	return (wstr_ncode_points(str, max_len * sizeof(wchar_t)) * sizeof(wchar_t));
 }
 
-/** Get number of characters in a string.
+/** Get number of unicode code points in a UTF-8 encoded string.
  *
- * @param str NULL-terminated string.
+ * @param str NULL-terminated UTF-8 string.
  *
- * @return Number of characters in string.
+ * @return Number of code points in the string.
  *
  */
 size_t str_code_points(const char *str)
@@ -376,11 +376,11 @@ size_t str_code_points(const char *str)
 	return len;
 }
 
-/** Get number of characters in a wide string.
+/** Get number of code points in a wide string.
  *
  * @param str NULL-terminated wide string.
  *
- * @return Number of characters in @a str.
+ * @return Number of code points in @a str.
  *
  */
 size_t wstr_code_points(const wchar_t *wstr)
@@ -393,12 +393,12 @@ size_t wstr_code_points(const wchar_t *wstr)
 	return len;
 }
 
-/** Get number of characters in a string with size limit.
+/** Get number of code points in a string with size limit.
  *
  * @param str  NULL-terminated string.
  * @param size Maximum number of bytes to consider.
  *
- * @return Number of characters in string.
+ * @return Number of code points in string.
  *
  */
 size_t str_ncode_points(const char *str, size_t size)
@@ -412,12 +412,12 @@ size_t str_ncode_points(const char *str, size_t size)
 	return len;
 }
 
-/** Get number of characters in a string with size limit.
+/** Get number of code points in a string with size limit.
  *
  * @param str  NULL-terminated string.
  * @param size Maximum number of bytes to consider.
  *
- * @return Number of characters in string.
+ * @return Number of code points in string.
  *
  */
 size_t wstr_ncode_points(const wchar_t *str, size_t size)
@@ -434,9 +434,9 @@ size_t wstr_ncode_points(const wchar_t *str, size_t size)
 	return len;
 }
 
-/** Check whether character is plain ASCII.
+/** Check whether code point is plain ASCII.
  *
- * @return True if character is plain ASCII.
+ * @return True if code point is plain ASCII.
  *
  */
 bool ascii_check(wchar_t ch)
@@ -447,9 +447,9 @@ bool ascii_check(wchar_t ch)
 	return false;
 }
 
-/** Check whether character is valid
+/** Check whether code point is valid
  *
- * @return True if character is a valid Unicode code point.
+ * @return True if code point is a valid Unicode code point.
  *
  */
 bool chr_check(wchar_t ch)
@@ -464,12 +464,12 @@ bool chr_check(wchar_t ch)
  *
  * Do a char-by-char comparison of two NULL-terminated strings.
  * The strings are considered equal iff their length is equal
- * and both strings consist of the same sequence of characters.
+ * and both strings consist of the same sequence of code points.
  *
- * A string S1 is less than another string S2 if it has a character with
- * lower value at the first character position where the strings differ.
+ * A string S1 is less than another string S2 if it has a code point with
+ * lower value at the first code point position where the strings differ.
  * If the strings differ in length, the shorter one is treated as if
- * padded by characters with a value of zero.
+ * padded by code points with a value of zero.
  *
  * @param s1 First string to compare.
  * @param s2 Second string to compare.
@@ -508,18 +508,18 @@ int str_cmp(const char *s1, const char *s2)
  * Do a char-by-char comparison of two NULL-terminated strings.
  * The strings are considered equal iff
  * min(str_code_points(s1), max_len) == min(str_code_points(s2), max_len)
- * and both strings consist of the same sequence of characters,
- * up to max_len characters.
+ * and both strings consist of the same sequence of code points,
+ * up to max_len code points.
  *
- * A string S1 is less than another string S2 if it has a character with
- * lower value at the first character position where the strings differ.
+ * A string S1 is less than another string S2 if it has a code point with
+ * lower value at the first code point position where the strings differ.
  * If the strings differ in length, the shorter one is treated as if
- * padded by characters with a value of zero. Only the first max_len
- * characters are considered.
+ * padded by code points with a value of zero. Only the first max_len
+ * code points are considered.
  *
  * @param s1      First string to compare.
  * @param s2      Second string to compare.
- * @param max_len Maximum number of characters to consider.
+ * @param max_len Maximum number of code points to consider.
  *
  * @return 0 if the strings are equal, -1 if the first is less than the second,
  *         1 if the second is less than the first.
@@ -563,7 +563,7 @@ int str_lcmp(const char *s1, const char *s2, size_t max_len)
  * Copy source string @a src to destination buffer @a dest.
  * No more than @a size bytes are written. If the size of the output buffer
  * is at least one byte, the output string will always be well-formed, i.e.
- * null-terminated and containing only complete characters.
+ * null-terminated and containing only complete code points.
  *
  * @param dest  Destination buffer.
  * @param count Size of the destination buffer (must be > 0).
@@ -593,7 +593,7 @@ void str_cpy(char *dest, size_t size, const char *src)
  * Copy prefix of string @a src of max. size @a size to destination buffer
  * @a dest. No more than @a size bytes are written. The output string will
  * always be well-formed, i.e. null-terminated and containing only complete
- * characters.
+ * code points.
  *
  * No more than @a n bytes are read from the input string, so it does not
  * have to be null-terminated.
@@ -651,12 +651,12 @@ void wstr_to_str(char *dest, size_t size, const wchar_t *src)
 	dest[dest_off] = '\0';
 }
 
-/** Find first occurence of character in string.
+/** Find first occurence of code point in string.
  *
  * @param str String to search.
- * @param ch  Character to look for.
+ * @param ch  code point to look for.
  *
- * @return Pointer to character in @a str or NULL if not found.
+ * @return Pointer to code point in @a str or NULL if not found.
  */
 char *str_chr(const char *str, wchar_t ch)
 {
@@ -673,15 +673,15 @@ char *str_chr(const char *str, wchar_t ch)
 	return NULL;
 }
 
-/** Insert a wide character into a wide string.
+/** Insert a code point into a wide string.
  *
- * Insert a wide character into a wide string at position
- * @a pos. The characters after the position are shifted.
+ * Insert a code point into a wide string at position
+ * @a pos. The code points after the position are shifted.
  *
  * @param str     String to insert to.
- * @param ch      Character to insert to.
- * @param pos     Character index where to insert.
- * @param max_pos Characters in the buffer.
+ * @param ch      Code point to insert.
+ * @param pos     Code point index where to insert.
+ * @param max_pos Number of code points that fit in the buffer.
  *
  * @return True if the insertion was sucessful, false if the position
  *         is out of bounds.
@@ -703,13 +703,13 @@ bool wstr_linsert(wchar_t *str, wchar_t ch, size_t pos, size_t max_pos)
 	return true;
 }
 
-/** Remove a wide character from a wide string.
+/** Remove a code point from a wide string.
  *
- * Remove a wide character from a wide string at position
- * @a pos. The characters after the position are shifted.
+ * Remove a code point from a wide string at position
+ * @a pos. The code points after the position are shifted.
  *
  * @param str String to remove from.
- * @param pos Character index to remove.
+ * @param pos Code point index to remove.
  *
  * @return True if the removal was sucessful, false if the position
  *         is out of bounds.
@@ -731,18 +731,16 @@ bool wstr_remove(wchar_t *str, size_t pos)
 
 /** Duplicate string.
  *
- * Allocate a new string and copy characters from the source
- * string into it. The duplicate string is allocated via sleeping
- * malloc(), thus this function can sleep in no memory conditions.
+ * Allocate a new string and copy the contents of the source string into it.
+ * The duplicate string is allocated as if by malloc().
  *
- * The allocation cannot fail and the return value is always
- * a valid pointer. The duplicate string is always a well-formed
+ * If successful, the duplicate string is always a well-formed
  * null-terminated UTF-8 string, but it can differ from the source
  * string on the byte level.
  *
  * @param src Source string.
  *
- * @return Duplicate string.
+ * @return Duplicate string, or NULL if allocation failed.
  *
  */
 char *str_dup(const char *src)
@@ -759,14 +757,12 @@ char *str_dup(const char *src)
 /** Duplicate string with size limit.
  *
  * Allocate a new string and copy up to @max_size bytes from the source
- * string into it. The duplicate string is allocated via sleeping
- * malloc(), thus this function can sleep in no memory conditions.
+ * string into it. The duplicate string is allocated as if by malloc().
  * No more than @max_size + 1 bytes is allocated, but if the size
  * occupied by the source string is smaller than @max_size + 1,
  * less is allocated.
  *
- * The allocation cannot fail and the return value is always
- * a valid pointer. The duplicate string is always a well-formed
+ * If successful, the duplicate string is always a well-formed
  * null-terminated UTF-8 string, but it can differ from the source
  * string on the byte level.
  *

--- a/kernel/generic/src/main/kinit.c
+++ b/kernel/generic/src/main/kinit.c
@@ -192,11 +192,11 @@ void kinit(void *arg)
 	// but pass them directly to the tasks
 	for (i = 0; i < init.cnt; i++) {
 		const char *arguments = init.tasks[i].arguments;
-		if (str_length(arguments) == 0)
+		if (str_code_points(arguments) == 0)
 			continue;
-		if (str_length(init.tasks[i].name) == 0)
+		if (str_code_points(init.tasks[i].name) == 0)
 			continue;
-		size_t arguments_size = str_size(arguments);
+		size_t arguments_size = str_bytes(arguments);
 
 		void *arguments_copy = malloc(arguments_size);
 		if (arguments_copy == NULL)

--- a/kernel/generic/src/main/main.c
+++ b/kernel/generic/src/main/main.c
@@ -278,7 +278,7 @@ void main_bsp_separated_stack(void)
 	thread_init();
 	sys_waitq_init();
 
-	sysinfo_set_item_data("boot_args", NULL, bargs, str_size(bargs) + 1);
+	sysinfo_set_item_data("boot_args", NULL, bargs, str_bytes(bargs) + 1);
 
 	if (init.cnt > 0) {
 		size_t i;

--- a/kernel/generic/src/printf/printf_core.c
+++ b/kernel/generic/src/printf/printf_core.c
@@ -155,9 +155,9 @@ static int printf_wputnchars(const wchar_t *buf, size_t size,
 static int printf_putstr(const char *str, printf_spec_t *ps)
 {
 	if (str == NULL)
-		return printf_putnchars(nullstr, str_size(nullstr), ps);
+		return printf_putnchars(nullstr, str_bytes(nullstr), ps);
 
-	return ps->str_write((void *) str, str_size(str), ps->data);
+	return ps->str_write((void *) str, str_bytes(str), ps->data);
 }
 
 /** Print one ASCII character.
@@ -284,7 +284,7 @@ static int print_str(char *str, int width, unsigned int precision,
 		return printf_putstr(nullstr, ps);
 
 	/* Print leading spaces. */
-	size_t strw = str_length(str);
+	size_t strw = str_code_points(str);
 	if ((precision == 0) || (precision > strw))
 		precision = strw;
 
@@ -300,7 +300,7 @@ static int print_str(char *str, int width, unsigned int precision,
 
 	/* Part of @a str fitting into the alloted space. */
 	int retval;
-	size_t size = str_lsize(str, precision);
+	size_t size = str_lbytes(str, precision);
 	if ((retval = printf_putnchars(str, size, ps)) < 0)
 		return -counter;
 
@@ -332,7 +332,7 @@ static int print_wstr(wchar_t *str, int width, unsigned int precision,
 		return printf_putstr(nullstr, ps);
 
 	/* Print leading spaces. */
-	size_t strw = wstr_length(str);
+	size_t strw = wstr_code_points(str);
 	if ((precision == 0) || (precision > strw))
 		precision = strw;
 
@@ -348,7 +348,7 @@ static int print_wstr(wchar_t *str, int width, unsigned int precision,
 
 	/* Part of @a wstr fitting into the alloted space. */
 	int retval;
-	size_t size = wstr_lsize(str, precision);
+	size_t size = wstr_lbytes(str, precision);
 	if ((retval = printf_wputnchars(str, size, ps)) < 0)
 		return -counter;
 

--- a/kernel/generic/src/sysinfo/sysinfo.c
+++ b/kernel/generic/src/sysinfo/sysinfo.c
@@ -529,11 +529,11 @@ NO_TRACE static void sysinfo_dump_internal(sysinfo_item_t *root, size_t spaces)
 
 		if (spaces == 0) {
 			printf("%s", cur->name);
-			length = str_length(cur->name);
+			length = str_code_points(cur->name);
 		} else {
 			sysinfo_indent(spaces);
 			printf(".%s", cur->name);
-			length = str_length(cur->name) + 1;
+			length = str_code_points(cur->name) + 1;
 		}
 
 		sysarg_t val;
@@ -746,7 +746,7 @@ NO_TRACE static sysinfo_return_t sysinfo_get_keys(const char *name,
 		 */
 		size_t size = 0;
 		for (sysinfo_item_t *cur = subtree; cur; cur = cur->next)
-			size += str_size(cur->name) + 1;
+			size += str_bytes(cur->name) + 1;
 
 		if (dry_run) {
 			ret.tag = SYSINFO_VAL_DATA;
@@ -761,7 +761,7 @@ NO_TRACE static sysinfo_return_t sysinfo_get_keys(const char *name,
 			size_t pos = 0;
 			for (sysinfo_item_t *cur = subtree; cur; cur = cur->next) {
 				str_cpy(names + pos, size - pos, cur->name);
-				pos += str_size(cur->name) + 1;
+				pos += str_bytes(cur->name) + 1;
 			}
 
 			/* Correct return value */

--- a/kernel/generic/src/udebug/udebug_ops.c
+++ b/kernel/generic/src/udebug/udebug_ops.c
@@ -431,7 +431,7 @@ errno_t udebug_thread_read(void **buffer, size_t buf_size, size_t *stored,
  */
 errno_t udebug_name_read(char **data, size_t *data_size)
 {
-	size_t name_size = str_size(TASK->name) + 1;
+	size_t name_size = str_bytes(TASK->name) + 1;
 
 	*data = malloc(name_size);
 	if (!*data)

--- a/kernel/test/test.c
+++ b/kernel/test/test.c
@@ -65,7 +65,7 @@ test_t tests[] = {
 const char *tests_hints_enum(const char *input, const char **help,
     void **ctx)
 {
-	size_t len = str_length(input);
+	size_t len = str_code_points(input);
 	test_t **test = (test_t **) ctx;
 
 	if (*test == NULL)
@@ -74,14 +74,14 @@ const char *tests_hints_enum(const char *input, const char **help,
 	for (; (*test)->name; (*test)++) {
 		const char *curname = (*test)->name;
 
-		if (str_length(curname) < len)
+		if (str_code_points(curname) < len)
 			continue;
 
 		if (str_lcmp(input, curname, len) == 0) {
 			(*test)++;
 			if (help)
 				*help = (*test)->desc;
-			return (curname + str_lsize(curname, len));
+			return (curname + str_lbytes(curname, len));
 		}
 	}
 

--- a/uspace/app/bdsh/cmds/modules/cp/cp.c
+++ b/uspace/app/bdsh/cmds/modules/cp/cp.c
@@ -187,7 +187,7 @@ static errno_t do_copy(const char *src, const char *dest,
 	dentry_type_t src_type = get_type(src);
 	dentry_type_t dest_type = get_type(dest);
 
-	const size_t src_len = str_size(src);
+	const size_t src_len = str_bytes(src);
 
 	if (src_type == TYPE_FILE) {
 		char *src_fname;
@@ -213,7 +213,7 @@ static errno_t do_copy(const char *src, const char *dest,
 			merge_paths(dest_path, PATH_MAX, src_fname);
 			dest_type = get_type(dest_path);
 		} else if (dest_type == TYPE_NONE) {
-			if (dest_path[str_size(dest_path) - 1] == '/') {
+			if (dest_path[str_bytes(dest_path) - 1] == '/') {
 				/* e.g. cp /textdemo /data/dirnotexists/ */
 
 				printf("The dest directory %s does not exists",

--- a/uspace/app/bdsh/cmds/modules/ls/ls.c
+++ b/uspace/app/bdsh/cmds/modules/ls/ls.c
@@ -173,13 +173,13 @@ static signed int ls_scan_dir(const char *d, DIR *dirp,
 		}
 
 		/* fill the name field */
-		tosort[nbdirs].name = (char *) malloc(str_size(dp->d_name) + 1);
+		tosort[nbdirs].name = (char *) malloc(str_bytes(dp->d_name) + 1);
 		if (!tosort[nbdirs].name) {
 			cli_error(CL_ENOMEM, "ls: failed to scan %s", d);
 			goto out;
 		}
 
-		str_cpy(tosort[nbdirs].name, str_size(dp->d_name) + 1, dp->d_name);
+		str_cpy(tosort[nbdirs].name, str_bytes(dp->d_name) + 1, dp->d_name);
 		len = snprintf(buff, PATH_MAX - 1, "%s/%s", d, tosort[nbdirs].name);
 		buff[len] = '\0';
 
@@ -263,13 +263,13 @@ static unsigned int ls_recursive(const char *path, DIR *dirp)
 	for (i = 0; i < nbdirs; ++i) {
 		memset(subdir_path, 0, PATH_MAX);
 
-		if (str_size(subdir_path) + str_size(path) + 1 <= PATH_MAX)
+		if (str_bytes(subdir_path) + str_bytes(path) + 1 <= PATH_MAX)
 			str_append(subdir_path, PATH_MAX, path);
-		if (path[str_size(path) - 1] != '/' &&
-		    str_size(subdir_path) + str_size(trailing_slash) + 1 <= PATH_MAX)
+		if (path[str_bytes(path) - 1] != '/' &&
+		    str_bytes(subdir_path) + str_bytes(trailing_slash) + 1 <= PATH_MAX)
 			str_append(subdir_path, PATH_MAX, trailing_slash);
-		if (str_size(subdir_path) +
-		    str_size(dir_list[i].name) + 1 <= PATH_MAX)
+		if (str_bytes(subdir_path) +
+		    str_bytes(dir_list[i].name) + 1 <= PATH_MAX)
 			str_append(subdir_path, PATH_MAX, dir_list[i].name);
 
 		scope = ls_scope(subdir_path, &dir_list[i]);

--- a/uspace/app/bdsh/cmds/modules/printf/printf.c
+++ b/uspace/app/bdsh/cmds/modules/printf/printf.c
@@ -134,7 +134,7 @@ int cmd_printf(char **argv)
 	}
 
 	fmt = argv[1];
-	fmt_sz = str_size(fmt);
+	fmt_sz = str_bytes(fmt);
 	pos = 0;
 	carg = 2;
 

--- a/uspace/app/bdsh/cmds/modules/rm/rm.c
+++ b/uspace/app/bdsh/cmds/modules/rm/rm.c
@@ -301,7 +301,7 @@ int cmd_rm(char **argv)
 
 	i = optind;
 	while (NULL != argv[i]) {
-		len = str_size(argv[i]) + 2;
+		len = str_bytes(argv[i]) + 2;
 		buff = (char *) realloc(buff, len);
 		if (buff == NULL) {
 			printf("rm: out of memory\n");

--- a/uspace/app/bdsh/compl.c
+++ b/uspace/app/bdsh/compl.c
@@ -159,7 +159,7 @@ static errno_t compl_init(wchar_t *text, size_t pos, size_t *cstart, void **stat
 	 * Extract the prefix being completed
 	 * XXX: handle strings, etc.
 	 */
-	pref_size = str_lsize(stext, pos - *cstart);
+	pref_size = str_lbytes(stext, pos - *cstart);
 	prefix = malloc(pref_size + 1);
 	if (prefix == NULL) {
 		retval = ENOMEM;
@@ -236,7 +236,7 @@ static errno_t compl_init(wchar_t *text, size_t pos, size_t *cstart, void **stat
 		cs->path = &dirlist_arg[0];
 	}
 
-	cs->prefix_len = str_length(cs->prefix);
+	cs->prefix_len = str_code_points(cs->prefix);
 
 	tok_fini(&tok);
 

--- a/uspace/app/bdsh/tok.c
+++ b/uspace/app/bdsh/tok.c
@@ -64,7 +64,7 @@ errno_t tok_init(tokenizer_t *tok, char *input, token_t *out_tokens,
 	tok->outtok_size = max_tokens;
 
 	/* Prepare a buffer where all the token strings will be stored */
-	size_t len = str_size(input) + max_tokens + 1;
+	size_t len = str_bytes(input) + max_tokens + 1;
 	char *tmp = malloc(len);
 
 	if (tmp == NULL) {

--- a/uspace/app/date/date.c
+++ b/uspace/app/date/date.c
@@ -202,7 +202,7 @@ read_date_from_arg(char *wdate, struct tm *t)
 	errno_t rc;
 	uint32_t tmp;
 
-	if (str_size(wdate) != 10) /* str_size("DD/MM/YYYY") == 10 */
+	if (str_bytes(wdate) != 10) /* str_bytes("DD/MM/YYYY") == 10 */
 		return EINVAL;
 
 	if (wdate[2] != '/' ||
@@ -235,12 +235,12 @@ static errno_t
 read_time_from_arg(char *wtime, struct tm *t)
 {
 	errno_t rc;
-	size_t len = str_size(wtime);
+	size_t len = str_bytes(wtime);
 	bool sec_present = len == 8;
 	uint32_t tmp;
 
-	/* str_size("HH:MM") == 5 */
-	/* str_size("HH:MM:SS") == 8 */
+	/* str_bytes("HH:MM") == 5 */
+	/* str_bytes("HH:MM:SS") == 8 */
 	if (len != 8 && len != 5)
 		return EINVAL;
 

--- a/uspace/app/edit/edit.c
+++ b/uspace/app/edit/edit.c
@@ -636,14 +636,14 @@ static char *prompt(char const *prompt, char const *init_value)
 
 	asprintf(&str, "%s: %s", prompt, init_value);
 	status_display(str);
-	console_set_pos(con, 1 + str_length(str), scr_rows - 1);
+	console_set_pos(con, 1 + str_code_points(str), scr_rows - 1);
 	free(str);
 
 	console_set_style(con, STYLE_INVERTED);
 
-	max_len = min(INFNAME_MAX_LEN, scr_columns - 4 - str_length(prompt));
+	max_len = min(INFNAME_MAX_LEN, scr_columns - 4 - str_code_points(prompt));
 	str_to_wstr(buffer, max_len + 1, init_value);
-	nc = wstr_length(buffer);
+	nc = wstr_code_points(buffer);
 	done = false;
 
 	while (!done) {
@@ -746,7 +746,7 @@ static errno_t file_save_range(char const *fname, spt_t const *spos,
 
 	do {
 		sheet_copy_out(doc.sh, &sp, epos, buf, BUF_SIZE, &bep);
-		bytes = str_size(buf);
+		bytes = str_bytes(buf);
 
 		n_written = fwrite(buf, 1, bytes, f);
 		if (n_written != bytes) {
@@ -782,7 +782,7 @@ static char *range_get_str(spt_t const *spos, spt_t const *epos)
 	while (true) {
 		sheet_copy_out(doc.sh, &sp, epos, &buf[bpos], buf_size - bpos,
 		    &bep);
-		bytes = str_size(&buf[bpos]);
+		bytes = str_bytes(&buf[bpos]);
 		bpos += bytes;
 		sp = bep;
 
@@ -892,7 +892,7 @@ static void pane_row_range_display(int r0, int r1)
 		}
 
 		console_set_pos(con, 0, i);
-		size = str_size(row_buf);
+		size = str_bytes(row_buf);
 		pos = 0;
 		s_column = pane.sh_column;
 		while (pos < size) {
@@ -1011,7 +1011,7 @@ static void pane_status_display(void)
 
 		/* Compute position where we overwrite with '..\0' */
 		if (fnw >= nextra + 2) {
-			p = fname + str_lsize(fname, fnw - nextra - 2);
+			p = fname + str_lbytes(fname, fnw - nextra - 2);
 		} else {
 			p = fname;
 		}
@@ -1608,7 +1608,7 @@ static bool pt_is_word_beginning(spt_t *pt)
 static wchar_t get_first_wchar(const char *str)
 {
 	size_t offset = 0;
-	return str_decode(str, &offset, str_size(str));
+	return str_decode(str, &offset, str_bytes(str));
 }
 
 static bool pt_is_delimiter(spt_t *pt)

--- a/uspace/app/edit/search.c
+++ b/uspace/app/edit/search.c
@@ -55,7 +55,7 @@ search_t *search_init(const char *pattern, void *client_data, search_ops_t ops,
 		return NULL;
 	}
 
-	search->pattern_length = wstr_length(p);
+	search->pattern_length = wstr_code_points(p);
 
 	if (reverse) {
 		/* Reverse the pattern */

--- a/uspace/app/edit/sheet.c
+++ b/uspace/app/edit/sheet.c
@@ -106,7 +106,7 @@ errno_t sheet_insert(sheet_t *sh, spt_t *pos, enum dir_spec dir, char *str)
 	size_t sz;
 	char *newp;
 
-	sz = str_size(str);
+	sz = str_bytes(str);
 	if (sh->text_size + sz > sh->dbuf_size) {
 		/* Enlarge data buffer. */
 		newp = realloc(sh->data, sh->dbuf_size * 2);

--- a/uspace/app/fdisk/fdisk.c
+++ b/uspace/app/fdisk/fdisk.c
@@ -616,7 +616,7 @@ static errno_t fdsk_add_part_choices(fdisk_dev_t *dev,
 				goto error;
 			}
 
-			if (str_size(pinfo.label) > 0)
+			if (str_bytes(pinfo.label) > 0)
 				label = pinfo.label;
 			else
 				label = "(No name)";
@@ -1009,7 +1009,7 @@ static errno_t fdsk_dev_menu(fdisk_dev_t *dev)
 			goto error;
 		}
 
-		if (str_size(pinfo.label) > 0)
+		if (str_bytes(pinfo.label) > 0)
 			label = pinfo.label;
 		else
 			label = "(No name)";

--- a/uspace/app/hbench/env.c
+++ b/uspace/app/hbench/env.c
@@ -48,13 +48,13 @@ typedef struct {
 static size_t param_hash(const ht_link_t *item)
 {
 	param_t *param = hash_table_get_inst(item, param_t, link);
-	return str_size(param->key);
+	return str_bytes(param->key);
 }
 
 static size_t param_key_hash(void *key)
 {
 	char *key_str = key;
-	return str_size(key_str);
+	return str_bytes(key_str);
 }
 
 static bool param_key_equal(void *key, const ht_link_t *item)

--- a/uspace/app/hbench/main.c
+++ b/uspace/app/hbench/main.c
@@ -290,7 +290,7 @@ static void list_benchmarks(void)
 {
 	size_t len = 0;
 	for (size_t i = 0; i < benchmark_count; i++) {
-		size_t len_now = str_length(benchmarks[i]->name);
+		size_t len_now = str_code_points(benchmarks[i]->name);
 		if (len_now > len)
 			len = len_now;
 	}

--- a/uspace/app/kio/kio.c
+++ b/uspace/app/kio/kio.c
@@ -244,7 +244,7 @@ int main(int argc, char *argv[])
 			continue;
 		}
 
-		kio_command(str, str_size(str));
+		kio_command(str, str_bytes(str));
 		free(str);
 	}
 

--- a/uspace/app/lprint/lprint.c
+++ b/uspace/app/lprint/lprint.c
@@ -99,7 +99,7 @@ static errno_t lprint_msg(chardev_t *chardev, int argc, char *argv[])
 		--argc;
 		++argv;
 
-		rc = chardev_write(chardev, msg, str_size(msg), &nbytes);
+		rc = chardev_write(chardev, msg, str_bytes(msg), &nbytes);
 		if (rc != EOK) {
 			printf(NAME ": Failed sending data.\n");
 			return EIO;
@@ -107,7 +107,7 @@ static errno_t lprint_msg(chardev_t *chardev, int argc, char *argv[])
 
 		sep = argc > 0 ? " " : "\n";
 
-		rc = chardev_write(chardev, sep, str_size(sep), &nbytes);
+		rc = chardev_write(chardev, sep, str_bytes(sep), &nbytes);
 		if (rc != EOK) {
 			printf(NAME ": Failed sending data.\n");
 			return EIO;

--- a/uspace/app/netecho/netecho.c
+++ b/uspace/app/netecho/netecho.c
@@ -138,7 +138,7 @@ static void netecho_send_messages(char **msgs)
 	errno_t rc;
 
 	while (*msgs != NULL) {
-		rc = comm_send(*msgs, str_size(*msgs));
+		rc = comm_send(*msgs, str_bytes(*msgs));
 		if (rc != EOK) {
 			printf("[Failed sending data]\n");
 		}

--- a/uspace/app/nic/nic.c
+++ b/uspace/app/nic/nic.c
@@ -451,7 +451,7 @@ static errno_t nic_set_addr(int i, char *str)
 		return EINVAL;
 	}
 
-	if (str_size(str) != 17) {
+	if (str_bytes(str) != 17) {
 		printf("Invalid MAC address specified");
 		return EINVAL;
 	}

--- a/uspace/app/sbi/src/builtin/bi_string.c
+++ b/uspace/app/sbi/src/builtin/bi_string.c
@@ -85,7 +85,7 @@ static void bi_string_length(run_t *run)
 	self_value_var = builtin_get_self_mbr_var(run, "Value");
 	assert(self_value_var->vc == vc_string);
 	str = self_value_var->u.string_v->value;
-	str_l = os_str_length(str);
+	str_l = os_str_code_points(str);
 
 #ifdef DEBUG_RUN_TRACE
 	printf("Get length of string '%s'.\n", str);
@@ -130,7 +130,7 @@ static void bi_string_slice(run_t *run)
 	self_value_var = builtin_get_self_mbr_var(run, "Value");
 	assert(self_value_var->vc == vc_string);
 	str = self_value_var->u.string_v->value;
-	str_l = os_str_length(str);
+	str_l = os_str_code_points(str);
 
 	/* Get argument @a start. */
 	start_var = run_local_vars_lookup(run, strtab_get_sid("start"));

--- a/uspace/app/sbi/src/lex.c
+++ b/uspace/app/sbi/src/lex.c
@@ -596,7 +596,7 @@ static void lex_char(lex_t *lex)
 
 	lex_char_string_core(lex, cs_chr);
 
-	len = os_str_length(strlit_buf);
+	len = os_str_code_points(strlit_buf);
 	if (len != 1) {
 		printf("Character literal should contain one character, "
 		    "but contains %u characters instead.\n", (unsigned) len);

--- a/uspace/app/sbi/src/os/helenos.c
+++ b/uspace/app/sbi/src/os/helenos.c
@@ -59,8 +59,8 @@ char *os_str_acat(const char *a, const char *b)
 	int a_size, b_size;
 	char *str;
 
-	a_size = str_size(a);
-	b_size = str_size(b);
+	a_size = str_bytes(a);
+	b_size = str_bytes(b);
 
 	str = malloc(a_size + b_size + 1);
 	if (str == NULL) {
@@ -95,7 +95,7 @@ char *os_str_aslice(const char *str, size_t start, size_t length)
 	size_t size;
 	wchar_t c;
 
-	assert(start + length <= str_length(str));
+	assert(start + length <= str_code_points(str));
 
 	offset = 0;
 	for (i = 0; i < start; ++i) {
@@ -105,7 +105,7 @@ char *os_str_aslice(const char *str, size_t start, size_t length)
 		(void) c;
 	}
 
-	size = str_lsize(str, length);
+	size = str_lbytes(str, length);
 	slice = str_ndup(str + offset, size);
 
 	return slice;
@@ -127,9 +127,9 @@ int os_str_cmp(const char *a, const char *b)
  * @param str	String
  * @return	Number of characters in @a str.
  */
-size_t os_str_length(const char *str)
+size_t os_str_code_points(const char *str)
 {
-	return str_length(str);
+	return str_code_points(str);
 }
 
 /** Duplicate string.

--- a/uspace/app/sbi/src/os/os.h
+++ b/uspace/app/sbi/src/os/os.h
@@ -35,7 +35,7 @@ char *os_str_acat(const char *a, const char *b);
 char *os_str_aslice(const char *str, size_t start, size_t length);
 int os_str_cmp(const char *a, const char *b);
 char *os_str_dup(const char *str);
-size_t os_str_length(const char *str);
+size_t os_str_code_points(const char *str);
 errno_t os_str_get_char(const char *str, int index, int *out_char);
 char *os_chr_to_astr(wchar_t chr);
 void os_input_disp_help(void);

--- a/uspace/app/sbi/src/os/posix.c
+++ b/uspace/app/sbi/src/os/posix.c
@@ -123,7 +123,7 @@ errno_t os_str_cmp(const char *a, const char *b)
  * @param str	String
  * @return	Number of characters in @a str.
  */
-size_t os_str_length(const char *str)
+size_t os_str_code_points(const char *str)
 {
 	return strlen(str);
 }

--- a/uspace/app/sportdmp/sportdmp.c
+++ b/uspace/app/sportdmp/sportdmp.c
@@ -53,9 +53,9 @@ int main(int argc, char **argv)
 	errno_t rc;
 
 	if (argc > arg && str_test_prefix(argv[arg], "--baud=")) {
-		size_t arg_offset = str_lsize(argv[arg], 7);
+		size_t arg_offset = str_lbytes(argv[arg], 7);
 		char *arg_str = argv[arg] + arg_offset;
-		if (str_length(arg_str) == 0) {
+		if (str_code_points(arg_str) == 0) {
 			fprintf(stderr, "--baud requires an argument\n");
 			syntax_print();
 			return 1;

--- a/uspace/app/sysinfo/sysinfo.c
+++ b/uspace/app/sysinfo/sysinfo.c
@@ -128,11 +128,11 @@ static void print_keys(const char *path, size_t spaces)
 	size_t pos = 0;
 	while (pos < size) {
 		/* Process each key with sanity checks */
-		size_t cur_size = str_nsize(keys + pos, size - pos);
+		size_t cur_size = str_nbytes(keys + pos, size - pos);
 		if (keys[pos + cur_size] != 0)
 			break;
 
-		size_t path_size = str_size(path) + cur_size + 2;
+		size_t path_size = str_bytes(path) + cur_size + 2;
 		char *cur_path = (char *) malloc(path_size);
 		if (cur_path == NULL)
 			break;
@@ -142,12 +142,12 @@ static void print_keys(const char *path, size_t spaces)
 		if (path[0] != 0) {
 			print_spaces(spaces);
 			printf(".%s\n", keys + pos);
-			length = str_length(keys + pos) + 1;
+			length = str_code_points(keys + pos) + 1;
 
 			snprintf(cur_path, path_size, "%s.%s", path, keys + pos);
 		} else {
 			printf("%s\n", keys + pos);
-			length = str_length(keys + pos);
+			length = str_code_points(keys + pos);
 
 			snprintf(cur_path, path_size, "%s", keys + pos);
 		}

--- a/uspace/app/taskdump/elf_core.c
+++ b/uspace/app/taskdump/elf_core.c
@@ -176,7 +176,7 @@ errno_t elf_core_save(const char *file_name, as_area_info_t *ainfo, unsigned int
 	p_hdr[0].p_vaddr = 0;
 	p_hdr[0].p_paddr = 0;
 	p_hdr[0].p_filesz = sizeof(elf_note_t) +
-	    ALIGN_UP((str_size("CORE") + 1), word_size) +
+	    ALIGN_UP((str_bytes("CORE") + 1), word_size) +
 	    ALIGN_UP(sizeof(elf_prstatus_t), word_size);
 	p_hdr[0].p_memsz = 0;
 	p_hdr[0].p_flags = 0;
@@ -229,7 +229,7 @@ errno_t elf_core_save(const char *file_name, as_area_info_t *ainfo, unsigned int
 	/*
 	 * Write note header
 	 */
-	note.namesz = str_size("CORE") + 1;
+	note.namesz = str_bytes("CORE") + 1;
 	note.descsz = sizeof(elf_prstatus_t);
 	note.type = NT_PRSTATUS;
 

--- a/uspace/app/tester/hw/serial/serial1.c
+++ b/uspace/app/tester/hw/serial/serial1.c
@@ -197,7 +197,7 @@ const char *test_serial1(void)
 
 	TPRINTF("Trying to write EOT banner to the serial device\n");
 
-	size_t eot_size = str_size(EOT);
+	size_t eot_size = str_bytes(EOT);
 	rc = chardev_write(chardev, (void *) EOT, eot_size, &nwritten);
 
 	(void) serial_set_comm_props(serial, old_baud, old_par, old_word_size,

--- a/uspace/app/tester/tester.c
+++ b/uspace/app/tester/tester.c
@@ -141,8 +141,8 @@ static void list_tests(void)
 	size_t len = 0;
 	test_t *test;
 	for (test = tests; test->name != NULL; test++) {
-		if (str_length(test->name) > len)
-			len = str_length(test->name);
+		if (str_code_points(test->name) > len)
+			len = str_code_points(test->name);
 	}
 
 	assert(can_cast_size_t_to_int(len) && "test name length overflow");

--- a/uspace/app/tetris/screen.c
+++ b/uspace/app/tetris/screen.c
@@ -320,7 +320,7 @@ void scr_update(void)
  */
 void scr_msg(char *s, bool set)
 {
-	int l = str_size(s);
+	int l = str_bytes(s);
 
 	moveto(Rows - 2, ((Cols - l) >> 1) - 1);
 

--- a/uspace/app/tetris/tetris.c
+++ b/uspace/app/tetris/tetris.c
@@ -267,7 +267,7 @@ int main(int argc, char *argv[])
 			classic = 1;
 			break;
 		case 'k':
-			if (str_size(keys = optarg) != 6)
+			if (str_bytes(keys = optarg) != 6)
 				usage();
 			break;
 		case 'p':

--- a/uspace/app/tmon/tests.c
+++ b/uspace/app/tmon/tests.c
@@ -129,9 +129,9 @@ static void print_params(const usbdiag_test_params_t *params)
 	free(str_min_duration);
 
 	if (params->transfer_size) {
-		char *str_size = tmon_format_size(params->transfer_size, "%.3f %s");
-		printf("Transfer size: %s\n", str_size);
-		free(str_size);
+		char *str_bytes = tmon_format_size(params->transfer_size, "%.3f %s");
+		printf("Transfer size: %s\n", str_bytes);
+		free(str_bytes);
 	} else {
 		printf("Transfer size: (max. transfer size)\n");
 	}

--- a/uspace/app/usbinfo/list.c
+++ b/uspace/app/usbinfo/list.c
@@ -97,7 +97,7 @@ static void print_usb_bus(service_id_t svc)
 
 	/* Get handle of parent device */
 	devman_handle_t fh;
-	path[str_size(path) - str_size(name) - 1] = '\0';
+	path[str_bytes(path) - str_bytes(name) - 1] = '\0';
 	rc = devman_fun_get_handle(path, &fh, IPC_FLAG_BLOCKING);
 	if (rc != EOK) {
 		printf(NAME ": Error resolving parent handle of HC with"

--- a/uspace/app/wavplay/wave.c
+++ b/uspace/app/wavplay/wave.c
@@ -150,7 +150,7 @@ errno_t wav_parse_header(const void *hdata, const void **data, size_t *data_size
 void wav_init_header(wave_header_t *header, pcm_format_t format, size_t size)
 {
 	assert(header);
-#define COPY_STR(dst, src)   memcpy(dst, src, str_size(src))
+#define COPY_STR(dst, src)   memcpy(dst, src, str_bytes(src))
 
 	COPY_STR(&header->chunk_id, CHUNK_ID);
 	COPY_STR(&header->format, FORMAT_STR);

--- a/uspace/app/websrv/websrv.c
+++ b/uspace/app/websrv/websrv.c
@@ -226,7 +226,7 @@ static bool uri_is_valid(char *uri)
 
 static errno_t send_response(tcp_conn_t *conn, const char *msg)
 {
-	size_t response_size = str_size(msg);
+	size_t response_size = str_bytes(msg);
 
 	if (verbose)
 		fprintf(stderr, "Sending response\n");
@@ -321,7 +321,7 @@ static errno_t req_process(tcp_conn_t *conn, recv_t *recv)
 	char *uri = reqline + 4;
 	char *end_uri = str_chr(uri, ' ');
 	if (end_uri == NULL) {
-		end_uri = reqline + str_size(reqline) - 2;
+		end_uri = reqline + str_bytes(reqline) - 2;
 		assert(*end_uri == '\r');
 	}
 

--- a/uspace/dist/src/c/demos/edit/edit.c
+++ b/uspace/dist/src/c/demos/edit/edit.c
@@ -636,14 +636,14 @@ static char *prompt(char const *prompt, char const *init_value)
 
 	asprintf(&str, "%s: %s", prompt, init_value);
 	status_display(str);
-	console_set_pos(con, 1 + str_length(str), scr_rows - 1);
+	console_set_pos(con, 1 + str_code_points(str), scr_rows - 1);
 	free(str);
 
 	console_set_style(con, STYLE_INVERTED);
 
-	max_len = min(INFNAME_MAX_LEN, scr_columns - 4 - str_length(prompt));
+	max_len = min(INFNAME_MAX_LEN, scr_columns - 4 - str_code_points(prompt));
 	str_to_wstr(buffer, max_len + 1, init_value);
-	nc = wstr_length(buffer);
+	nc = wstr_code_points(buffer);
 	done = false;
 
 	while (!done) {
@@ -746,7 +746,7 @@ static errno_t file_save_range(char const *fname, spt_t const *spos,
 
 	do {
 		sheet_copy_out(doc.sh, &sp, epos, buf, BUF_SIZE, &bep);
-		bytes = str_size(buf);
+		bytes = str_bytes(buf);
 
 		n_written = fwrite(buf, 1, bytes, f);
 		if (n_written != bytes) {
@@ -782,7 +782,7 @@ static char *range_get_str(spt_t const *spos, spt_t const *epos)
 	while (true) {
 		sheet_copy_out(doc.sh, &sp, epos, &buf[bpos], buf_size - bpos,
 		    &bep);
-		bytes = str_size(&buf[bpos]);
+		bytes = str_bytes(&buf[bpos]);
 		bpos += bytes;
 		sp = bep;
 
@@ -892,7 +892,7 @@ static void pane_row_range_display(int r0, int r1)
 		}
 
 		console_set_pos(con, 0, i);
-		size = str_size(row_buf);
+		size = str_bytes(row_buf);
 		pos = 0;
 		s_column = pane.sh_column;
 		while (pos < size) {
@@ -1011,7 +1011,7 @@ static void pane_status_display(void)
 
 		/* Compute position where we overwrite with '..\0' */
 		if (fnw >= nextra + 2) {
-			p = fname + str_lsize(fname, fnw - nextra - 2);
+			p = fname + str_lbytes(fname, fnw - nextra - 2);
 		} else {
 			p = fname;
 		}
@@ -1608,7 +1608,7 @@ static bool pt_is_word_beginning(spt_t *pt)
 static wchar_t get_first_wchar(const char *str)
 {
 	size_t offset = 0;
-	return str_decode(str, &offset, str_size(str));
+	return str_decode(str, &offset, str_bytes(str));
 }
 
 static bool pt_is_delimiter(spt_t *pt)

--- a/uspace/dist/src/c/demos/edit/search.c
+++ b/uspace/dist/src/c/demos/edit/search.c
@@ -54,7 +54,7 @@ search_t *search_init(const char *pattern, void *client_data, search_ops_t ops,
 		return NULL;
 	}
 
-	search->pattern_length = wstr_length(p);
+	search->pattern_length = wstr_code_points(p);
 
 	if (reverse) {
 		/* Reverse the pattern */

--- a/uspace/dist/src/c/demos/edit/sheet.c
+++ b/uspace/dist/src/c/demos/edit/sheet.c
@@ -106,7 +106,7 @@ errno_t sheet_insert(sheet_t *sh, spt_t *pos, enum dir_spec dir, char *str)
 	size_t sz;
 	char *newp;
 
-	sz = str_size(str);
+	sz = str_bytes(str);
 	if (sh->text_size + sz > sh->dbuf_size) {
 		/* Enlarge data buffer. */
 		newp = realloc(sh->data, sh->dbuf_size * 2);

--- a/uspace/dist/src/c/demos/tetris/screen.c
+++ b/uspace/dist/src/c/demos/tetris/screen.c
@@ -320,7 +320,7 @@ void scr_update(void)
  */
 void scr_msg(char *s, bool set)
 {
-	int l = str_size(s);
+	int l = str_bytes(s);
 
 	moveto(Rows - 2, ((Cols - l) >> 1) - 1);
 

--- a/uspace/dist/src/c/demos/tetris/tetris.c
+++ b/uspace/dist/src/c/demos/tetris/tetris.c
@@ -269,7 +269,7 @@ int main(int argc, char *argv[])
 			classic = 1;
 			break;
 		case 'k':
-			if (str_size(keys = optarg) != 6)
+			if (str_bytes(keys = optarg) != 6)
 				usage();
 			break;
 		case 'p':

--- a/uspace/drv/bus/isa/isa.c
+++ b/uspace/drv/bus/isa/isa.c
@@ -588,7 +588,7 @@ static void fun_parse_match_id(isa_fun_t *fun, const char *val)
 static bool prop_parse(isa_fun_t *fun, const char *line, const char *prop,
     void (*read_fn)(isa_fun_t *, const char *))
 {
-	size_t proplen = str_size(prop);
+	size_t proplen = str_bytes(prop);
 
 	if (str_lcmp(line, prop, proplen) == 0) {
 		line += proplen;

--- a/uspace/lib/bithenge/src/linux/common.h
+++ b/uspace/lib/bithenge/src/linux/common.h
@@ -66,7 +66,7 @@ static inline bool string_iterator_done(const string_iterator_t *i)
 	return !**i;
 }
 
-static inline size_t str_length(const char *string)
+static inline size_t str_code_points(const char *string)
 {
 	return strlen(string);
 }

--- a/uspace/lib/bithenge/src/source.c
+++ b/uspace/lib/bithenge/src/source.c
@@ -59,7 +59,7 @@ static inline int hex_digit(char digit)
 
 static errno_t blob_from_hex(bithenge_node_t **out, const char *hex)
 {
-	size_t size = str_length(hex);
+	size_t size = str_code_points(hex);
 	if (size % 2)
 		return EINVAL;
 	size /= 2;

--- a/uspace/lib/bithenge/src/transform.c
+++ b/uspace/lib/bithenge/src/transform.c
@@ -285,7 +285,7 @@ errno_t bithenge_scope_error(bithenge_scope_t *scope, const char *format, ...)
 		} else {
 			const char *end = str_chr(format, '%');
 			if (!end)
-				end = format + str_length(format);
+				end = format + str_code_points(format);
 			size_t size = min((size_t)(end - format),
 			    space_left - 1);
 			memcpy(out, format, size);

--- a/uspace/lib/c/generic/arg_parse.c
+++ b/uspace/lib/c/generic/arg_parse.c
@@ -39,8 +39,8 @@ int arg_parse_short_long(const char *arg, const char *ashort, const char *along)
 	if (str_cmp(arg, ashort) == 0)
 		return 0;
 
-	if (str_lcmp(arg, along, str_length(along)) == 0)
-		return str_length(along);
+	if (str_lcmp(arg, along, str_code_points(along)) == 0)
+		return str_code_points(along);
 
 	return -1;
 }

--- a/uspace/lib/c/generic/cap.c
+++ b/uspace/lib/c/generic/cap.c
@@ -284,8 +284,8 @@ errno_t cap_parse(const char *str, cap_spec_t *cap)
 	} else {
 		for (i = 0; i < CU_LIMIT; i++) {
 			if (str_lcasecmp(eptr, cu_str[i],
-			    str_length(cu_str[i])) == 0) {
-				p = eptr + str_size(cu_str[i]);
+			    str_code_points(cu_str[i])) == 0) {
+				p = eptr + str_bytes(cu_str[i]);
 				while (*p == ' ')
 					++p;
 				if (*p == '\0')

--- a/uspace/lib/c/generic/clipboard.c
+++ b/uspace/lib/c/generic/clipboard.c
@@ -99,7 +99,7 @@ static void clip_exchange_end(async_exch_t *exch)
  */
 errno_t clipboard_put_str(const char *str)
 {
-	size_t size = str_size(str);
+	size_t size = str_bytes(str);
 
 	if (size == 0) {
 		async_exch_t *exch = clip_exchange_begin();

--- a/uspace/lib/c/generic/devman.c
+++ b/uspace/lib/c/generic/devman.c
@@ -181,7 +181,7 @@ errno_t devman_driver_register(const char *name)
 
 	ipc_call_t answer;
 	aid_t req = async_send_2(exch, DEVMAN_DRIVER_REGISTER, 0, 0, &answer);
-	errno_t retval = async_data_write_start(exch, name, str_size(name));
+	errno_t retval = async_data_write_start(exch, name, str_bytes(name));
 
 	devman_exchange_end(exch);
 
@@ -221,7 +221,7 @@ errno_t devman_add_function(const char *name, fun_type_t ftype,
 	ipc_call_t answer;
 	aid_t req = async_send_3(exch, DEVMAN_ADD_FUNCTION, (sysarg_t) ftype,
 	    devh, match_count, &answer);
-	errno_t retval = async_data_write_start(exch, name, str_size(name));
+	errno_t retval = async_data_write_start(exch, name, str_bytes(name));
 	if (retval != EOK) {
 		devman_exchange_end(exch);
 		async_forget(req);
@@ -233,7 +233,7 @@ errno_t devman_add_function(const char *name, fun_type_t ftype,
 		aid_t req2 = async_send_1(exch, DEVMAN_ADD_MATCH_ID,
 		    match_id->score, &answer2);
 		retval = async_data_write_start(exch, match_id->id,
-		    str_size(match_id->id));
+		    str_bytes(match_id->id));
 		if (retval != EOK) {
 			devman_exchange_end(exch);
 			async_forget(req2);
@@ -272,7 +272,7 @@ errno_t devman_add_device_to_category(devman_handle_t devman_handle,
 	aid_t req = async_send_1(exch, DEVMAN_ADD_DEVICE_TO_CATEGORY,
 	    devman_handle, &answer);
 	errno_t retval = async_data_write_start(exch, cat_name,
-	    str_size(cat_name));
+	    str_bytes(cat_name));
 
 	devman_exchange_end(exch);
 
@@ -374,7 +374,7 @@ errno_t devman_fun_get_handle(const char *pathname, devman_handle_t *handle,
 	aid_t req = async_send_2(exch, DEVMAN_DEVICE_GET_HANDLE, flags, 0,
 	    &answer);
 	errno_t retval = async_data_write_start(exch, pathname,
-	    str_size(pathname));
+	    str_bytes(pathname));
 
 	devman_exchange_end(exch);
 
@@ -643,7 +643,7 @@ errno_t devman_driver_get_handle(const char *drvname, devman_handle_t *handle)
 	ipc_call_t answer;
 	aid_t req = async_send_0(exch, DEVMAN_DRIVER_GET_HANDLE, &answer);
 	errno_t retval = async_data_write_start(exch, drvname,
-	    str_size(drvname));
+	    str_bytes(drvname));
 
 	devman_exchange_end(exch);
 

--- a/uspace/lib/c/generic/dnsr.c
+++ b/uspace/lib/c/generic/dnsr.c
@@ -74,7 +74,7 @@ errno_t dnsr_name2host(const char *name, dnsr_hostinfo_t **rinfo, ip_ver_t ver)
 	aid_t req = async_send_1(exch, DNSR_NAME2HOST, (sysarg_t) ver,
 	    &answer);
 
-	errno_t rc = async_data_write_start(exch, name, str_size(name));
+	errno_t rc = async_data_write_start(exch, name, str_bytes(name));
 	if (rc != EOK) {
 		async_exchange_end(exch);
 		async_forget(req);

--- a/uspace/lib/c/generic/getopt.c
+++ b/uspace/lib/c/generic/getopt.c
@@ -365,15 +365,15 @@ int getopt_long(int nargc, char *const *nargv, const char *options,
 			current_argv_len = has_equal - current_argv;
 			has_equal++;
 		} else
-			current_argv_len = str_size(current_argv);
+			current_argv_len = str_bytes(current_argv);
 
 		for (i = 0; long_options[i].name; i++) {
 			/* find matching long option */
 			if (str_lcmp(current_argv, long_options[i].name,
-			    str_nlength(current_argv, current_argv_len)))
+			    str_ncode_points(current_argv, current_argv_len)))
 				continue;
 
-			if (str_size(long_options[i].name) ==
+			if (str_bytes(long_options[i].name) ==
 			    (unsigned)current_argv_len) {
 				/* exact match */
 				match = i;

--- a/uspace/lib/c/generic/inetcfg.c
+++ b/uspace/lib/c/generic/inetcfg.c
@@ -148,7 +148,7 @@ errno_t inetcfg_addr_create_static(const char *name, inet_naddr_t *naddr,
 		return rc;
 	}
 
-	rc = async_data_write_start(exch, name, str_size(name));
+	rc = async_data_write_start(exch, name, str_bytes(name));
 
 	async_exchange_end(exch);
 
@@ -233,7 +233,7 @@ errno_t inetcfg_addr_get_id(const char *name, sysarg_t link_id, sysarg_t *addr_i
 
 	ipc_call_t answer;
 	aid_t req = async_send_1(exch, INETCFG_ADDR_GET_ID, link_id, &answer);
-	errno_t retval = async_data_write_start(exch, name, str_size(name));
+	errno_t retval = async_data_write_start(exch, name, str_bytes(name));
 
 	async_exchange_end(exch);
 
@@ -346,7 +346,7 @@ errno_t inetcfg_sroute_create(const char *name, inet_naddr_t *dest,
 		return rc;
 	}
 
-	rc = async_data_write_start(exch, name, str_size(name));
+	rc = async_data_write_start(exch, name, str_bytes(name));
 
 	async_exchange_end(exch);
 
@@ -443,7 +443,7 @@ errno_t inetcfg_sroute_get_id(const char *name, sysarg_t *sroute_id)
 
 	ipc_call_t answer;
 	aid_t req = async_send_0(exch, INETCFG_SROUTE_GET_ID, &answer);
-	errno_t retval = async_data_write_start(exch, name, str_size(name));
+	errno_t retval = async_data_write_start(exch, name, str_bytes(name));
 
 	async_exchange_end(exch);
 

--- a/uspace/lib/c/generic/io/asprintf.c
+++ b/uspace/lib/c/generic/io/asprintf.c
@@ -42,15 +42,15 @@
 
 static int asprintf_str_write(const char *str, size_t count, void *unused)
 {
-	return str_nlength(str, count);
+	return str_ncode_points(str, count);
 }
 
 static int asprintf_wstr_write(const wchar_t *str, size_t count, void *unused)
 {
-	return wstr_nlength(str, count);
+	return wstr_ncode_points(str, count);
 }
 
-int vprintf_length(const char *fmt, va_list args)
+int vprintf_code_points(const char *fmt, va_list args)
 {
 	printf_spec_t ps = {
 		asprintf_str_write,
@@ -61,11 +61,11 @@ int vprintf_length(const char *fmt, va_list args)
 	return printf_core(fmt, &ps, args);
 }
 
-int printf_length(const char *fmt, ...)
+int printf_code_points(const char *fmt, ...)
 {
 	va_list args;
 	va_start(args, fmt);
-	int ret = vprintf_length(fmt, args);
+	int ret = vprintf_code_points(fmt, args);
 	va_end(args);
 
 	return ret;

--- a/uspace/lib/c/generic/io/io.c
+++ b/uspace/lib/c/generic/io/io.c
@@ -773,7 +773,7 @@ int putchar(int c)
 
 int fputs(const char *str, FILE *stream)
 {
-	(void) fwrite(str, str_size(str), 1, stream);
+	(void) fwrite(str, str_bytes(str), 1, stream);
 	if (ferror(stream))
 		return EOF;
 	return 0;

--- a/uspace/lib/c/generic/io/kio.c
+++ b/uspace/lib/c/generic/io/kio.c
@@ -136,7 +136,7 @@ static int kio_vprintf_str_write(const char *str, size_t size, void *data)
 
 	wr = 0;
 	(void) kio_write(str, size, &wr);
-	return str_nlength(str, wr);
+	return str_ncode_points(str, wr);
 }
 
 static int kio_vprintf_wstr_write(const wchar_t *str, size_t size, void *data)

--- a/uspace/lib/c/generic/io/log.c
+++ b/uspace/lib/c/generic/io/log.c
@@ -88,7 +88,7 @@ static errno_t logger_message(async_sess_t *session, log_t log, log_level_t leve
 
 	aid_t reg_msg = async_send_2(exchange, LOGGER_WRITER_MESSAGE,
 	    log, level, NULL);
-	errno_t rc = async_data_write_start(exchange, message, str_size(message));
+	errno_t rc = async_data_write_start(exchange, message, str_bytes(message));
 	errno_t reg_msg_rc;
 	async_wait_for(reg_msg, &reg_msg_rc);
 
@@ -143,7 +143,7 @@ errno_t log_level_from_str(const char *name, log_level_t *level_out)
 	/* Maybe user specified number directly. */
 	char *end_ptr;
 	int level_int = strtol(name, &end_ptr, 0);
-	if ((end_ptr == name) || (str_length(end_ptr) != 0))
+	if ((end_ptr == name) || (str_code_points(end_ptr) != 0))
 		return EINVAL;
 	if (level_int < 0)
 		return ERANGE;
@@ -198,7 +198,7 @@ log_t log_create(const char *name, log_t parent)
 	ipc_call_t answer;
 	aid_t reg_msg = async_send_1(exchange, LOGGER_WRITER_CREATE_LOG,
 	    parent, &answer);
-	errno_t rc = async_data_write_start(exchange, name, str_size(name));
+	errno_t rc = async_data_write_start(exchange, name, str_bytes(name));
 	errno_t reg_msg_rc;
 	async_wait_for(reg_msg, &reg_msg_rc);
 

--- a/uspace/lib/c/generic/io/logctl.c
+++ b/uspace/lib/c/generic/io/logctl.c
@@ -109,7 +109,7 @@ errno_t logctl_set_log_level(const char *logname, log_level_t new_level)
 
 	aid_t reg_msg = async_send_1(exchange, LOGGER_CONTROL_SET_LOG_LEVEL,
 	    new_level, NULL);
-	rc = async_data_write_start(exchange, logname, str_size(logname));
+	rc = async_data_write_start(exchange, logname, str_bytes(logname));
 	errno_t reg_msg_rc;
 	async_wait_for(reg_msg, &reg_msg_rc);
 

--- a/uspace/lib/c/generic/io/printf_core.c
+++ b/uspace/lib/c/generic/io/printf_core.c
@@ -203,9 +203,9 @@ static int printf_wputnchars(const wchar_t *buf, size_t size,
 static int printf_putstr(const char *str, printf_spec_t *ps)
 {
 	if (str == NULL)
-		return printf_putnchars(nullstr, str_size(nullstr), ps);
+		return printf_putnchars(nullstr, str_bytes(nullstr), ps);
 
-	return ps->str_write((void *) str, str_size(str), ps->data);
+	return ps->str_write((void *) str, str_bytes(str), ps->data);
 }
 
 /** Print one ASCII character.
@@ -331,7 +331,7 @@ static int print_str(char *str, int width, unsigned int precision,
 	if (str == NULL)
 		return printf_putstr(nullstr, ps);
 
-	size_t strw = str_length(str);
+	size_t strw = str_code_points(str);
 
 	/* Precision unspecified - print everything. */
 	if ((precision == 0) || (precision > strw))
@@ -349,7 +349,7 @@ static int print_str(char *str, int width, unsigned int precision,
 
 	/* Part of @a str fitting into the alloted space. */
 	int retval;
-	size_t size = str_lsize(str, precision);
+	size_t size = str_lbytes(str, precision);
 	if ((retval = printf_putnchars(str, size, ps)) < 0)
 		return -counter;
 
@@ -380,7 +380,7 @@ static int print_wstr(wchar_t *str, int width, unsigned int precision,
 	if (str == NULL)
 		return printf_putstr(nullstr, ps);
 
-	size_t strw = wstr_length(str);
+	size_t strw = wstr_code_points(str);
 
 	/* Precision not specified - print everything. */
 	if ((precision == 0) || (precision > strw))
@@ -398,7 +398,7 @@ static int print_wstr(wchar_t *str, int width, unsigned int precision,
 
 	/* Part of @a wstr fitting into the alloted space. */
 	int retval;
-	size_t size = wstr_lsize(str, precision);
+	size_t size = wstr_lbytes(str, precision);
 	if ((retval = printf_wputnchars(str, size, ps)) < 0)
 		return -counter;
 

--- a/uspace/lib/c/generic/io/vprintf.c
+++ b/uspace/lib/c/generic/io/vprintf.c
@@ -44,7 +44,7 @@ static FIBRIL_MUTEX_INITIALIZE(printf_mutex);
 static int vprintf_str_write(const char *str, size_t size, void *stream)
 {
 	size_t wr = fwrite(str, 1, size, (FILE *) stream);
-	return str_nlength(str, wr);
+	return str_ncode_points(str, wr);
 }
 
 static int vprintf_wstr_write(const wchar_t *str, size_t size, void *stream)

--- a/uspace/lib/c/generic/loader.c
+++ b/uspace/lib/c/generic/loader.c
@@ -56,7 +56,7 @@
 errno_t loader_spawn(const char *name)
 {
 	return (errno_t) __SYSCALL2(SYS_PROGRAM_SPAWN_LOADER,
-	    (sysarg_t) name, str_size(name));
+	    (sysarg_t) name, str_bytes(name));
 }
 
 loader_t *loader_connect(void)
@@ -124,7 +124,7 @@ errno_t loader_set_cwd(loader_t *ldr)
 	if (vfs_cwd_get(cwd, MAX_PATH_LEN + 1) != EOK)
 		str_cpy(cwd, MAX_PATH_LEN + 1, "/");
 
-	size_t len = str_length(cwd);
+	size_t len = str_code_points(cwd);
 
 	async_exch_t *exch = async_exchange_begin(ldr->sess);
 
@@ -160,7 +160,7 @@ errno_t loader_set_program(loader_t *ldr, const char *name, int file)
 	ipc_call_t answer;
 	aid_t req = async_send_0(exch, LOADER_SET_PROGRAM, &answer);
 
-	errno_t rc = async_data_write_start(exch, name, str_size(name) + 1);
+	errno_t rc = async_data_write_start(exch, name, str_bytes(name) + 1);
 	if (rc == EOK) {
 		async_exch_t *vfs_exch = vfs_exchange_begin();
 		rc = vfs_pass_handle(vfs_exch, file, exch);
@@ -225,7 +225,7 @@ errno_t loader_set_args(loader_t *ldr, const char *const argv[])
 	const char *const *ap = argv;
 	size_t buffer_size = 0;
 	while (*ap != NULL) {
-		buffer_size += str_size(*ap) + 1;
+		buffer_size += str_bytes(*ap) + 1;
 		ap++;
 	}
 
@@ -239,7 +239,7 @@ errno_t loader_set_args(loader_t *ldr, const char *const argv[])
 
 	while (*ap != NULL) {
 		str_cpy(dp, buffer_size - (dp - arg_buf), *ap);
-		dp += str_size(*ap) + 1;
+		dp += str_bytes(*ap) + 1;
 		ap++;
 	}
 
@@ -279,7 +279,7 @@ errno_t loader_add_inbox(loader_t *ldr, const char *name, int file)
 
 	aid_t req = async_send_0(exch, LOADER_ADD_INBOX, NULL);
 
-	errno_t rc = async_data_write_start(exch, name, str_size(name) + 1);
+	errno_t rc = async_data_write_start(exch, name, str_bytes(name) + 1);
 	if (rc == EOK) {
 		rc = vfs_pass_handle(vfs_exch, file, exch);
 	}

--- a/uspace/lib/c/generic/loc.c
+++ b/uspace/lib/c/generic/loc.c
@@ -245,7 +245,7 @@ errno_t loc_server_register(const char *name)
 
 	ipc_call_t answer;
 	aid_t req = async_send_2(exch, LOC_SERVER_REGISTER, 0, 0, &answer);
-	errno_t retval = async_data_write_start(exch, name, str_size(name));
+	errno_t retval = async_data_write_start(exch, name, str_bytes(name));
 
 	if (retval != EOK) {
 		async_forget(req);
@@ -278,7 +278,7 @@ errno_t loc_service_register(const char *fqsn, service_id_t *sid)
 
 	ipc_call_t answer;
 	aid_t req = async_send_0(exch, LOC_SERVICE_REGISTER, &answer);
-	errno_t retval = async_data_write_start(exch, fqsn, str_size(fqsn));
+	errno_t retval = async_data_write_start(exch, fqsn, str_bytes(fqsn));
 
 	if (retval != EOK) {
 		async_forget(req);
@@ -339,7 +339,7 @@ errno_t loc_service_get_id(const char *fqdn, service_id_t *handle,
 	ipc_call_t answer;
 	aid_t req = async_send_2(exch, LOC_SERVICE_GET_ID, flags, 0,
 	    &answer);
-	errno_t retval = async_data_write_start(exch, fqdn, str_size(fqdn));
+	errno_t retval = async_data_write_start(exch, fqdn, str_bytes(fqdn));
 
 	loc_exchange_end(exch);
 
@@ -472,7 +472,7 @@ errno_t loc_namespace_get_id(const char *name, service_id_t *handle,
 	ipc_call_t answer;
 	aid_t req = async_send_2(exch, LOC_NAMESPACE_GET_ID, flags, 0,
 	    &answer);
-	errno_t retval = async_data_write_start(exch, name, str_size(name));
+	errno_t retval = async_data_write_start(exch, name, str_bytes(name));
 
 	loc_exchange_end(exch);
 
@@ -521,7 +521,7 @@ errno_t loc_category_get_id(const char *name, category_id_t *cat_id,
 	ipc_call_t answer;
 	aid_t req = async_send_0(exch, LOC_CATEGORY_GET_ID,
 	    &answer);
-	errno_t retval = async_data_write_start(exch, name, str_size(name));
+	errno_t retval = async_data_write_start(exch, name, str_bytes(name));
 
 	loc_exchange_end(exch);
 

--- a/uspace/lib/c/generic/rtld/module.c
+++ b/uspace/lib/c/generic/rtld/module.c
@@ -195,7 +195,7 @@ module_t *module_load(rtld_t *rtld, const char *name, mlflags_t flags)
 	if ((flags & mlf_local) != 0)
 		m->local = true;
 
-	if (str_size(name) > NAME_BUF_SIZE - 2) {
+	if (str_bytes(name) > NAME_BUF_SIZE - 2) {
 		printf("soname too long. increase NAME_BUF_SIZE\n");
 		exit(1);
 	}

--- a/uspace/lib/c/generic/str.c
+++ b/uspace/lib/c/generic/str.c
@@ -331,7 +331,7 @@ errno_t chr_encode(const wchar_t ch, char *str, size_t *offset, size_t size)
  * @return Number of bytes used by the string
  *
  */
-size_t str_size(const char *str)
+size_t str_bytes(const char *str)
 {
 	size_t size = 0;
 
@@ -351,9 +351,9 @@ size_t str_size(const char *str)
  * @return Number of bytes used by the wide string
  *
  */
-size_t wstr_size(const wchar_t *str)
+size_t wstr_bytes(const wchar_t *str)
 {
-	return (wstr_length(str) * sizeof(wchar_t));
+	return (wstr_code_points(str) * sizeof(wchar_t));
 }
 
 /** Get size of string with length limit.
@@ -369,7 +369,7 @@ size_t wstr_size(const wchar_t *str)
  * @return Number of bytes used by the characters.
  *
  */
-size_t str_lsize(const char *str, size_t max_len)
+size_t str_lbytes(const char *str, size_t max_len)
 {
 	size_t len = 0;
 	size_t offset = 0;
@@ -395,7 +395,7 @@ size_t str_lsize(const char *str, size_t max_len)
  * @return Number of bytes used by the string
  *
  */
-size_t str_nsize(const char *str, size_t max_size)
+size_t str_nbytes(const char *str, size_t max_size)
 {
 	size_t size = 0;
 
@@ -416,9 +416,9 @@ size_t str_nsize(const char *str, size_t max_size)
  * @return Number of bytes used by the wide string
  *
  */
-size_t wstr_nsize(const wchar_t *str, size_t max_size)
+size_t wstr_nbytes(const wchar_t *str, size_t max_size)
 {
-	return (wstr_nlength(str, max_size) * sizeof(wchar_t));
+	return (wstr_ncode_points(str, max_size) * sizeof(wchar_t));
 }
 
 /** Get size of wide string with length limit.
@@ -434,9 +434,9 @@ size_t wstr_nsize(const wchar_t *str, size_t max_size)
  * @return Number of bytes used by the wide characters.
  *
  */
-size_t wstr_lsize(const wchar_t *str, size_t max_len)
+size_t wstr_lbytes(const wchar_t *str, size_t max_len)
 {
-	return (wstr_nlength(str, max_len * sizeof(wchar_t)) * sizeof(wchar_t));
+	return (wstr_ncode_points(str, max_len * sizeof(wchar_t)) * sizeof(wchar_t));
 }
 
 /** Get number of characters in a string.
@@ -446,7 +446,7 @@ size_t wstr_lsize(const wchar_t *str, size_t max_len)
  * @return Number of characters in string.
  *
  */
-size_t str_length(const char *str)
+size_t str_code_points(const char *str)
 {
 	size_t len = 0;
 	size_t offset = 0;
@@ -464,7 +464,7 @@ size_t str_length(const char *str)
  * @return Number of characters in @a str.
  *
  */
-size_t wstr_length(const wchar_t *wstr)
+size_t wstr_code_points(const wchar_t *wstr)
 {
 	size_t len = 0;
 
@@ -482,7 +482,7 @@ size_t wstr_length(const wchar_t *wstr)
  * @return Number of characters in string.
  *
  */
-size_t str_nlength(const char *str, size_t size)
+size_t str_ncode_points(const char *str, size_t size)
 {
 	size_t len = 0;
 	size_t offset = 0;
@@ -501,7 +501,7 @@ size_t str_nlength(const char *str, size_t size)
  * @return Number of characters in string.
  *
  */
-size_t wstr_nlength(const wchar_t *str, size_t size)
+size_t wstr_ncode_points(const wchar_t *str, size_t size)
 {
 	size_t len = 0;
 	size_t limit = ALIGN_DOWN(size, sizeof(wchar_t));
@@ -615,7 +615,7 @@ int str_cmp(const char *s1, const char *s2)
  *
  * Do a char-by-char comparison of two NULL-terminated strings.
  * The strings are considered equal iff
- * min(str_length(s1), max_len) == min(str_length(s2), max_len)
+ * min(str_code_points(s1), max_len) == min(str_code_points(s2), max_len)
  * and both strings consist of the same sequence of characters,
  * up to max_len characters.
  *
@@ -715,7 +715,7 @@ int str_casecmp(const char *s1, const char *s2)
  *
  * Do a char-by-char comparison of two NULL-terminated strings.
  * The strings are considered equal iff
- * min(str_length(s1), max_len) == min(str_length(s2), max_len)
+ * min(str_code_points(s1), max_len) == min(str_code_points(s2), max_len)
  * and both strings consist of the same sequence of characters,
  * up to max_len characters.
  *
@@ -878,13 +878,13 @@ void str_ncpy(char *dest, size_t size, const char *src, size_t n)
  */
 void str_append(char *dest, size_t size, const char *src)
 {
-	size_t dstr_size;
+	size_t dstr_bytes;
 
-	dstr_size = str_size(dest);
-	if (dstr_size >= size)
+	dstr_bytes = str_bytes(dest);
+	if (dstr_bytes >= size)
 		return;
 
-	str_cpy(dest + dstr_size, size - dstr_size, src);
+	str_cpy(dest + dstr_bytes, size - dstr_bytes, src);
 }
 
 /** Convert space-padded ASCII to string.
@@ -1177,7 +1177,7 @@ void str_to_wstr(wchar_t *dest, size_t dlen, const char *src)
  */
 wchar_t *str_to_awstr(const char *str)
 {
-	size_t len = str_length(str);
+	size_t len = str_code_points(str);
 
 	wchar_t *wstr = calloc(len + 1, sizeof(wchar_t));
 	if (wstr == NULL)
@@ -1220,11 +1220,11 @@ char *str_str(const char *hs, const char *n)
 {
 	size_t off = 0;
 
-	if (str_lcmp(hs, n, str_length(n)) == 0)
+	if (str_lcmp(hs, n, str_code_points(n)) == 0)
 		return (char *)hs;
 
 	while (str_decode(hs, &off, STR_NO_LIMIT) != 0) {
-		if (str_lcmp(hs + off, n, str_length(n)) == 0)
+		if (str_lcmp(hs + off, n, str_code_points(n)) == 0)
 			return (char *)(hs + off);
 	}
 
@@ -1269,7 +1269,7 @@ void str_ltrim(char *str, wchar_t ch)
 	wchar_t acc;
 	size_t off = 0;
 	size_t pos = 0;
-	size_t str_sz = str_size(str);
+	size_t str_sz = str_bytes(str);
 
 	while ((acc = str_decode(str, &off, STR_NO_LIMIT)) != 0) {
 		if (acc != ch)
@@ -1324,7 +1324,7 @@ char *str_rchr(const char *str, wchar_t ch)
  */
 bool wstr_linsert(wchar_t *str, wchar_t ch, size_t pos, size_t max_pos)
 {
-	size_t len = wstr_length(str);
+	size_t len = wstr_code_points(str);
 
 	if ((pos > len) || (pos + 1 > max_pos))
 		return false;
@@ -1352,7 +1352,7 @@ bool wstr_linsert(wchar_t *str, wchar_t ch, size_t pos, size_t max_pos)
  */
 bool wstr_remove(wchar_t *str, size_t pos)
 {
-	size_t len = wstr_length(str);
+	size_t len = wstr_code_points(str);
 
 	if (pos >= len)
 		return false;
@@ -1382,7 +1382,7 @@ bool wstr_remove(wchar_t *str, size_t pos)
  */
 char *str_dup(const char *src)
 {
-	size_t size = str_size(src) + 1;
+	size_t size = str_bytes(src) + 1;
 	char *dest = malloc(size);
 	if (!dest)
 		return NULL;
@@ -1413,7 +1413,7 @@ char *str_dup(const char *src)
  */
 char *str_ndup(const char *src, size_t n)
 {
-	size_t size = str_size(src);
+	size_t size = str_bytes(src);
 	if (size > n)
 		size = n;
 
@@ -1444,7 +1444,7 @@ char *str_tok(char *s, const char *delim, char **next)
 	if (!s)
 		return NULL;
 
-	size_t len = str_size(s);
+	size_t len = str_bytes(s);
 	size_t cur;
 	size_t tmp;
 	wchar_t ch;

--- a/uspace/lib/c/generic/str.c
+++ b/uspace/lib/c/generic/str.c
@@ -40,7 +40,7 @@
  *
  * Strings and characters use the Universal Character Set (UCS). The standard
  * strings, called just strings are encoded in UTF-8. Wide strings (encoded
- * in UTF-32) are supported to a limited degree. A single character is
+ * in UTF-32) are supported to a limited degree. A single code point is
  * represented as wchar_t.@n
  *
  * Overview of the terminology:@n
@@ -49,7 +49,7 @@
  *  --------------------  ----------------------------------------------------
  *  byte                  8 bits stored in uint8_t (unsigned 8 bit integer)
  *
- *  character             UTF-32 encoded Unicode character, stored in wchar_t
+ *  character             UTF-32 encoded Unicode code point, stored in wchar_t
  *                        (signed 32 bit integer), code points 0 .. 1114111
  *                        are valid
  *
@@ -65,7 +65,7 @@
  *  [wide] string size    number of BYTES in a [wide] string (excluding
  *                        the NULL-terminator), size_t
  *
- *  [wide] string length  number of CHARACTERS in a [wide] string (excluding
+ *  [wide] string length  number of CODE POINTS in a [wide] string (excluding
  *                        the NULL-terminator), size_t
  *
  *  [wide] string width   number of display cells on a monospace display taken
@@ -79,7 +79,7 @@
  *  size    n        size_t   number of BYTES in a string (excluding the
  *                            NULL-terminator)
  *
- *  length  l        size_t   number of CHARACTERS in a string (excluding the
+ *  length  l        size_t   number of CODE POINTS in a string (excluding the
  *                            null terminator)
  *
  *  width  w         size_t   number of display cells on a monospace display
@@ -88,7 +88,7 @@
  *
  * Function naming prefixes:@n
  *
- *  chr_    operate on characters
+ *  chr_    operate on code points
  *  ascii_  operate on ASCII characters
  *  str_    operate on strings
  *  wstr_   operate on wide strings
@@ -101,7 +101,7 @@
  *
  *  pointer (char *, wchar_t *)
  *  byte offset (size_t)
- *  character index (size_t)
+ *  code point index (size_t)
  *
  */
 
@@ -137,18 +137,18 @@
 /** Number of data bits in a UTF-8 continuation byte */
 #define CONT_BITS  6
 
-/** Decode a single character from a string.
+/** Decode a single code point from an UTF-8 encoded string.
  *
- * Decode a single character from a string of size @a size. Decoding starts
+ * Decode a single code point from a string of size @a size. Decoding starts
  * at @a offset and this offset is moved to the beginning of the next
- * character. In case of decoding error, offset generally advances at least
+ * code point. In case of decoding error, offset generally advances at least
  * by one. However, offset is never moved beyond size.
  *
  * @param str    String (not necessarily NULL-terminated).
  * @param offset Byte offset in string where to start decoding.
  * @param size   Size of the string (in bytes).
  *
- * @return Value of decoded character, U_SPECIAL on decoding error or
+ * @return Value of decoded code point, U_SPECIAL on decoding error or
  *         NULL if attempt to decode beyond @a size.
  *
  */
@@ -207,18 +207,18 @@ wchar_t str_decode(const char *str, size_t *offset, size_t size)
 	return ch;
 }
 
-/** Decode a single character from a string to the left.
+/** Decode a single code point from an UTF-8 encoded string to the left.
  *
- * Decode a single character from a string of size @a size. Decoding starts
+ * Decode a single code point from a string of size @a size. Decoding starts
  * at @a offset and this offset is moved to the beginning of the previous
- * character. In case of decoding error, offset generally decreases at least
+ * code point. In case of decoding error, offset generally decreases at least
  * by one. However, offset is never moved before 0.
  *
  * @param str    String (not necessarily NULL-terminated).
  * @param offset Byte offset in string where to start decoding.
  * @param size   Size of the string (in bytes).
  *
- * @return Value of decoded character, U_SPECIAL on decoding error or
+ * @return Value of decoded code point, U_SPECIAL on decoding error or
  *         NULL if attempt to decode beyond @a start of str.
  *
  */
@@ -250,19 +250,19 @@ wchar_t str_decode_reverse(const char *str, size_t *offset, size_t size)
 	return U_SPECIAL;
 }
 
-/** Encode a single character to string representation.
+/** Encode a single code point to a UTF-8 string representation.
  *
- * Encode a single character to string representation (i.e. UTF-8) and store
+ * Encode a single code point to a UTF-8 string representation and store
  * it into a buffer at @a offset. Encoding starts at @a offset and this offset
- * is moved to the position where the next character can be written to.
+ * is moved to the position where the next code point can be written to.
  *
- * @param ch     Input character.
+ * @param ch     Input code point.
  * @param str    Output buffer.
  * @param offset Byte offset where to start writing.
  * @param size   Size of the output buffer (in bytes).
  *
- * @return EOK if the character was encoded successfully, EOVERFLOW if there
- *         was not enough space in the output buffer or EINVAL if the character
+ * @return EOK if the code point was encoded successfully, EOVERFLOW if there
+ *         was not enough space in the output buffer or EINVAL if the code point
  *         code was invalid.
  */
 errno_t chr_encode(const wchar_t ch, char *str, size_t *offset, size_t size)
@@ -356,17 +356,17 @@ size_t wstr_bytes(const wchar_t *str)
 	return (wstr_code_points(str) * sizeof(wchar_t));
 }
 
-/** Get size of string with length limit.
+/** Get size of string with code point count limit.
  *
  * Get the number of bytes which are used by up to @a max_len first
- * characters in the string @a str. If @a max_len is greater than
- * the length of @a str, the entire string is measured (excluding the
- * NULL-terminator).
+ * code points in the string @a str. If @a max_len is greater than
+ * the number of code points in @a str, the entire string is measured
+ * (excluding the NULL-terminator).
  *
  * @param str     String to consider.
- * @param max_len Maximum number of characters to measure.
+ * @param max_len Maximum number of code points to measure.
  *
- * @return Number of bytes used by the characters.
+ * @return Number of bytes used by the code points.
  *
  */
 size_t str_lbytes(const char *str, size_t max_len)
@@ -424,14 +424,14 @@ size_t wstr_nbytes(const wchar_t *str, size_t max_size)
 /** Get size of wide string with length limit.
  *
  * Get the number of bytes which are used by up to @a max_len first
- * wide characters in the wide string @a str. If @a max_len is greater than
+ * code points in the wide string @a str. If @a max_len is greater than
  * the length of @a str, the entire wide string is measured (excluding the
  * NULL-terminator).
  *
  * @param str     Wide string to consider.
- * @param max_len Maximum number of wide characters to measure.
+ * @param max_len Maximum number of code points to measure.
  *
- * @return Number of bytes used by the wide characters.
+ * @return Number of bytes used by the code points.
  *
  */
 size_t wstr_lbytes(const wchar_t *str, size_t max_len)
@@ -439,11 +439,11 @@ size_t wstr_lbytes(const wchar_t *str, size_t max_len)
 	return (wstr_ncode_points(str, max_len * sizeof(wchar_t)) * sizeof(wchar_t));
 }
 
-/** Get number of characters in a string.
+/** Get number of unicode code points in a UTF-8 encoded string.
  *
- * @param str NULL-terminated string.
+ * @param str NULL-terminated UTF-8 string.
  *
- * @return Number of characters in string.
+ * @return Number of code points in the string.
  *
  */
 size_t str_code_points(const char *str)
@@ -457,11 +457,11 @@ size_t str_code_points(const char *str)
 	return len;
 }
 
-/** Get number of characters in a wide string.
+/** Get number of code points in a wide string.
  *
  * @param str NULL-terminated wide string.
  *
- * @return Number of characters in @a str.
+ * @return Number of code points in @a str.
  *
  */
 size_t wstr_code_points(const wchar_t *wstr)
@@ -474,12 +474,12 @@ size_t wstr_code_points(const wchar_t *wstr)
 	return len;
 }
 
-/** Get number of characters in a string with size limit.
+/** Get number of code points in a string with size limit.
  *
  * @param str  NULL-terminated string.
  * @param size Maximum number of bytes to consider.
  *
- * @return Number of characters in string.
+ * @return Number of code points in string.
  *
  */
 size_t str_ncode_points(const char *str, size_t size)
@@ -493,12 +493,12 @@ size_t str_ncode_points(const char *str, size_t size)
 	return len;
 }
 
-/** Get number of characters in a string with size limit.
+/** Get number of code points in a string with size limit.
  *
  * @param str  NULL-terminated string.
  * @param size Maximum number of bytes to consider.
  *
- * @return Number of characters in string.
+ * @return Number of code points in string.
  *
  */
 size_t wstr_ncode_points(const wchar_t *str, size_t size)
@@ -515,10 +515,10 @@ size_t wstr_ncode_points(const wchar_t *str, size_t size)
 	return len;
 }
 
-/** Get character display width on a character cell display.
+/** Get display width of a code point on a character cell display.
  *
- * @param ch	Character
- * @return	Width of character in cells.
+ * @param ch	Code point
+ * @return	Display width in cells.
  */
 size_t chr_width(wchar_t ch)
 {
@@ -542,9 +542,9 @@ size_t str_width(const char *str)
 	return width;
 }
 
-/** Check whether character is plain ASCII.
+/** Check whether code point is plain ASCII.
  *
- * @return True if character is plain ASCII.
+ * @return True if code point is plain ASCII.
  *
  */
 bool ascii_check(wchar_t ch)
@@ -555,9 +555,9 @@ bool ascii_check(wchar_t ch)
 	return false;
 }
 
-/** Check whether character is valid
+/** Check whether code point is valid
  *
- * @return True if character is a valid Unicode code point.
+ * @return True if code point is a valid Unicode code point.
  *
  */
 bool chr_check(wchar_t ch)
@@ -572,12 +572,12 @@ bool chr_check(wchar_t ch)
  *
  * Do a char-by-char comparison of two NULL-terminated strings.
  * The strings are considered equal iff their length is equal
- * and both strings consist of the same sequence of characters.
+ * and both strings consist of the same sequence of code points.
  *
- * A string S1 is less than another string S2 if it has a character with
- * lower value at the first character position where the strings differ.
+ * A string S1 is less than another string S2 if it has a code point with
+ * lower value at the first code point position where the strings differ.
  * If the strings differ in length, the shorter one is treated as if
- * padded by characters with a value of zero.
+ * padded by code points with a value of zero.
  *
  * @param s1 First string to compare.
  * @param s2 Second string to compare.
@@ -616,18 +616,18 @@ int str_cmp(const char *s1, const char *s2)
  * Do a char-by-char comparison of two NULL-terminated strings.
  * The strings are considered equal iff
  * min(str_code_points(s1), max_len) == min(str_code_points(s2), max_len)
- * and both strings consist of the same sequence of characters,
- * up to max_len characters.
+ * and both strings consist of the same sequence of code points,
+ * up to max_len code points.
  *
- * A string S1 is less than another string S2 if it has a character with
- * lower value at the first character position where the strings differ.
+ * A string S1 is less than another string S2 if it has a code point with
+ * lower value at the first code point position where the strings differ.
  * If the strings differ in length, the shorter one is treated as if
- * padded by characters with a value of zero. Only the first max_len
- * characters are considered.
+ * padded by code points with a value of zero. Only the first max_len
+ * code points are considered.
  *
  * @param s1      First string to compare.
  * @param s2      Second string to compare.
- * @param max_len Maximum number of characters to consider.
+ * @param max_len Maximum number of code points to consider.
  *
  * @return 0 if the strings are equal, -1 if the first is less than the second,
  *         1 if the second is less than the first.
@@ -670,13 +670,13 @@ int str_lcmp(const char *s1, const char *s2, size_t max_len)
  *
  * Do a char-by-char comparison of two NULL-terminated strings.
  * The strings are considered equal iff their length is equal
- * and both strings consist of the same sequence of characters
+ * and both strings consist of the same sequence of code points
  * when converted to lower case.
  *
- * A string S1 is less than another string S2 if it has a character with
- * lower value at the first character position where the strings differ.
+ * A string S1 is less than another string S2 if it has a code point with
+ * lower value at the first code point position where the strings differ.
  * If the strings differ in length, the shorter one is treated as if
- * padded by characters with a value of zero.
+ * padded by code points with a value of zero.
  *
  * @param s1 First string to compare.
  * @param s2 Second string to compare.
@@ -716,18 +716,18 @@ int str_casecmp(const char *s1, const char *s2)
  * Do a char-by-char comparison of two NULL-terminated strings.
  * The strings are considered equal iff
  * min(str_code_points(s1), max_len) == min(str_code_points(s2), max_len)
- * and both strings consist of the same sequence of characters,
- * up to max_len characters.
+ * and both strings consist of the same sequence of code points,
+ * up to max_len code points.
  *
- * A string S1 is less than another string S2 if it has a character with
- * lower value at the first character position where the strings differ.
+ * A string S1 is less than another string S2 if it has a code point with
+ * lower value at the first code point position where the strings differ.
  * If the strings differ in length, the shorter one is treated as if
- * padded by characters with a value of zero. Only the first max_len
- * characters are considered.
+ * padded by code points with a value of zero. Only the first max_len
+ * code points are considered.
  *
  * @param s1      First string to compare.
  * @param s2      Second string to compare.
- * @param max_len Maximum number of characters to consider.
+ * @param max_len Maximum number of code points to consider.
  *
  * @return 0 if the strings are equal, -1 if the first is less than the second,
  *         1 if the second is less than the first.
@@ -807,7 +807,7 @@ bool str_test_prefix(const char *s, const char *p)
  * Copy source string @a src to destination buffer @a dest.
  * No more than @a size bytes are written. If the size of the output buffer
  * is at least one byte, the output string will always be well-formed, i.e.
- * null-terminated and containing only complete characters.
+ * null-terminated and containing only complete code points.
  *
  * @param dest  Destination buffer.
  * @param count Size of the destination buffer (must be > 0).
@@ -837,7 +837,7 @@ void str_cpy(char *dest, size_t size, const char *src)
  * Copy prefix of string @a src of max. size @a size to destination buffer
  * @a dest. No more than @a size bytes are written. The output string will
  * always be well-formed, i.e. null-terminated and containing only complete
- * characters.
+ * code points.
  *
  * No more than @a n bytes are read from the input string, so it does not
  * have to be null-terminated.
@@ -870,7 +870,7 @@ void str_ncpy(char *dest, size_t size, const char *src, size_t n)
  * Append source string @a src to string in destination buffer @a dest.
  * Size of the destination buffer is @a dest. If the size of the output buffer
  * is at least one byte, the output string will always be well-formed, i.e.
- * null-terminated and containing only complete characters.
+ * null-terminated and containing only complete code points.
  *
  * @param dest   Destination buffer.
  * @param count Size of the destination buffer.
@@ -1029,7 +1029,7 @@ errno_t utf16_to_str(char *dest, size_t size, const uint16_t *src)
  * written will always be well-formed. Surrogate pairs also supported.
  *
  * @param dest	Destination buffer.
- * @param dlen	Number of utf16 characters that fit in the destination buffer.
+ * @param dlen	Number of utf16 code points that fit in the destination buffer.
  * @param src	Source string.
  *
  * @return EOK, if success, an error code otherwise.
@@ -1187,12 +1187,12 @@ wchar_t *str_to_awstr(const char *str)
 	return wstr;
 }
 
-/** Find first occurence of character in string.
+/** Find first occurence of code point in string.
  *
  * @param str String to search.
- * @param ch  Character to look for.
+ * @param ch  code point to look for.
  *
- * @return Pointer to character in @a str or NULL if not found.
+ * @return Pointer to code point in @a str or NULL if not found.
  */
 char *str_chr(const char *str, wchar_t ch)
 {
@@ -1214,7 +1214,7 @@ char *str_chr(const char *str, wchar_t ch)
  * @param hs  Haystack (string)
  * @param n   Needle (substring to look for)
  *
- * @return Pointer to character in @a hs or @c NULL if not found.
+ * @return Pointer to substring in @a hs or @c NULL if not found.
  */
 char *str_str(const char *hs, const char *n)
 {
@@ -1231,10 +1231,10 @@ char *str_str(const char *hs, const char *n)
 	return NULL;
 }
 
-/** Removes specified trailing characters from a string.
+/** Removes specified trailing code points from a string.
  *
  * @param str String to remove from.
- * @param ch  Character to remove.
+ * @param ch  Code point to remove.
  */
 void str_rtrim(char *str, wchar_t ch)
 {
@@ -1259,10 +1259,10 @@ void str_rtrim(char *str, wchar_t ch)
 		*last_chunk = '\0';
 }
 
-/** Removes specified leading characters from a string.
+/** Removes specified leading code points from a string.
  *
  * @param str String to remove from.
- * @param ch  Character to remove.
+ * @param ch  code point to remove.
  */
 void str_ltrim(char *str, wchar_t ch)
 {
@@ -1285,12 +1285,12 @@ void str_ltrim(char *str, wchar_t ch)
 	}
 }
 
-/** Find last occurence of character in string.
+/** Find last occurence of code point in string.
  *
  * @param str String to search.
- * @param ch  Character to look for.
+ * @param ch  code point to look for.
  *
- * @return Pointer to character in @a str or NULL if not found.
+ * @return Pointer to code point in @a str or NULL if not found.
  */
 char *str_rchr(const char *str, wchar_t ch)
 {
@@ -1308,15 +1308,15 @@ char *str_rchr(const char *str, wchar_t ch)
 	return (char *) res;
 }
 
-/** Insert a wide character into a wide string.
+/** Insert a code point into a wide string.
  *
- * Insert a wide character into a wide string at position
- * @a pos. The characters after the position are shifted.
+ * Insert a code point into a wide string at position
+ * @a pos. The code points after the position are shifted.
  *
  * @param str     String to insert to.
- * @param ch      Character to insert to.
- * @param pos     Character index where to insert.
- * @param max_pos Characters in the buffer.
+ * @param ch      Code point to insert.
+ * @param pos     Code point index where to insert.
+ * @param max_pos Number of code points that fit in the buffer.
  *
  * @return True if the insertion was sucessful, false if the position
  *         is out of bounds.
@@ -1338,13 +1338,13 @@ bool wstr_linsert(wchar_t *str, wchar_t ch, size_t pos, size_t max_pos)
 	return true;
 }
 
-/** Remove a wide character from a wide string.
+/** Remove a code point from a wide string.
  *
- * Remove a wide character from a wide string at position
- * @a pos. The characters after the position are shifted.
+ * Remove a code point from a wide string at position
+ * @a pos. The code points after the position are shifted.
  *
  * @param str String to remove from.
- * @param pos Character index to remove.
+ * @param pos Code point index to remove.
  *
  * @return True if the removal was sucessful, false if the position
  *         is out of bounds.
@@ -1366,18 +1366,16 @@ bool wstr_remove(wchar_t *str, size_t pos)
 
 /** Duplicate string.
  *
- * Allocate a new string and copy characters from the source
- * string into it. The duplicate string is allocated via sleeping
- * malloc(), thus this function can sleep in no memory conditions.
+ * Allocate a new string and copy the contents of the source string into it.
+ * The duplicate string is allocated as if by malloc().
  *
- * The allocation cannot fail and the return value is always
- * a valid pointer. The duplicate string is always a well-formed
+ * If successful, the duplicate string is always a well-formed
  * null-terminated UTF-8 string, but it can differ from the source
  * string on the byte level.
  *
  * @param src Source string.
  *
- * @return Duplicate string.
+ * @return Duplicate string, or NULL if allocation failed.
  *
  */
 char *str_dup(const char *src)
@@ -1394,14 +1392,12 @@ char *str_dup(const char *src)
 /** Duplicate string with size limit.
  *
  * Allocate a new string and copy up to @max_size bytes from the source
- * string into it. The duplicate string is allocated via sleeping
- * malloc(), thus this function can sleep in no memory conditions.
+ * string into it. The duplicate string is allocated as if by malloc().
  * No more than @max_size + 1 bytes is allocated, but if the size
  * occupied by the source string is smaller than @max_size + 1,
  * less is allocated.
  *
- * The allocation cannot fail and the return value is always
- * a valid pointer. The duplicate string is always a well-formed
+ * If successful, the duplicate string is always a well-formed
  * null-terminated UTF-8 string, but it can differ from the source
  * string on the byte level.
  *

--- a/uspace/lib/c/generic/sysinfo.c
+++ b/uspace/lib/c/generic/sysinfo.c
@@ -51,7 +51,7 @@
 static errno_t sysinfo_get_keys_size(const char *path, size_t *size)
 {
 	return (errno_t) __SYSCALL3(SYS_SYSINFO_GET_KEYS_SIZE, (sysarg_t) path,
-	    (sysarg_t) str_size(path), (sysarg_t) size);
+	    (sysarg_t) str_bytes(path), (sysarg_t) size);
 }
 
 /** Get sysinfo keys
@@ -92,7 +92,7 @@ char *sysinfo_get_keys(const char *path, size_t *size)
 	/* Get the data */
 	size_t sz;
 	ret = (errno_t) __SYSCALL5(SYS_SYSINFO_GET_KEYS, (sysarg_t) path,
-	    (sysarg_t) str_size(path), (sysarg_t) data, (sysarg_t) *size,
+	    (sysarg_t) str_bytes(path), (sysarg_t) data, (sysarg_t) *size,
 	    (sysarg_t) &sz);
 	if (ret == EOK) {
 		*size = sz;
@@ -114,7 +114,7 @@ char *sysinfo_get_keys(const char *path, size_t *size)
 sysinfo_item_val_type_t sysinfo_get_val_type(const char *path)
 {
 	return (sysinfo_item_val_type_t) __SYSCALL2(SYS_SYSINFO_GET_VAL_TYPE,
-	    (sysarg_t) path, (sysarg_t) str_size(path));
+	    (sysarg_t) path, (sysarg_t) str_bytes(path));
 }
 
 /** Get sysinfo numerical value
@@ -129,7 +129,7 @@ sysinfo_item_val_type_t sysinfo_get_val_type(const char *path)
 errno_t sysinfo_get_value(const char *path, sysarg_t *value)
 {
 	return (errno_t) __SYSCALL3(SYS_SYSINFO_GET_VALUE, (sysarg_t) path,
-	    (sysarg_t) str_size(path), (sysarg_t) value);
+	    (sysarg_t) str_bytes(path), (sysarg_t) value);
 }
 
 /** Get sysinfo binary data size
@@ -144,7 +144,7 @@ errno_t sysinfo_get_value(const char *path, sysarg_t *value)
 static errno_t sysinfo_get_data_size(const char *path, size_t *size)
 {
 	return (errno_t) __SYSCALL3(SYS_SYSINFO_GET_DATA_SIZE, (sysarg_t) path,
-	    (sysarg_t) str_size(path), (sysarg_t) size);
+	    (sysarg_t) str_bytes(path), (sysarg_t) size);
 }
 
 /** Get sysinfo binary data
@@ -186,7 +186,7 @@ void *sysinfo_get_data(const char *path, size_t *size)
 	/* Get the data */
 	size_t sz;
 	ret = (errno_t) __SYSCALL5(SYS_SYSINFO_GET_DATA, (sysarg_t) path,
-	    (sysarg_t) str_size(path), (sysarg_t) data, (sysarg_t) *size,
+	    (sysarg_t) str_bytes(path), (sysarg_t) data, (sysarg_t) *size,
 	    (sysarg_t) &sz);
 	if (ret == EOK) {
 		*size = sz;
@@ -222,7 +222,7 @@ void *sysinfo_get_property(const char *path, const char *name, size_t *size)
 	size_t pos = 0;
 	while (pos < total_size) {
 		/* Process each property with sanity checks */
-		size_t cur_size = str_nsize(data + pos, total_size - pos);
+		size_t cur_size = str_nbytes(data + pos, total_size - pos);
 		if (((char *) data)[pos + cur_size] != 0)
 			break;
 

--- a/uspace/lib/c/generic/task.c
+++ b/uspace/lib/c/generic/task.c
@@ -74,7 +74,7 @@ errno_t task_set_name(const char *name)
 {
 	assert(name);
 
-	return (errno_t) __SYSCALL2(SYS_TASK_SET_NAME, (sysarg_t) name, str_size(name));
+	return (errno_t) __SYSCALL2(SYS_TASK_SET_NAME, (sysarg_t) name, str_bytes(name));
 }
 
 /** Kill a task.

--- a/uspace/lib/c/generic/thread/thread.c
+++ b/uspace/lib/c/generic/thread/thread.c
@@ -121,7 +121,7 @@ errno_t thread_create(void (*function)(void *), void *arg, const char *name,
 	uarg->uspace_uarg = uarg;
 
 	errno_t rc = (errno_t) __SYSCALL4(SYS_THREAD_CREATE, (sysarg_t) uarg,
-	    (sysarg_t) name, (sysarg_t) str_size(name), (sysarg_t) tid);
+	    (sysarg_t) name, (sysarg_t) str_bytes(name), (sysarg_t) tid);
 
 	if (rc != EOK) {
 		/*

--- a/uspace/lib/c/generic/tmpfile.c
+++ b/uspace/lib/c/generic/tmpfile.c
@@ -61,7 +61,7 @@ int __tmpfile_templ(char *templ, bool create)
 	int file;
 	errno_t rc;
 
-	tsize = str_size(templ);
+	tsize = str_bytes(templ);
 	if (tsize < 6)
 		return -1;
 

--- a/uspace/lib/c/generic/vfs/vfs.c
+++ b/uspace/lib/c/generic/vfs/vfs.c
@@ -180,7 +180,7 @@ char *vfs_absolutize(const char *path, size_t *retlen)
 	char *ncwd_path_nc;
 
 	fibril_mutex_lock(&cwd_mutex);
-	size_t size = str_size(path);
+	size_t size = str_bytes(path);
 	if (*path != '/') {
 		if (cwd_path == NULL) {
 			fibril_mutex_unlock(&cwd_mutex);
@@ -381,7 +381,7 @@ errno_t vfs_fsprobe(const char *fs_name, service_id_t serv,
 	aid_t req = async_send_1(exch, VFS_IN_FSPROBE, serv, &answer);
 
 	rc = async_data_write_start(exch, (void *) fs_name,
-	    str_size(fs_name));
+	    str_bytes(fs_name));
 
 	async_wait_for(req, &rc);
 
@@ -629,10 +629,10 @@ errno_t vfs_mount(int mp, const char *fs_name, service_id_t serv, const char *op
 	aid_t req = async_send_4(exch, VFS_IN_MOUNT, mp, serv, flags, instance,
 	    &answer);
 
-	rc1 = async_data_write_start(exch, (void *) opts, str_size(opts));
+	rc1 = async_data_write_start(exch, (void *) opts, str_bytes(opts));
 	if (rc1 == EOK) {
 		rc1 = async_data_write_start(exch, (void *) fs_name,
-		    str_size(fs_name));
+		    str_bytes(fs_name));
 	}
 
 	vfs_exchange_end(exch);
@@ -1179,7 +1179,7 @@ errno_t vfs_unlink(int parent, const char *child, int expect)
 	async_exch_t *exch = vfs_exchange_begin();
 
 	req = async_send_2(exch, VFS_IN_UNLINK, parent, expect, NULL);
-	rc = async_data_write_start(exch, child, str_size(child));
+	rc = async_data_write_start(exch, child, str_bytes(child));
 
 	vfs_exchange_end(exch);
 
@@ -1270,7 +1270,7 @@ errno_t vfs_walk(int parent, const char *path, int flags, int *handle)
 
 	ipc_call_t answer;
 	aid_t req = async_send_2(exch, VFS_IN_WALK, parent, flags, &answer);
-	errno_t rc = async_data_write_start(exch, path, str_size(path));
+	errno_t rc = async_data_write_start(exch, path, str_bytes(path));
 	vfs_exchange_end(exch);
 
 	errno_t rc_orig;

--- a/uspace/lib/c/generic/vol.c
+++ b/uspace/lib/c/generic/vol.c
@@ -327,7 +327,7 @@ errno_t vol_part_insert_by_path(vol_t *vol, const char *path)
 	exch = async_exchange_begin(vol->sess);
 	aid_t req = async_send_0(exch, VOL_PART_INSERT_BY_PATH, &answer);
 
-	retval = async_data_write_start(exch, path, str_size(path));
+	retval = async_data_write_start(exch, path, str_bytes(path));
 	if (retval != EOK) {
 		async_exchange_end(exch);
 		async_forget(req);
@@ -394,14 +394,14 @@ errno_t vol_part_mkfs(vol_t *vol, service_id_t sid, vol_fstype_t fstype,
 	exch = async_exchange_begin(vol->sess);
 	aid_t req = async_send_2(exch, VOL_PART_MKFS, sid, fstype, &answer);
 
-	retval = async_data_write_start(exch, label, str_size(label));
+	retval = async_data_write_start(exch, label, str_bytes(label));
 	if (retval != EOK) {
 		async_exchange_end(exch);
 		async_forget(req);
 		return retval;
 	}
 
-	retval = async_data_write_start(exch, mountp, str_size(mountp));
+	retval = async_data_write_start(exch, mountp, str_bytes(mountp));
 	if (retval != EOK) {
 		async_exchange_end(exch);
 		async_forget(req);
@@ -436,7 +436,7 @@ errno_t vol_part_set_mountp(vol_t *vol, service_id_t sid,
 	aid_t req = async_send_1(exch, VOL_PART_SET_MOUNTP, sid,
 	    &answer);
 
-	retval = async_data_write_start(exch, mountp, str_size(mountp));
+	retval = async_data_write_start(exch, mountp, str_bytes(mountp));
 	if (retval != EOK) {
 		async_exchange_end(exch);
 		async_forget(req);

--- a/uspace/lib/c/include/io/klog.h
+++ b/uspace/lib/c/include/io/klog.h
@@ -50,7 +50,7 @@ extern errno_t klog_read(void *, size_t, size_t *);
 	char *_s; \
 	errno_t _rc = ENOMEM; \
 	if (asprintf(&_s, fmt, ##__VA_ARGS__) >= 0) { \
-		_rc = klog_write((lvl), _s, str_size(_s)); \
+		_rc = klog_write((lvl), _s, str_bytes(_s)); \
 		free(_s); \
 	}; \
 	(_rc != EOK); \

--- a/uspace/lib/c/include/stdio.h
+++ b/uspace/lib/c/include/stdio.h
@@ -203,8 +203,8 @@ enum _buffer_state {
 	_bs_read
 };
 
-extern int vprintf_length(const char *, va_list);
-extern int printf_length(const char *, ...)
+extern int vprintf_code_points(const char *, va_list);
+extern int printf_code_points(const char *, ...)
     _HELENOS_PRINTF_ATTRIBUTE(1, 2);
 extern FILE *fdopen(int, const char *);
 extern int fileno(FILE *);

--- a/uspace/lib/c/include/str.h
+++ b/uspace/lib/c/include/str.h
@@ -67,20 +67,20 @@ extern wchar_t str_decode(const char *str, size_t *offset, size_t sz);
 extern wchar_t str_decode_reverse(const char *str, size_t *offset, size_t sz);
 extern errno_t chr_encode(wchar_t ch, char *str, size_t *offset, size_t sz);
 
-extern size_t str_size(const char *str);
-extern size_t wstr_size(const wchar_t *str);
+extern size_t str_bytes(const char *str);
+extern size_t wstr_bytes(const wchar_t *str);
 
-extern size_t str_nsize(const char *str, size_t max_size);
-extern size_t wstr_nsize(const wchar_t *str, size_t max_size);
+extern size_t str_nbytes(const char *str, size_t max_size);
+extern size_t wstr_nbytes(const wchar_t *str, size_t max_size);
 
-extern size_t str_lsize(const char *str, size_t max_len);
-extern size_t wstr_lsize(const wchar_t *str, size_t max_len);
+extern size_t str_lbytes(const char *str, size_t max_len);
+extern size_t wstr_lbytes(const wchar_t *str, size_t max_len);
 
-extern size_t str_length(const char *str);
-extern size_t wstr_length(const wchar_t *wstr);
+extern size_t str_code_points(const char *str);
+extern size_t wstr_code_points(const wchar_t *wstr);
 
-extern size_t str_nlength(const char *str, size_t size);
-extern size_t wstr_nlength(const wchar_t *str, size_t size);
+extern size_t str_ncode_points(const char *str, size_t size);
+extern size_t wstr_ncode_points(const wchar_t *str, size_t size);
 
 extern size_t chr_width(wchar_t ch);
 extern size_t str_width(const char *str);

--- a/uspace/lib/c/include/str.h
+++ b/uspace/lib/c/include/str.h
@@ -54,7 +54,7 @@ extern "C" {
 /** No size limit constant */
 #define STR_NO_LIMIT  ((size_t) -1)
 
-/** Maximum size of a string containing @c length characters */
+/** Maximum size of a string containing @c length code points */
 #define STR_BOUNDS(length)  ((length) << 2)
 
 /**

--- a/uspace/lib/clui/tinput.c
+++ b/uspace/lib/clui/tinput.c
@@ -202,7 +202,7 @@ static errno_t tinput_display(tinput_t *ti)
 		return EIO;
 
 	ti->prompt_coord = row0 * ti->con_cols + col0;
-	ti->text_coord = ti->prompt_coord + str_length(ti->prompt);
+	ti->text_coord = ti->prompt_coord + str_code_points(ti->prompt);
 
 	tinput_display_prompt(ti);
 	tinput_display_tail(ti, 0, 0);
@@ -242,7 +242,7 @@ static void tinput_insert_char(tinput_t *ti, wchar_t c)
 
 static void tinput_insert_string(tinput_t *ti, const char *str)
 {
-	size_t ilen = min(str_length(str), INPUT_MAX_SIZE - ti->nc);
+	size_t ilen = min(str_code_points(str), INPUT_MAX_SIZE - ti->nc);
 	if (ilen == 0)
 		return;
 
@@ -466,7 +466,7 @@ static void tinput_history_insert(tinput_t *ti, char *str)
 static void tinput_set_str(tinput_t *ti, const char *str)
 {
 	str_to_wstr(ti->buffer, INPUT_MAX_SIZE, str);
-	ti->nc = wstr_length(ti->buffer);
+	ti->nc = wstr_code_points(ti->buffer);
 	ti->pos = ti->nc;
 	ti->sel_start = ti->pos;
 }
@@ -578,7 +578,7 @@ static void tinput_history_seek(tinput_t *ti, int offs)
 	ti->history[ti->hpos] = tinput_get_str(ti);
 	ti->hpos += offs;
 
-	int pad = (int) ti->nc - str_length(ti->history[ti->hpos]);
+	int pad = (int) ti->nc - str_code_points(ti->history[ti->hpos]);
 	if (pad < 0)
 		pad = 0;
 
@@ -726,19 +726,19 @@ static void tinput_text_complete(tinput_t *ti)
 		 */
 		size_t cplen;
 
-		cplen = str_length(compl[0]);
+		cplen = str_code_points(compl[0]);
 		for (i = 1; i < cnum; i++)
 			cplen = min(cplen, common_pref_len(compl[0], compl[i]));
 
 		/* Compute how many bytes we should skip. */
-		size_t istart = str_lsize(compl[0], ti->pos - cstart);
+		size_t istart = str_lbytes(compl[0], ti->pos - cstart);
 
 		if (cplen > istart) {
 			/* Insert common prefix. */
 
 			/* Copy remainder of common prefix. */
 			char *cpref = str_ndup(compl[0] + istart,
-			    str_lsize(compl[0], cplen - istart));
+			    str_lbytes(compl[0], cplen - istart));
 
 			/* Insert it. */
 			tinput_insert_string(ti, cpref);
@@ -758,7 +758,7 @@ static void tinput_text_complete(tinput_t *ti)
 		 */
 
 		/* Compute how many bytes of completion string we should skip. */
-		size_t istart = str_lsize(compl[0], ti->pos - cstart);
+		size_t istart = str_lbytes(compl[0], ti->pos - cstart);
 
 		/* Insert remainder of completion string at current position. */
 		tinput_insert_string(ti, compl[0] + istart);

--- a/uspace/lib/cpp/include/__bits/string/string.hpp
+++ b/uspace/lib/cpp/include/__bits/string/string.hpp
@@ -86,7 +86,7 @@ namespace std
 
         static size_t length(const char_type* s)
         {
-            return hel::str_size(s);
+            return hel::str_bytes(s);
         }
 
         static const char_type* find(const char_type* s, size_t n, const char_type& c)
@@ -372,7 +372,7 @@ namespace std
 
         static size_t length(const char_type* s)
         {
-            return hel::wstr_size(s);
+            return hel::wstr_bytes(s);
         }
 
         static const char_type* find(const char_type* s, size_t n, const char_type& c)

--- a/uspace/lib/drv/generic/logbuf.c
+++ b/uspace/lib/drv/generic/logbuf.c
@@ -104,8 +104,8 @@ static size_t count_dump_length(size_t item_size, size_t items)
 	size_t normal_space_count = items - 1 - group_space_count;
 
 	size_t dump_itself = item_size * 2 * items;
-	size_t group_spaces = str_size(SPACE_GROUP) * group_space_count;
-	size_t normal_spaces = str_size(SPACE_NORMAL) * normal_space_count;
+	size_t group_spaces = str_bytes(SPACE_GROUP) * group_space_count;
+	size_t normal_spaces = str_bytes(SPACE_NORMAL) * normal_space_count;
 
 	return dump_itself + group_spaces + normal_spaces;
 }
@@ -192,7 +192,7 @@ void ddf_dump_buffer(char *dump, size_t dump_size,
 	}
 
 	if (print_remainder && (index < items)) {
-		size_t s = str_size(dump);
+		size_t s = str_bytes(dump);
 		snprintf(dump + s, dump_size - s, REMAINDER_STR_FMT,
 		    items - index);
 	}

--- a/uspace/lib/drv/generic/remote_ahci.c
+++ b/uspace/lib/drv/generic/remote_ahci.c
@@ -69,7 +69,7 @@ async_sess_t *ahci_get_sess(devman_handle_t funh, char **name)
 	if (rc != EOK)
 		return NULL;
 
-	size_t devn_size = str_size(devn);
+	size_t devn_size = str_bytes(devn);
 
 	if ((devn_size > 5) && (str_lcmp(devn, "ahci_", 5) == 0)) {
 		async_sess_t *sess = devman_device_connect(funh, IPC_FLAG_BLOCKING);

--- a/uspace/lib/drv/generic/remote_audio_mixer.c
+++ b/uspace/lib/drv/generic/remote_audio_mixer.c
@@ -233,7 +233,7 @@ void remote_audio_mixer_get_info(ddf_fun_t *fun, void *iface, ipc_call_t *icall)
 	const char *name = NULL;
 	unsigned items = 0;
 	const errno_t ret = mixer_iface->get_info(fun, &name, &items);
-	const size_t name_size = name ? str_size(name) + 1 : 0;
+	const size_t name_size = name ? str_bytes(name) + 1 : 0;
 	async_answer_2(icall, ret, name_size, items);
 
 	/* Send the name. */
@@ -268,7 +268,7 @@ void remote_audio_mixer_get_item_info(ddf_fun_t *fun, void *iface,
 	const char *name = NULL;
 	unsigned values = 0;
 	const errno_t ret = mixer_iface->get_item_info(fun, item, &name, &values);
-	const size_t name_size = name ? str_size(name) + 1 : 0;
+	const size_t name_size = name ? str_bytes(name) + 1 : 0;
 	async_answer_2(icall, ret, name_size, values);
 
 	/* Send the name. */

--- a/uspace/lib/drv/generic/remote_audio_pcm.c
+++ b/uspace/lib/drv/generic/remote_audio_pcm.c
@@ -645,7 +645,7 @@ void remote_audio_pcm_get_info_str(ddf_fun_t *fun, void *iface,
 
 	const char *name = NULL;
 	const errno_t ret = pcm_iface->get_info_str(fun, &name);
-	const size_t name_size = name ? str_size(name) + 1 : 0;
+	const size_t name_size = name ? str_bytes(name) + 1 : 0;
 	async_answer_1(call, ret, name_size);
 
 	/* Send the string. */

--- a/uspace/lib/drv/generic/remote_ieee80211.c
+++ b/uspace/lib/drv/generic/remote_ieee80211.c
@@ -137,7 +137,7 @@ errno_t ieee80211_connect(async_sess_t *dev_sess, char *ssid_start, char *passwo
 	    IEEE80211_CONNECT, NULL);
 
 	errno_t rc = async_data_write_start(exch, ssid_start,
-	    str_size(ssid_start) + 1);
+	    str_bytes(ssid_start) + 1);
 	if (rc != EOK) {
 		async_exchange_end(exch);
 		async_wait_for(aid, &rc_orig);
@@ -152,7 +152,7 @@ errno_t ieee80211_connect(async_sess_t *dev_sess, char *ssid_start, char *passwo
 	if (password == NULL)
 		password = (char *) "";
 
-	rc = async_data_write_start(exch, password, str_size(password) + 1);
+	rc = async_data_write_start(exch, password, str_bytes(password) + 1);
 	if (rc != EOK) {
 		async_exchange_end(exch);
 		async_wait_for(aid, &rc_orig);

--- a/uspace/lib/ext4/src/directory.c
+++ b/uspace/lib/ext4/src/directory.c
@@ -416,7 +416,7 @@ errno_t ext4_directory_add_entry(ext4_inode_ref_t *parent, const char *name,
 	uint32_t inode_size = ext4_inode_get_size(fs->superblock, parent->inode);
 	uint32_t total_blocks = inode_size / block_size;
 
-	uint32_t name_len = str_size(name);
+	uint32_t name_len = str_bytes(name);
 
 	/* Find block, where is space for new entry and try to add */
 	bool success = false;
@@ -484,7 +484,7 @@ errno_t ext4_directory_add_entry(ext4_inode_ref_t *parent, const char *name,
 errno_t ext4_directory_find_entry(ext4_directory_search_result_t *result,
     ext4_inode_ref_t *parent, const char *name)
 {
-	uint32_t name_len = str_size(name);
+	uint32_t name_len = str_bytes(name);
 
 	ext4_superblock_t *sb = parent->fs->superblock;
 

--- a/uspace/lib/ext4/src/directory_index.c
+++ b/uspace/lib/ext4/src/directory_index.c
@@ -1065,7 +1065,7 @@ errno_t ext4_directory_dx_add_entry(ext4_inode_ref_t *parent,
 		return rc;
 
 	/* Initialize hinfo structure (mainly compute hash) */
-	uint32_t name_len = str_size(name);
+	uint32_t name_len = str_bytes(name);
 	ext4_hash_info_t hinfo;
 	rc = ext4_directory_hinfo_init(&hinfo, root_block, fs->superblock,
 	    name_len, name);

--- a/uspace/lib/ext4/src/ops.c
+++ b/uspace/lib/ext4/src/ops.c
@@ -538,7 +538,7 @@ errno_t ext4_destroy_node(fs_node_t *fn)
 errno_t ext4_link(fs_node_t *pfn, fs_node_t *cfn, const char *name)
 {
 	/* Check maximum name length */
-	if (str_size(name) > EXT4_DIRECTORY_FILENAME_LEN)
+	if (str_bytes(name) > EXT4_DIRECTORY_FILENAME_LEN)
 		return ENAMETOOLONG;
 
 	ext4_node_t *parent = EXT4_NODE(pfn);

--- a/uspace/lib/fmtutil/fmtutil.c
+++ b/uspace/lib/fmtutil/fmtutil.c
@@ -90,7 +90,7 @@ errno_t print_aligned_w(const wchar_t *wstr, size_t width, bool last,
     align_mode_t mode)
 {
 	size_t i;
-	size_t len = wstr_length(wstr);
+	size_t len = wstr_code_points(wstr);
 	if (mode == ALIGN_LEFT || (mode == ALIGN_JUSTIFY && last)) {
 		for (i = 0; i < width; i++) {
 			if (i < len)

--- a/uspace/lib/gui/terminal.c
+++ b/uspace/lib/gui/terminal.c
@@ -424,7 +424,7 @@ static errno_t term_read(con_srv_t *srv, void *buf, size_t size, size_t *nread)
 				};
 
 				wstr_to_str(term->char_remains, UTF8_CHAR_BUFFER_SIZE, tmp);
-				term->char_remains_len = str_size(term->char_remains);
+				term->char_remains_len = str_bytes(term->char_remains);
 			}
 
 			free(event);

--- a/uspace/lib/hound/src/protocol.c
+++ b/uspace/lib/hound/src/protocol.c
@@ -130,7 +130,7 @@ errno_t hound_service_register_context(hound_sess_t *sess,
 	errno_t ret = mid ? EOK : EPARTY;
 
 	if (ret == EOK)
-		ret = async_data_write_start(exch, name, str_size(name));
+		ret = async_data_write_start(exch, name, str_bytes(name));
 	else
 		async_forget(mid);
 
@@ -193,7 +193,7 @@ errno_t hound_service_get_list(hound_sess_t *sess, char ***ids, size_t *count,
 	errno_t ret = EOK;
 	if (mid && connection)
 		ret = async_data_write_start(exch, connection,
-		    str_size(connection));
+		    str_bytes(connection));
 
 	if (ret == EOK)
 		async_wait_for(mid, &ret);
@@ -260,9 +260,9 @@ errno_t hound_service_connect_source_sink(hound_sess_t *sess, const char *source
 	aid_t id = async_send_0(exch, IPC_M_HOUND_CONNECT, &call);
 	errno_t ret = id ? EOK : EPARTY;
 	if (ret == EOK)
-		ret = async_data_write_start(exch, source, str_size(source));
+		ret = async_data_write_start(exch, source, str_bytes(source));
 	if (ret == EOK)
-		ret = async_data_write_start(exch, sink, str_size(sink));
+		ret = async_data_write_start(exch, sink, str_bytes(sink));
 	async_wait_for(id, &ret);
 	async_exchange_end(exch);
 	return ret;
@@ -286,9 +286,9 @@ errno_t hound_service_disconnect_source_sink(hound_sess_t *sess, const char *sou
 	aid_t id = async_send_0(exch, IPC_M_HOUND_DISCONNECT, &call);
 	errno_t ret = id ? EOK : EPARTY;
 	if (ret == EOK)
-		ret = async_data_write_start(exch, source, str_size(source));
+		ret = async_data_write_start(exch, source, str_bytes(source));
 	if (ret == EOK)
-		ret = async_data_write_start(exch, sink, str_size(sink));
+		ret = async_data_write_start(exch, sink, str_bytes(sink));
 	async_wait_for(id, &ret);
 	async_exchange_end(exch);
 	return ENOTSUP;
@@ -485,7 +485,7 @@ void hound_connection_handler(ipc_call_t *icall, void *arg)
 
 			/* Prepare sizes table */
 			for (unsigned i = 0; i < count; ++i)
-				sizes[i] = str_size(list[i]);
+				sizes[i] = str_bytes(list[i]);
 
 			/* Send sizes table */
 			ipc_call_t id;
@@ -497,7 +497,7 @@ void hound_connection_handler(ipc_call_t *icall, void *arg)
 
 			/* Proceed to send names */
 			for (unsigned i = 0; i < count; ++i) {
-				size_t size = str_size(list[i]);
+				size_t size = str_bytes(list[i]);
 				ipc_call_t id;
 				if (ret == EOK &&
 				    async_data_read_receive(&id, NULL)) {

--- a/uspace/lib/http/src/request.c
+++ b/uspace/lib/http/src/request.c
@@ -99,7 +99,7 @@ errno_t http_request_format(http_request_t *req, char **out_buf,
 			return EINVAL;
 		size += header_size;
 	}
-	size += str_length(HTTP_REQUEST_LINE);
+	size += str_code_points(HTTP_REQUEST_LINE);
 
 	char *buf = malloc(size);
 	if (buf == NULL)
@@ -125,7 +125,7 @@ errno_t http_request_format(http_request_t *req, char **out_buf,
 		pos_size -= written;
 	}
 
-	size_t rlsize = str_size(HTTP_REQUEST_LINE);
+	size_t rlsize = str_bytes(HTTP_REQUEST_LINE);
 	memcpy(pos, HTTP_REQUEST_LINE, rlsize);
 	pos_size -= rlsize;
 	assert(pos_size == 0);

--- a/uspace/lib/http/src/response.c
+++ b/uspace/lib/http/src/response.c
@@ -99,7 +99,7 @@ static errno_t expect(receive_buffer_t *rb, const char *expect)
 	errno_t rc = recv_discard_str(rb, expect, &ndisc);
 	if (rc != EOK)
 		return rc;
-	if (ndisc < str_length(expect))
+	if (ndisc < str_code_points(expect))
 		return HTTP_EPARSE;
 	return EOK;
 }

--- a/uspace/lib/ieee80211/src/ieee80211.c
+++ b/uspace/lib/ieee80211/src/ieee80211.c
@@ -857,7 +857,7 @@ errno_t ieee80211_probe_request(ieee80211_dev_t *ieee80211_dev, char *ssid)
 	nic_address_t nic_address;
 	nic_query_address(nic, &nic_address);
 
-	size_t ssid_data_size = (ssid != NULL) ? str_size(ssid) : 0;
+	size_t ssid_data_size = (ssid != NULL) ? str_bytes(ssid) : 0;
 	size_t channel_data_size = 1;
 
 	uint8_t channel =
@@ -979,7 +979,7 @@ errno_t ieee80211_associate(ieee80211_dev_t *ieee80211_dev, char *password)
 
 	ieee80211_scan_result_t *auth_data = &auth_link->scan_result;
 
-	size_t ssid_data_size = str_size(auth_data->ssid);
+	size_t ssid_data_size = str_bytes(auth_data->ssid);
 
 	size_t payload_size =
 	    sizeof(ieee80211_ie_header_t) * 3 +
@@ -1042,7 +1042,7 @@ errno_t ieee80211_associate(ieee80211_dev_t *ieee80211_dev, char *password)
 	 */
 	memset(ieee80211_dev->bssid_info.password, 0, IEEE80211_MAX_PASSW_LEN);
 	memcpy(ieee80211_dev->bssid_info.password, password,
-	    str_size(password));
+	    str_bytes(password));
 
 	free(buffer);
 
@@ -1537,9 +1537,9 @@ static errno_t ieee80211_process_4way_handshake(ieee80211_dev_t *ieee80211_dev,
 		/* Compute PMK. */
 		uint8_t pmk[PBKDF2_KEY_LENGTH];
 		pbkdf2((uint8_t *) ieee80211_dev->bssid_info.password,
-		    str_size(ieee80211_dev->bssid_info.password),
+		    str_bytes(ieee80211_dev->bssid_info.password),
 		    (uint8_t *) auth_data->ssid,
-		    str_size(auth_data->ssid), pmk);
+		    str_bytes(auth_data->ssid), pmk);
 
 		uint8_t *anonce = key_frame->key_nonce;
 

--- a/uspace/lib/ieee80211/src/ieee80211_iface_impl.c
+++ b/uspace/lib/ieee80211/src/ieee80211_iface_impl.c
@@ -203,7 +203,7 @@ errno_t ieee80211_connect_impl(ddf_fun_t *fun, char *ssid_start, char *password)
 
 	ieee80211_scan_result_list_foreach(ieee80211_dev->ap_list, result) {
 		if (!str_lcmp(ssid_start, result->scan_result.ssid,
-		    str_size(ssid_start))) {
+		    str_bytes(ssid_start))) {
 			rc = ieee80211_connect_proc(ieee80211_dev, result,
 			    password);
 			break;

--- a/uspace/lib/ieee80211/src/ieee80211_impl.c
+++ b/uspace/lib/ieee80211/src/ieee80211_impl.c
@@ -192,12 +192,12 @@ errno_t ieee80211_prf(uint8_t *key, uint8_t *data, uint8_t *hash,
 	uint8_t result[HASH_SHA1 * iters];
 	uint8_t temp[HASH_SHA1];
 
-	size_t data_size = PRF_CRYPT_DATA_LENGTH + str_size(a) + 2;
+	size_t data_size = PRF_CRYPT_DATA_LENGTH + str_bytes(a) + 2;
 	uint8_t work_arr[data_size];
 	memset(work_arr, 0, data_size);
 
-	memcpy(work_arr, a, str_size(a));
-	memcpy(work_arr + str_size(a) + 1, data, PRF_CRYPT_DATA_LENGTH);
+	memcpy(work_arr, a, str_bytes(a));
+	memcpy(work_arr + str_bytes(a) + 1, data, PRF_CRYPT_DATA_LENGTH);
 
 	for (uint8_t i = 0; i < iters; i++) {
 		memcpy(work_arr + data_size - 1, &i, 1);

--- a/uspace/lib/pcut/src/assert.c
+++ b/uspace/lib/pcut/src/assert.c
@@ -69,7 +69,7 @@ void pcut_failed_assertion_fmt(const char *filename, int line, const char *fmt, 
 	message_buffer_index = (message_buffer_index + 1) % MESSAGE_BUFFER_COUNT;
 
 	pcut_snprintf(current_buffer, MAX_MESSAGE_LENGTH, "%s:%d: ", filename, line);
-	offset = pcut_str_size(current_buffer);
+	offset = pcut_str_bytes(current_buffer);
 
 	if (offset + 1 < MAX_MESSAGE_LENGTH) {
 		va_start(args, fmt);

--- a/uspace/lib/pcut/src/internal.h
+++ b/uspace/lib/pcut/src/internal.h
@@ -165,7 +165,7 @@ int pcut_str_start_equals(const char *a, const char *b, int len);
  * @param s String in question.
  * @return Size of @p s in bytes.
  */
-int pcut_str_size(const char *s);
+int pcut_str_bytes(const char *s);
 
 /** Convert string to integer.
  *

--- a/uspace/lib/pcut/src/main.c
+++ b/uspace/lib/pcut/src/main.c
@@ -61,7 +61,7 @@ static pcut_main_extra_t empty_main_extra[] = {
  * @return Whether @p arg is @p opt followed by a number.
  */
 int pcut_is_arg_with_number(const char *arg, const char *opt, int *value) {
-	int opt_len = pcut_str_size(opt);
+	int opt_len = pcut_str_bytes(opt);
 	if (! pcut_str_start_equals(arg, opt, opt_len)) {
 		return 0;
 	}

--- a/uspace/lib/pcut/src/os/helenos.c
+++ b/uspace/lib/pcut/src/os/helenos.c
@@ -54,8 +54,8 @@ int pcut_str_start_equals(const char *a, const char *b, int len) {
 	return str_lcmp(a, b, len) == 0;
 }
 
-int pcut_str_size(const char *s) {
-	return str_size(s);
+int pcut_str_bytes(const char *s) {
+	return str_bytes(s);
 }
 
 int pcut_str_to_int(const char *s) {

--- a/uspace/lib/pcut/src/os/stdc.c
+++ b/uspace/lib/pcut/src/os/stdc.c
@@ -45,7 +45,7 @@ int pcut_str_start_equals(const char *a, const char *b, int len) {
 	return strncmp(a, b, len) == 0;
 }
 
-int pcut_str_size(const char *s) {
+int pcut_str_bytes(const char *s) {
 	return strlen(s);
 }
 

--- a/uspace/lib/pcut/src/report/report.c
+++ b/uspace/lib/pcut/src/report/report.c
@@ -77,7 +77,7 @@ void pcut_print_fail_message(const char *msg) {
 	if (msg == NULL) {
 		return;
 	}
-	if (pcut_str_size(msg) == 0) {
+	if (pcut_str_bytes(msg) == 0) {
 		return;
 	}
 
@@ -129,7 +129,7 @@ static void parse_command_output(const char *full_output, size_t full_output_siz
 		}
 
 		/* Determine the length of the text after the zeros. */
-		message_length = pcut_str_size(full_output);
+		message_length = pcut_str_bytes(full_output);
 
 		if (cont_zeros_count < 2) {
 			/* Okay, standard I/O. */

--- a/uspace/lib/posix/src/stdio.c
+++ b/uspace/lib/posix/src/stdio.c
@@ -237,7 +237,7 @@ static int _dprintf_str_write(const char *str, size_t size, void *fd)
 	size_t wr;
 	if (failed(vfs_write(fildes, &posix_pos[fildes], str, size, &wr)))
 		return -1;
-	return str_nlength(str, wr);
+	return str_ncode_points(str, wr);
 }
 
 /**

--- a/uspace/lib/posix/test/stdio.c
+++ b/uspace/lib/posix/test/stdio.c
@@ -44,7 +44,7 @@ PCUT_TEST(tempnam_no_slash)
 	PCUT_ASSERT_NOT_NULL(p);
 
 	PCUT_ASSERT_TRUE(str_lcmp(p, "/tmp/tmp.",
-	    str_length("/tmp/tmp.")) == 0);
+	    str_code_points("/tmp/tmp.")) == 0);
 
 	f = fopen(p, "w+x");
 	PCUT_ASSERT_NOT_NULL(f);
@@ -63,7 +63,7 @@ PCUT_TEST(tempnam_with_slash)
 	PCUT_ASSERT_NOT_NULL(p);
 
 	PCUT_ASSERT_TRUE(str_lcmp(p, "/tmp/tmp.",
-	    str_length("/tmp/tmp.")) == 0);
+	    str_code_points("/tmp/tmp.")) == 0);
 
 	f = fopen(p, "w+x");
 	PCUT_ASSERT_NOT_NULL(f);
@@ -82,7 +82,7 @@ PCUT_TEST(tempnam_no_dir)
 	PCUT_ASSERT_NOT_NULL(p);
 
 	PCUT_ASSERT_TRUE(str_lcmp(p, P_tmpdir "/tmp.",
-	    str_length(P_tmpdir "/tmp.")) == 0);
+	    str_code_points(P_tmpdir "/tmp.")) == 0);
 
 	f = fopen(p, "w+x");
 	PCUT_ASSERT_NOT_NULL(f);

--- a/uspace/lib/posix/test/stdlib.c
+++ b/uspace/lib/posix/test/stdlib.c
@@ -53,7 +53,7 @@ PCUT_TEST(mktemp)
 	p = mktemp(buf);
 	PCUT_ASSERT_TRUE(p == buf);
 	PCUT_ASSERT_TRUE(str_lcmp(p, MKSTEMP_TEMPL,
-	    str_length(MKSTEMP_TEMPL) - 6) == 0);
+	    str_code_points(MKSTEMP_TEMPL) - 6) == 0);
 
 	file = open(p, O_CREAT | O_EXCL | O_RDWR, 0600);
 	PCUT_ASSERT_TRUE(file >= 0);
@@ -75,12 +75,12 @@ PCUT_TEST(mktemp_twice)
 	p = mktemp(buf1);
 	PCUT_ASSERT_TRUE(p == buf1);
 	PCUT_ASSERT_TRUE(str_lcmp(p, MKSTEMP_TEMPL,
-	    str_length(MKSTEMP_TEMPL) - 6) == 0);
+	    str_code_points(MKSTEMP_TEMPL) - 6) == 0);
 
 	p = mktemp(buf2);
 	PCUT_ASSERT_TRUE(p == buf2);
 	PCUT_ASSERT_TRUE(str_lcmp(p, MKSTEMP_TEMPL,
-	    str_length(MKSTEMP_TEMPL) - 6) == 0);
+	    str_code_points(MKSTEMP_TEMPL) - 6) == 0);
 
 	PCUT_ASSERT_TRUE(str_cmp(buf1, buf2) != 0);
 }

--- a/uspace/lib/sif/src/sif.c
+++ b/uspace/lib/sif/src/sif.c
@@ -701,14 +701,14 @@ static errno_t sif_export_string(const char *str, FILE *f)
 static errno_t sif_import_string(FILE *f, char **rstr)
 {
 	char *str;
-	size_t str_size;
+	size_t str_bytes;
 	size_t sidx;
 	int c;
 	errno_t rc;
 
-	str_size = 1;
+	str_bytes = 1;
 	sidx = 0;
-	str = malloc(str_size + 1);
+	str = malloc(str_bytes + 1);
 	if (str == NULL)
 		return ENOMEM;
 
@@ -736,9 +736,9 @@ static errno_t sif_import_string(FILE *f, char **rstr)
 			}
 		}
 
-		if (sidx >= str_size) {
-			str_size *= 2;
-			str = realloc(str, str_size + 1);
+		if (sidx >= str_bytes) {
+			str_bytes *= 2;
+			str = realloc(str, str_bytes + 1);
 			if (str == NULL) {
 				rc = ENOMEM;
 				goto error;

--- a/uspace/lib/trackmod/xm.c
+++ b/uspace/lib/trackmod/xm.c
@@ -288,7 +288,7 @@ static errno_t trackmod_xm_load_instruments(xm_hdr_t *xm_hdr, FILE *f,
 	xm_instr_ext_t instrx;
 	xm_smp_t smp;
 	size_t samples;
-	size_t instr_size;
+	size_t instr_bytes;
 	size_t smp_size;
 	size_t smp_hdr_size = 0;  /* GCC false alarm on uninitialized */
 	ssize_t nread;
@@ -313,7 +313,7 @@ static errno_t trackmod_xm_load_instruments(xm_hdr_t *xm_hdr, FILE *f,
 		}
 
 		samples = uint16_t_le2host(instr.samples);
-		instr_size = (size_t)uint32_t_le2host(instr.size);
+		instr_bytes = (size_t)uint32_t_le2host(instr.size);
 
 		if (samples > 0) {
 			ret = fread(&instrx, 1, sizeof(xm_instr_ext_t), f);
@@ -338,7 +338,7 @@ static errno_t trackmod_xm_load_instruments(xm_hdr_t *xm_hdr, FILE *f,
 			}
 		}
 
-		if (fseek(f, pos + instr_size, SEEK_SET) < 0) {
+		if (fseek(f, pos + instr_bytes, SEEK_SET) < 0) {
 			rc = EIO;
 			goto error;
 		}

--- a/uspace/lib/untar/tar.c
+++ b/uspace/lib/untar/tar.c
@@ -69,7 +69,7 @@ const char *tar_type_str(tar_type_t type)
 
 errno_t tar_header_parse(tar_header_t *parsed, const tar_header_raw_t *raw)
 {
-	if (str_length(raw->filename) == 0) {
+	if (str_code_points(raw->filename) == 0) {
 		return EEMPTY;
 	}
 

--- a/uspace/lib/usbvirt/src/ipc_dev.c
+++ b/uspace/lib/usbvirt/src/ipc_dev.c
@@ -53,7 +53,7 @@ static void ipc_get_name(usbvirt_device_t *dev, ipc_call_t *icall)
 		async_answer_0(icall, ENOENT);
 	}
 
-	size_t size = str_size(dev->name);
+	size_t size = str_bytes(dev->name);
 
 	ipc_call_t call;
 	size_t accepted_size;

--- a/uspace/srv/devman/client_conn.c
+++ b/uspace/srv/devman/client_conn.c
@@ -139,7 +139,7 @@ static void devman_fun_get_match_id(ipc_call_t *icall)
 
 	match_id_t *mid = list_get_instance(link, match_id_t, link);
 
-	size_t sent_length = str_size(mid->id);
+	size_t sent_length = str_bytes(mid->id);
 	if (sent_length > data_len) {
 		sent_length = data_len;
 	}
@@ -201,7 +201,7 @@ static void devman_fun_get_name(ipc_call_t *icall)
 		return;
 	}
 
-	size_t sent_length = str_size(fun->name);
+	size_t sent_length = str_bytes(fun->name);
 	if (sent_length > data_len) {
 		sent_length = data_len;
 	}
@@ -265,7 +265,7 @@ static void devman_fun_get_driver_name(ipc_call_t *icall)
 		return;
 	}
 
-	size_t sent_length = str_size(fun->child->drv->name);
+	size_t sent_length = str_bytes(fun->child->drv->name);
 	if (sent_length > data_len) {
 		sent_length = data_len;
 	}
@@ -319,7 +319,7 @@ static void devman_fun_get_path(ipc_call_t *icall)
 		return;
 	}
 
-	size_t sent_length = str_size(fun->pathname);
+	size_t sent_length = str_bytes(fun->pathname);
 	if (sent_length > data_len) {
 		sent_length = data_len;
 	}
@@ -638,7 +638,7 @@ static void devman_driver_get_match_id(ipc_call_t *icall)
 
 	match_id_t *mid = list_get_instance(link, match_id_t, link);
 
-	size_t sent_length = str_size(mid->id);
+	size_t sent_length = str_bytes(mid->id);
 	if (sent_length > data_len) {
 		sent_length = data_len;
 	}
@@ -678,7 +678,7 @@ static void devman_driver_get_name(ipc_call_t *icall)
 
 	fibril_mutex_lock(&drv->driver_mutex);
 
-	size_t sent_length = str_size(drv->name);
+	size_t sent_length = str_bytes(drv->name);
 	if (sent_length > data_len) {
 		sent_length = data_len;
 	}

--- a/uspace/srv/devman/driver.c
+++ b/uspace/srv/devman/driver.c
@@ -132,7 +132,7 @@ bool get_driver_info(const char *base_path, const char *name, driver_t *drv)
 		goto cleanup;
 
 	/* Allocate and fill driver's name. */
-	name_size = str_size(name) + 1;
+	name_size = str_bytes(name) + 1;
 	drv->name = malloc(name_size);
 	if (drv->name == NULL)
 		goto cleanup;
@@ -653,7 +653,7 @@ void add_device(driver_t *drv, dev_node_t *dev, dev_tree_t *tree)
 
 	/* Send the device name to the driver. */
 	errno_t rc = async_data_write_start(exch, dev->pfun->name,
-	    str_size(dev->pfun->name) + 1);
+	    str_bytes(dev->pfun->name) + 1);
 
 	async_exchange_end(exch);
 

--- a/uspace/srv/devman/fun.c
+++ b/uspace/srv/devman/fun.c
@@ -170,9 +170,9 @@ bool set_fun_path(dev_tree_t *tree, fun_node_t *fun, fun_node_t *parent)
 	assert(fibril_rwlock_is_write_locked(&tree->rwlock));
 	assert(fun->name != NULL);
 
-	size_t pathsize = (str_size(fun->name) + 1);
+	size_t pathsize = (str_bytes(fun->name) + 1);
 	if (parent != NULL)
-		pathsize += str_size(parent->pathname) + 1;
+		pathsize += str_bytes(parent->pathname) + 1;
 
 	fun->pathname = (char *) malloc(pathsize);
 	if (fun->pathname == NULL) {

--- a/uspace/srv/devman/util.c
+++ b/uspace/srv/devman/util.c
@@ -38,8 +38,8 @@
 char *get_abs_path(const char *base_path, const char *name, const char *ext)
 {
 	char *res;
-	int base_len = str_size(base_path);
-	int size = base_len + 2 * str_size(name) + str_size(ext) + 3;
+	int base_len = str_bytes(base_path);
+	int size = base_len + 2 * str_bytes(name) + str_bytes(ext) + 3;
 
 	res = malloc(size);
 

--- a/uspace/srv/fs/cdfs/cdfs_ops.c
+++ b/uspace/srv/fs/cdfs/cdfs_ops.c
@@ -482,12 +482,12 @@ static char *cdfs_decode_str(void *data, size_t dsize, cdfs_enc_t enc)
 			    ((unaligned_uint16_t *)data)[i]);
 		}
 
-		size_t dstr_size = dsize / sizeof(uint16_t) * 4 + 1;
-		str = malloc(dstr_size);
+		size_t dstr_bytes = dsize / sizeof(uint16_t) * 4 + 1;
+		str = malloc(dstr_bytes);
 		if (str == NULL)
 			return NULL;
 
-		rc = utf16_to_str(str, dstr_size, buf);
+		rc = utf16_to_str(str, dstr_bytes, buf);
 		free(buf);
 
 		if (rc != EOK)
@@ -557,7 +557,7 @@ static char *cdfs_decode_vol_ident(void *data, size_t dsize, cdfs_enc_t enc)
 		return NULL;
 
 	/* Trim trailing spaces */
-	i = str_size(ident);
+	i = str_bytes(ident);
 	while (i > 0 && ident[i - 1] == ' ')
 		--i;
 	ident[i] = '\0';
@@ -1316,7 +1316,7 @@ static errno_t cdfs_read(service_id_t service_id, fs_index_t index, aoff64_t pos
 
 		*rbytes = 1;
 		async_data_read_finalize(&call, dentry->name,
-		    str_size(dentry->name) + 1);
+		    str_bytes(dentry->name) + 1);
 	}
 
 	return EOK;

--- a/uspace/srv/fs/exfat/exfat_ops.c
+++ b/uspace/srv/fs/exfat/exfat_ops.c
@@ -1427,7 +1427,7 @@ exfat_read(service_id_t service_id, fs_index_t index, aoff64_t pos,
 		if (rc != EOK)
 			goto err;
 		(void) async_data_read_finalize(&call, name,
-		    str_size(name) + 1);
+		    str_bytes(name) + 1);
 		bytes = (pos - spos) + 1;
 	}
 

--- a/uspace/srv/fs/fat/fat_dentry.c
+++ b/uspace/srv/fs/fat/fat_dentry.c
@@ -69,7 +69,7 @@ int fat_dentry_namecmp(char *name, const char *component)
 		 * There is no '.' in the name, so we know that there is enough
 		 * space for appending an extra '.' to name.
 		 */
-		size = str_size(name);
+		size = str_bytes(name);
 		name[size] = '.';
 		name[size + 1] = '\0';
 		rc = str_casecmp(name, component);
@@ -268,7 +268,7 @@ uint8_t fat_dentry_chksum(uint8_t *name)
  * @return Number of bytes in string (without 0 and ff).
  *
  */
-size_t fat_lfn_str_nlength(const unaligned_uint16_t *str, size_t size)
+size_t fat_lfn_str_ncode_points(const unaligned_uint16_t *str, size_t size)
 {
 	size_t offset = 0;
 
@@ -291,9 +291,9 @@ size_t fat_lfn_size(const fat_dentry_t *d)
 {
 	size_t size = 0;
 
-	size += fat_lfn_str_nlength(FAT_LFN_PART1(d), FAT_LFN_PART1_SIZE);
-	size += fat_lfn_str_nlength(FAT_LFN_PART2(d), FAT_LFN_PART2_SIZE);
-	size += fat_lfn_str_nlength(FAT_LFN_PART3(d), FAT_LFN_PART3_SIZE);
+	size += fat_lfn_str_ncode_points(FAT_LFN_PART1(d), FAT_LFN_PART1_SIZE);
+	size += fat_lfn_str_ncode_points(FAT_LFN_PART2(d), FAT_LFN_PART2_SIZE);
+	size += fat_lfn_str_ncode_points(FAT_LFN_PART3(d), FAT_LFN_PART3_SIZE);
 
 	return size;
 }

--- a/uspace/srv/fs/fat/fat_dentry.h
+++ b/uspace/srv/fs/fat/fat_dentry.h
@@ -144,7 +144,7 @@ extern void fat_dentry_vollabel_get(const fat_dentry_t *, char *);
 extern fat_dentry_clsf_t fat_classify_dentry(const fat_dentry_t *);
 extern uint8_t fat_dentry_chksum(uint8_t *);
 
-extern size_t fat_lfn_str_nlength(const unaligned_uint16_t *, size_t);
+extern size_t fat_lfn_str_ncode_points(const unaligned_uint16_t *, size_t);
 extern size_t fat_lfn_size(const fat_dentry_t *);
 extern size_t fat_lfn_get_entry(const fat_dentry_t *, uint16_t *, size_t *);
 extern size_t fat_lfn_set_entry(const uint16_t *, size_t *, size_t,

--- a/uspace/srv/fs/fat/fat_directory.c
+++ b/uspace/srv/fs/fat/fat_directory.c
@@ -357,7 +357,7 @@ errno_t fat_directory_create_sfn(fat_directory_t *di, fat_dentry_t *de,
 	memset(ext, FAT_PAD, FAT_EXT_LEN);
 	memset(number, FAT_PAD, FAT_NAME_LEN);
 
-	size_t name_len = str_size(lname);
+	size_t name_len = str_bytes(lname);
 	char *pdot = str_rchr(lname, '.');
 	ext[FAT_EXT_LEN] = '\0';
 	if (pdot) {
@@ -376,19 +376,19 @@ errno_t fat_directory_create_sfn(fat_directory_t *di, fat_dentry_t *de,
 		/* Fill de->name with FAT_PAD */
 		memset(de->name, FAT_PAD, FAT_NAME_LEN + FAT_EXT_LEN);
 		/* Copy ext */
-		memcpy(de->ext, ext, str_size(ext));
+		memcpy(de->ext, ext, str_bytes(ext));
 		/* Copy name */
-		memcpy(de->name, name, str_size(name));
+		memcpy(de->name, name, str_bytes(name));
 
 		/* Copy number */
 		size_t offset;
-		if (str_size(name) + str_size(number) + 1 > FAT_NAME_LEN)
-			offset = FAT_NAME_LEN - str_size(number) - 1;
+		if (str_bytes(name) + str_bytes(number) + 1 > FAT_NAME_LEN)
+			offset = FAT_NAME_LEN - str_bytes(number) - 1;
 		else
-			offset = str_size(name);
+			offset = str_bytes(name);
 		de->name[offset] = '~';
 		offset++;
-		memcpy(de->name + offset, number, str_size(number));
+		memcpy(de->name + offset, number, str_bytes(number));
 
 		if (!fat_directory_is_sfn_exist(di, de))
 			return EOK;

--- a/uspace/srv/fs/fat/fat_ops.c
+++ b/uspace/srv/fs/fat/fat_ops.c
@@ -1307,7 +1307,7 @@ fat_read(service_id_t service_id, fs_index_t index, aoff64_t pos,
 		if (rc != EOK)
 			goto err;
 		(void) async_data_read_finalize(&call, name,
-		    str_size(name) + 1);
+		    str_bytes(name) + 1);
 		bytes = (pos - spos) + 1;
 	}
 

--- a/uspace/srv/fs/locfs/locfs_ops.c
+++ b/uspace/srv/fs/locfs/locfs_ops.c
@@ -499,7 +499,7 @@ locfs_read(service_id_t service_id, fs_index_t index, aoff64_t pos,
 		}
 
 		if (pos < count) {
-			async_data_read_finalize(&call, desc[pos].name, str_size(desc[pos].name) + 1);
+			async_data_read_finalize(&call, desc[pos].name, str_bytes(desc[pos].name) + 1);
 			free(desc);
 			*rbytes = 1;
 			return EOK;
@@ -514,7 +514,7 @@ locfs_read(service_id_t service_id, fs_index_t index, aoff64_t pos,
 			count = loc_get_services(namespace, &desc);
 
 			if (pos < count) {
-				async_data_read_finalize(&call, desc[pos].name, str_size(desc[pos].name) + 1);
+				async_data_read_finalize(&call, desc[pos].name, str_bytes(desc[pos].name) + 1);
 				free(desc);
 				*rbytes = 1;
 				return EOK;
@@ -542,7 +542,7 @@ locfs_read(service_id_t service_id, fs_index_t index, aoff64_t pos,
 		size_t count = loc_get_services(index, &desc);
 
 		if (pos < count) {
-			async_data_read_finalize(&call, desc[pos].name, str_size(desc[pos].name) + 1);
+			async_data_read_finalize(&call, desc[pos].name, str_bytes(desc[pos].name) + 1);
 			free(desc);
 			*rbytes = 1;
 			return EOK;

--- a/uspace/srv/fs/mfs/mfs_dentry.c
+++ b/uspace/srv/fs/mfs/mfs_dentry.c
@@ -163,7 +163,7 @@ mfs_remove_dentry(struct mfs_node *mnode, const char *d_name)
 	struct mfs_dentry_info d_info;
 	errno_t r;
 
-	const size_t name_len = str_size(d_name);
+	const size_t name_len = str_bytes(d_name);
 
 	if (name_len > sbi->max_name_len)
 		return ENAMETOOLONG;
@@ -175,7 +175,7 @@ mfs_remove_dentry(struct mfs_node *mnode, const char *d_name)
 		if (r != EOK)
 			return r;
 
-		const size_t d_name_len = str_size(d_info.d_name);
+		const size_t d_name_len = str_bytes(d_info.d_name);
 
 		if (name_len == d_name_len &&
 		    memcmp(d_info.d_name, d_name, name_len) == 0) {
@@ -206,7 +206,7 @@ mfs_insert_dentry(struct mfs_node *mnode, const char *d_name,
 	struct mfs_dentry_info d_info;
 	bool empty_dentry_found = false;
 
-	const size_t name_len = str_size(d_name);
+	const size_t name_len = str_bytes(d_name);
 
 	if (name_len > sbi->max_name_len)
 		return ENAMETOOLONG;

--- a/uspace/srv/fs/mfs/mfs_ops.c
+++ b/uspace/srv/fs/mfs/mfs_ops.c
@@ -494,7 +494,7 @@ mfs_match(fs_node_t **rfn, fs_node_t *pfn, const char *component)
 		return ENOTDIR;
 
 	struct mfs_sb_info *sbi = mnode->instance->sbi;
-	const size_t comp_size = str_size(component);
+	const size_t comp_size = str_bytes(component);
 
 	unsigned i;
 	for (i = 0; i < mnode->ino_i->i_size / sbi->dirsize; ++i) {
@@ -507,7 +507,7 @@ mfs_match(fs_node_t **rfn, fs_node_t *pfn, const char *component)
 			continue;
 		}
 
-		const size_t dentry_name_size = str_size(d_info.d_name);
+		const size_t dentry_name_size = str_bytes(d_info.d_name);
 
 		if (comp_size == dentry_name_size &&
 		    memcmp(component, d_info.d_name, dentry_name_size) == 0) {
@@ -702,7 +702,7 @@ mfs_link(fs_node_t *pfn, fs_node_t *cfn, const char *name)
 	struct mfs_sb_info *sbi = parent->instance->sbi;
 	bool destroy_dentry = false;
 
-	if (str_size(name) > sbi->max_name_len)
+	if (str_bytes(name) > sbi->max_name_len)
 		return ENAMETOOLONG;
 
 	errno_t r = mfs_insert_dentry(parent, name, child->ino_i->index);
@@ -872,7 +872,7 @@ mfs_read(service_id_t service_id, fs_index_t index, aoff64_t pos,
 		return rc;
 	found:
 		async_data_read_finalize(&call, d_info.d_name,
-		    str_size(d_info.d_name) + 1);
+		    str_bytes(d_info.d_name) + 1);
 		bytes = ((pos - spos) + 1);
 	} else {
 		struct mfs_sb_info *sbi = mnode->instance->sbi;

--- a/uspace/srv/fs/tmpfs/tmpfs_ops.c
+++ b/uspace/srv/fs/tmpfs/tmpfs_ops.c
@@ -374,7 +374,7 @@ errno_t tmpfs_link_node(fs_node_t *pfn, fs_node_t *cfn, const char *nm)
 	tmpfs_dentry_initialize(dentryp);
 
 	/* Populate and link the new dentry. */
-	size_t size = str_size(nm);
+	size_t size = str_bytes(nm);
 	dentryp->name = malloc(size + 1);
 	if (!dentryp->name) {
 		free(dentryp);
@@ -515,7 +515,7 @@ static errno_t tmpfs_read(service_id_t service_id, fs_index_t index, aoff64_t po
 		dentryp = list_get_instance(lnk, tmpfs_dentry_t, link);
 
 		(void) async_data_read_finalize(&call, dentryp->name,
-		    str_size(dentryp->name) + 1);
+		    str_bytes(dentryp->name) + 1);
 		bytes = 1;
 	}
 

--- a/uspace/srv/fs/udf/udf_ops.c
+++ b/uspace/srv/fs/udf/udf_ops.c
@@ -501,7 +501,7 @@ static errno_t udf_read(service_id_t service_id, fs_index_t index, aoff64_t pos,
 			    (char *) fid->implementation_use + FLE16(fid->length_iu),
 			    fid->length_file_id, &node->instance->charset);
 
-			async_data_read_finalize(&call, name, str_size(name) + 1);
+			async_data_read_finalize(&call, name, str_bytes(name) + 1);
 			*rbytes = 1;
 			free(name);
 			udf_node_put(rfn);

--- a/uspace/srv/fs/udf/udf_osta.c
+++ b/uspace/srv/fs/udf/udf_osta.c
@@ -289,7 +289,7 @@ void udf_to_unix_name(char *result, size_t result_len, char *id, size_t len,
 	} else {
 		/* Assume 8 bit char length byte Latin-1 */
 		str_ncpy(result, result_len, (char *) (id + 1),
-		    str_size((char *) (id + 1)));
+		    str_bytes((char *) (id + 1)));
 	}
 
 	free(raw_name);

--- a/uspace/srv/hid/console/console.c
+++ b/uspace/srv/hid/console/console.c
@@ -372,7 +372,7 @@ static errno_t cons_read(con_srv_t *srv, void *buf, size_t size, size_t *nread)
 			if ((event->type == KEY_PRESS) && (event->c != 0)) {
 				wchar_t tmp[2] = { event->c, 0 };
 				wstr_to_str(cons->char_remains, UTF8_CHAR_BUFFER_SIZE, tmp);
-				cons->char_remains_len = str_size(cons->char_remains);
+				cons->char_remains_len = str_bytes(cons->char_remains);
 			}
 
 			free(event);

--- a/uspace/srv/hid/isdv4_tablet/main.c
+++ b/uspace/srv/hid/isdv4_tablet/main.c
@@ -190,9 +190,9 @@ int main(int argc, char **argv)
 	isdv4_event_fn event_fn = emit_event;
 
 	if (argc > arg && str_test_prefix(argv[arg], "--baud=")) {
-		size_t arg_offset = str_lsize(argv[arg], 7);
+		size_t arg_offset = str_lbytes(argv[arg], 7);
 		char *arg_str = argv[arg] + arg_offset;
-		if (str_length(arg_str) == 0) {
+		if (str_code_points(arg_str) == 0) {
 			fprintf(stderr, "--baud requires an argument\n");
 			syntax_print();
 			return 1;

--- a/uspace/srv/hid/rfb/rfb.c
+++ b/uspace/srv/hid/rfb/rfb.c
@@ -654,7 +654,7 @@ static void rfb_socket_connection(rfb_t *rfb, tcp_conn_t *conn)
 
 	/* Server init */
 	fibril_mutex_lock(&rfb->lock);
-	size_t name_length = str_length(rfb->name);
+	size_t name_length = str_code_points(rfb->name);
 	size_t msg_length = sizeof(rfb_server_init_t) + name_length;
 	rfb_server_init_t *server_init = malloc(msg_length);
 	if (server_init == NULL) {

--- a/uspace/srv/loader/main.c
+++ b/uspace/srv/loader/main.c
@@ -185,7 +185,7 @@ static void ldr_set_args(ipc_call_t *req)
 		int count = 0;
 
 		while (cur < buf + buf_size) {
-			size_t arg_size = str_size(cur);
+			size_t arg_size = str_bytes(cur);
 			cur += arg_size + 1;
 			count++;
 		}
@@ -208,7 +208,7 @@ static void ldr_set_args(ipc_call_t *req)
 		while (cur < buf + buf_size) {
 			_argv[count] = cur;
 
-			size_t arg_size = str_size(cur);
+			size_t arg_size = str_bytes(cur);
 			cur += arg_size + 1;
 			count++;
 		}

--- a/uspace/srv/locsrv/locsrv.c
+++ b/uspace/srv/locsrv/locsrv.c
@@ -590,7 +590,7 @@ static void loc_category_get_name(ipc_call_t *icall)
 		return;
 	}
 
-	act_size = str_size(cat->name);
+	act_size = str_bytes(cat->name);
 	if (act_size > size) {
 		fibril_mutex_unlock(&cdir.mutex);
 		async_answer_0(&call, EOVERFLOW);
@@ -637,7 +637,7 @@ static void loc_service_get_name(ipc_call_t *icall)
 		return;
 	}
 
-	act_size = str_size(fqn);
+	act_size = str_bytes(fqn);
 	if (act_size > size) {
 		free(fqn);
 		fibril_mutex_unlock(&services_list_mutex);
@@ -685,7 +685,7 @@ static void loc_service_get_server_name(ipc_call_t *icall)
 		return;
 	}
 
-	act_size = str_size(svc->server->name);
+	act_size = str_bytes(svc->server->name);
 	if (act_size > size) {
 		fibril_mutex_unlock(&services_list_mutex);
 		async_answer_0(&call, EOVERFLOW);

--- a/uspace/srv/net/dnsrsrv/dns_msg.c
+++ b/uspace/srv/net/dnsrsrv/dns_msg.c
@@ -68,8 +68,8 @@ static errno_t dns_dstr_ext(char **dstr, const char *suff)
 		return EOK;
 	}
 
-	s1 = str_size(*dstr);
-	s2 = str_size(suff);
+	s1 = str_bytes(*dstr);
+	s2 = str_bytes(suff);
 	nsize = s1 + s2 + 1;
 
 	nstr = realloc(*dstr, nsize);

--- a/uspace/srv/net/dnsrsrv/dnsrsrv.c
+++ b/uspace/srv/net/dnsrsrv/dnsrsrv.c
@@ -133,7 +133,7 @@ static void dnsr_name2host_srv(dnsr_client_t *client, ipc_call_t *icall)
 		return;
 	}
 
-	size_t act_size = str_size(hinfo->cname);
+	size_t act_size = str_bytes(hinfo->cname);
 	if (act_size > size) {
 		async_answer_0(&call, EINVAL);
 		async_answer_0(icall, EINVAL);

--- a/uspace/srv/net/inetsrv/inetcfg.c
+++ b/uspace/srv/net/inetsrv/inetcfg.c
@@ -353,7 +353,7 @@ static void inetcfg_addr_get_srv(ipc_call_t *icall)
 	}
 
 	rc = async_data_read_finalize(&call, ainfo.name,
-	    min(size, str_size(ainfo.name)));
+	    min(size, str_bytes(ainfo.name)));
 	free(ainfo.name);
 
 	if (rc != EOK) {
@@ -542,7 +542,7 @@ static void inetcfg_link_get_srv(ipc_call_t *call)
 	}
 
 	errno_t retval = async_data_read_finalize(&name, linfo.name,
-	    min(name_max_size, str_size(linfo.name)));
+	    min(name_max_size, str_bytes(linfo.name)));
 	if (retval != EOK) {
 		free(linfo.name);
 		async_answer_0(&laddr, retval);
@@ -709,7 +709,7 @@ static void inetcfg_sroute_get_srv(ipc_call_t *icall)
 	}
 
 	rc = async_data_read_finalize(&call, srinfo.name,
-	    min(size, str_size(srinfo.name)));
+	    min(size, str_bytes(srinfo.name)));
 	free(srinfo.name);
 
 	async_answer_0(icall, rc);

--- a/uspace/srv/net/nconfsrv/iplink.c
+++ b/uspace/srv/net/nconfsrv/iplink.c
@@ -151,7 +151,7 @@ static errno_t ncs_link_add(service_id_t sid)
 		goto error;
 	}
 
-	if (str_lcmp(nlink->svc_name, "net/eth", str_length("net/eth")) == 0) {
+	if (str_lcmp(nlink->svc_name, "net/eth", str_code_points("net/eth")) == 0) {
 		rc = dhcp_link_add(sid);
 		if (rc != EOK) {
 			log_msg(LOG_DEFAULT, LVL_ERROR, "Failed configuring DHCP on "

--- a/uspace/srv/net/tcp/test.c
+++ b/uspace/srv/net/tcp/test.c
@@ -113,7 +113,7 @@ static errno_t test_cli(void *arg)
 
 	fibril_usleep(1000 * 1000 * 10);
 	printf("C: User send...\n");
-	tcp_uc_send(conn, (void *)msg, str_size(msg), 0);
+	tcp_uc_send(conn, (void *)msg, str_bytes(msg), 0);
 
 	fibril_usleep(1000 * 1000 * 20/**20*2*/);
 	printf("C: User close...\n");

--- a/uspace/srv/vfs/vfs_lookup.c
+++ b/uspace/srv/vfs/vfs_lookup.c
@@ -166,7 +166,7 @@ errno_t vfs_link_internal(vfs_node_t *base, char *path, vfs_triplet_t *child)
 			goto out;
 		}
 
-		memcpy(component, slash + 1, str_size(slash));
+		memcpy(component, slash + 1, str_bytes(slash));
 		*slash = 0;
 
 		rc = vfs_lookup_internal(base, path, L_DIRECTORY, &res);
@@ -181,7 +181,7 @@ errno_t vfs_link_internal(vfs_node_t *base, char *path, vfs_triplet_t *child)
 			goto out;
 		}
 
-		memcpy(component, path + 1, str_size(path));
+		memcpy(component, path + 1, str_bytes(path));
 		triplet = (vfs_triplet_t *) base;
 	}
 
@@ -195,7 +195,7 @@ errno_t vfs_link_internal(vfs_node_t *base, char *path, vfs_triplet_t *child)
 	aid_t req = async_send_3(exch, VFS_OUT_LINK, triplet->service_id,
 	    triplet->index, child->index, NULL);
 
-	rc = async_data_write_start(exch, component, str_size(component) + 1);
+	rc = async_data_write_start(exch, component, str_bytes(component) + 1);
 	errno_t orig_rc;
 	async_wait_for(req, &orig_rc);
 	vfs_exchange_release(exch);

--- a/uspace/srv/vfs/vfs_ops.c
+++ b/uspace/srv/vfs/vfs_ops.c
@@ -151,7 +151,7 @@ static errno_t vfs_connect_internal(service_id_t service_id, unsigned flags,
 	aid_t msg = async_send_1(exch, VFS_OUT_MOUNTED, (sysarg_t) service_id,
 	    &answer);
 	/* Send the mount options */
-	errno_t rc = async_data_write_start(exch, options, str_size(options));
+	errno_t rc = async_data_write_start(exch, options, str_bytes(options));
 	if (rc != EOK) {
 		async_forget(msg);
 		vfs_exchange_release(exch);

--- a/uspace/srv/vfs/vfs_register.c
+++ b/uspace/srv/vfs/vfs_register.c
@@ -355,7 +355,7 @@ errno_t vfs_get_fstypes(vfs_fstypes_t *fstypes)
 	size = 0;
 	count = 0;
 	list_foreach(fs_list, fs_link, fs_info_t, fs) {
-		size += str_size(fs->vfs_info.name) + 1;
+		size += str_bytes(fs->vfs_info.name) + 1;
 		count++;
 	}
 
@@ -381,7 +381,7 @@ errno_t vfs_get_fstypes(vfs_fstypes_t *fstypes)
 	size = 0;
 	count = 0;
 	list_foreach(fs_list, fs_link, fs_info_t, fs) {
-		l = str_size(fs->vfs_info.name) + 1;
+		l = str_bytes(fs->vfs_info.name) + 1;
 		memcpy(fstypes->buf + size, fs->vfs_info.name, l);
 		fstypes->fstypes[count] = &fstypes->buf[size];
 		size += l;

--- a/uspace/srv/volsrv/mkfs.c
+++ b/uspace/srv/volsrv/mkfs.c
@@ -132,7 +132,7 @@ errno_t volsrv_part_mkfs(service_id_t sid, vol_fstype_t fstype, const char *labe
 	if (rc != EOK)
 		return rc;
 
-	if (str_size(label) > 0)
+	if (str_bytes(label) > 0)
 		rc = cmd_runl(cmd, cmd, "--label", label, svc_name, NULL);
 	else
 		rc = cmd_runl(cmd, cmd, svc_name, NULL);

--- a/uspace/srv/volsrv/part.c
+++ b/uspace/srv/volsrv/part.c
@@ -314,7 +314,7 @@ static errno_t vol_part_determine_mount_path(vol_part_t *part, char **rpath,
 	int err;
 
 	/* Get configured mount point */
-	if (str_size(part->volume->mountp) > 0) {
+	if (str_bytes(part->volume->mountp) > 0) {
 		cfg_mp = part->volume->mountp;
 		log_msg(LOG_DEFAULT, LVL_NOTE, "Configured mount point '%s'",
 		    cfg_mp);
@@ -326,7 +326,7 @@ static errno_t vol_part_determine_mount_path(vol_part_t *part, char **rpath,
 
 	if (str_cmp(cfg_mp, "Auto") == 0 || str_cmp(cfg_mp, "auto") == 0) {
 
-		if (str_size(part->label) < 1) {
+		if (str_bytes(part->label) < 1) {
 			/* Don't mount nameless volumes */
 			*rpath = NULL;
 			*rauto = false;

--- a/uspace/srv/volsrv/volume.c
+++ b/uspace/srv/volsrv/volume.c
@@ -246,7 +246,7 @@ static errno_t vol_volume_lookup_ref_locked(vol_volumes_t *volumes,
 
 	list_foreach(volumes->volumes, lvolumes, vol_volume_t, volume) {
 		if (str_cmp(volume->label, label) == 0 &&
-		    str_size(label) > 0) {
+		    str_bytes(label) > 0) {
 			/* Add reference */
 			refcount_up(&volume->refcnt);
 			*rvolume = volume;
@@ -355,7 +355,7 @@ errno_t vol_volume_find_by_id_ref(vol_volumes_t *volumes, volume_id_t vid,
  */
 static bool vol_volume_is_persist(vol_volume_t *volume)
 {
-	return str_size(volume->mountp) > 0;
+	return str_bytes(volume->mountp) > 0;
 }
 
 /** Delete reference to volume.


### PR DESCRIPTION
Instead of ambiguous terms "size", "length", and "characters", use unambiguous terms "bytes" and "code points", including in function names.

Function name changes:
`(w)str_(ln)size` -> `(w)str_(ln)bytes`
`(w)str_(n)length` -> `(w)str_(n)code_points`

The purpose of this change is to avoid confusing the purpose of those functions, especially given the conflicting terminology of standard `strlen`, and the nonexistence of the term "character" in Unicode (there we have code units, code points, and grapheme clusters, only the last of which actually being what's colloquially understood as a character).