### PR TITLE
[RFC] Do not use preprocessor macros in `abi/`

### DIFF
--- a/abi/include/abi/cap.h
+++ b/abi/include/abi/cap.h
@@ -38,7 +38,9 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#define CAP_NIL  0
+enum {
+	CAP_NIL = 0,
+};
 
 typedef void *cap_handle_t;
 

--- a/abi/include/abi/ddi/arg.h
+++ b/abi/include/abi/ddi/arg.h
@@ -37,7 +37,9 @@
 
 #include <stdint.h>
 
-#define DMAMEM_FLAGS_ANONYMOUS  0x01
+enum {
+	DMAMEM_FLAGS_ANONYMOUS = 0x01,
+};
 
 /** Structure encapsulating arguments for SYS_PHYSMEM_MAP syscall. */
 typedef struct {

--- a/abi/include/abi/elf.h
+++ b/abi/include/abi/elf.h
@@ -41,154 +41,207 @@
 /**
  * Current ELF version
  */
-#define EV_CURRENT  1
+enum {
+	EV_CURRENT = 1,
+};
 
 /**
  * ELF types
  */
-#define ET_NONE    0       /* No type */
-#define ET_REL     1       /* Relocatable file */
-#define ET_EXEC    2       /* Executable */
-#define ET_DYN     3       /* Shared object */
-#define ET_CORE    4       /* Core */
-#define ET_LOPROC  0xff00  /* Processor specific */
-#define ET_HIPROC  0xffff  /* Processor specific */
+enum elf_type {
+	ET_NONE   = 0,       /* No type */
+	ET_REL    = 1,       /* Relocatable file */
+	ET_EXEC   = 2,       /* Executable */
+	ET_DYN    = 3,       /* Shared object */
+	ET_CORE   = 4,       /* Core */
+};
+
+enum {
+	ET_LOPROC = 0xff00,  /* Lowest processor specific */
+	ET_HIPROC = 0xffff,  /* Highest processor specific */
+};
 
 /**
  * ELF machine types
  */
-#define EM_NO           0    /* No machine */
-#define EM_SPARC        2    /* SPARC */
-#define EM_386          3    /* i386 */
-#define EM_MIPS         8    /* MIPS RS3000 */
-#define EM_MIPS_RS3_LE  10   /* MIPS RS3000 LE */
-#define EM_PPC          20   /* PPC32 */
-#define EM_PPC64        21   /* PPC64 */
-#define EM_ARM          40   /* ARM */
-#define EM_SPARCV9      43   /* SPARC64 */
-#define EM_IA_64        50   /* IA-64 */
-#define EM_X86_64       62   /* AMD64/EMT64 */
-#define EM_RISCV        243  /* RISC-V */
+enum elf_machine {
+	EM_NO          = 0,    /* No machine */
+	EM_SPARC       = 2,    /* SPARC */
+	EM_386         = 3,    /* i386 */
+	EM_MIPS        = 8,    /* MIPS RS3000 */
+	EM_MIPS_RS3_LE = 10,   /* MIPS RS3000 LE */
+	EM_PPC         = 20,   /* PPC32 */
+	EM_PPC64       = 21,   /* PPC64 */
+	EM_ARM         = 40,   /* ARM */
+	EM_SPARCV9     = 43,   /* SPARC64 */
+	EM_IA_64       = 50,   /* IA-64 */
+	EM_X86_64      = 62,   /* AMD64/EMT64 */
+	EM_RISCV       = 243,  /* RISC-V */
+};
 
 /**
  * ELF identification indexes
  */
-#define EI_MAG0        0
-#define EI_MAG1        1
-#define EI_MAG2        2
-#define EI_MAG3        3
-#define EI_CLASS       4   /* File class */
-#define EI_DATA        5   /* Data encoding */
-#define EI_VERSION     6   /* File version */
-#define EI_OSABI       7
-#define EI_ABIVERSION  8
-#define EI_PAD         9   /* Start of padding bytes */
-#define EI_NIDENT      16  /* ELF identification table size */
+enum {
+	EI_MAG0       = 0,
+	EI_MAG1       = 1,
+	EI_MAG2       = 2,
+	EI_MAG3       = 3,
+	EI_CLASS      = 4,   /* File class */
+	EI_DATA       = 5,   /* Data encoding */
+	EI_VERSION    = 6,   /* File version */
+	EI_OSABI      = 7,
+	EI_ABIVERSION = 8,
+	EI_PAD        = 9,   /* Start of padding bytes */
+	EI_NIDENT     = 16,  /* ELF identification table size */
+};
 
 /**
  * ELF magic number
  */
-#define ELFMAG0  0x7f
-#define ELFMAG1  'E'
-#define ELFMAG2  'L'
-#define ELFMAG3  'F'
+enum {
+	ELFMAG0 = 0x7f,
+	ELFMAG1 = 'E',
+	ELFMAG2 = 'L',
+	ELFMAG3 = 'F',
+};
 
 /**
  * ELF file classes
  */
-#define ELFCLASSNONE  0
-#define ELFCLASS32    1
-#define ELFCLASS64    2
+enum elf_class {
+	ELFCLASSNONE = 0,
+	ELFCLASS32   = 1,
+	ELFCLASS64   = 2,
+};
 
 /**
  * ELF data encoding types
  */
-#define ELFDATANONE  0
-#define ELFDATA2LSB  1  /* Least significant byte first (little endian) */
-#define ELFDATA2MSB  2  /* Most signigicant byte first (big endian) */
+enum elf_data_encoding {
+	ELFDATANONE = 0,
+	ELFDATA2LSB = 1,  /* Least significant byte first (little endian) */
+	ELFDATA2MSB = 2,  /* Most signigicant byte first (big endian) */
+};
 
 /**
  * ELF section types
  */
-#define SHT_NULL      0
-#define SHT_PROGBITS  1
-#define SHT_SYMTAB    2
-#define SHT_STRTAB    3
-#define SHT_RELA      4
-#define SHT_HASH      5
-#define SHT_DYNAMIC   6
-#define SHT_NOTE      7
-#define SHT_NOBITS    8
-#define SHT_REL       9
-#define SHT_SHLIB     10
-#define SHT_DYNSYM    11
-#define SHT_LOOS      0x60000000
-#define SHT_HIOS      0x6fffffff
-#define SHT_LOPROC    0x70000000
-#define SHT_HIPROC    0x7fffffff
-#define SHT_LOUSER    0x80000000
-#define SHT_HIUSER    0xffffffff
+enum elf_section_type {
+	SHT_NULL     = 0,
+	SHT_PROGBITS = 1,
+	SHT_SYMTAB   = 2,
+	SHT_STRTAB   = 3,
+	SHT_RELA     = 4,
+	SHT_HASH     = 5,
+	SHT_DYNAMIC  = 6,
+	SHT_NOTE     = 7,
+	SHT_NOBITS   = 8,
+	SHT_REL      = 9,
+	SHT_SHLIB    = 10,
+	SHT_DYNSYM   = 11,
+};
+
+enum {
+	SHT_LOOS     = 0x60000000,
+	SHT_HIOS     = 0x6fffffff,
+	SHT_LOPROC   = 0x70000000,
+	SHT_HIPROC   = 0x7fffffff,
+	SHT_LOUSER   = 0x80000000,
+	SHT_HIUSER   = 0xffffffff,
+};
 
 /**
  * ELF section flags
  */
-#define SHF_WRITE      0x1
-#define SHF_ALLOC      0x2
-#define SHF_EXECINSTR  0x4
-#define SHF_TLS        0x400
-#define SHF_MASKPROC   0xf0000000
+enum {
+	SHF_WRITE     = 0x1,
+	SHF_ALLOC     = 0x2,
+	SHF_EXECINSTR = 0x4,
+	SHF_TLS       = 0x400,
+	SHF_MASKPROC  = 0xf0000000,
+};
 
-/** Macros for decomposing elf_symbol.st_info into binging and type */
-#define ELF_ST_BIND(i)     ((i) >> 4)
-#define ELF_ST_TYPE(i)     ((i) & 0x0f)
-#define ELF_ST_INFO(b, t)  (((b) << 4) + ((t) & 0x0f))
+/** Functions for decomposing elf_symbol.st_info into binding and type */
+static inline uint8_t elf_st_bind(uint8_t info)
+{
+	return info >> 4;
+}
+
+static inline uint8_t elf_st_type(uint8_t info)
+{
+	return info & 0x0f;
+}
+
+static inline uint8_t elf_st_info(uint8_t bind, uint8_t type)
+{
+	return (bind << 4) | (type & 0x0f);
+}
 
 /**
  * Symbol binding
  */
-#define STB_LOCAL   0
-#define STB_GLOBAL  1
-#define STB_WEAK    2
-#define STB_LOPROC  13
-#define STB_HIPROC  15
+enum elf_symbol_binding {
+	STB_LOCAL  = 0,
+	STB_GLOBAL = 1,
+	STB_WEAK   = 2,
+};
+
+enum {
+	STB_LOPROC = 13,
+	STB_HIPROC = 15,
+};
 
 /**
  * Symbol types
  */
-#define STT_NOTYPE   0
-#define STT_OBJECT   1
-#define STT_FUNC     2
-#define STT_SECTION  3
-#define STT_FILE     4
-#define STT_TLS      6
-#define STT_LOPROC   13
-#define STT_HIPROC   15
+enum elf_symbol_type {
+	STT_NOTYPE  = 0,
+	STT_OBJECT  = 1,
+	STT_FUNC    = 2,
+	STT_SECTION = 3,
+	STT_FILE    = 4,
+	STT_TLS     = 6,
+};
+
+enum {
+	STT_LOPROC  = 13,
+	STT_HIPROC  = 15,
+};
 
 /**
  * Program segment types
  */
-#define PT_NULL          0
-#define PT_LOAD          1
-#define PT_DYNAMIC       2
-#define PT_INTERP        3
-#define PT_NOTE          4
-#define PT_SHLIB         5
-#define PT_PHDR          6
-#define PT_TLS           7
-#define PT_LOOS          0x60000000
-#define PT_GNU_EH_FRAME  0x6474e550
-#define PT_GNU_STACK     0x6474e551
-#define PT_GNU_RELRO     0x6474e552
-#define PT_HIOS          0x6fffffff
-#define PT_LOPROC        0x70000000
-#define PT_HIPROC        0x7fffffff
+enum elf_segment_type {
+	PT_NULL         = 0,
+	PT_LOAD         = 1,
+	PT_DYNAMIC      = 2,
+	PT_INTERP       = 3,
+	PT_NOTE         = 4,
+	PT_SHLIB        = 5,
+	PT_PHDR         = 6,
+	PT_TLS          = 7,
+
+	PT_GNU_EH_FRAME = 0x6474e550,
+	PT_GNU_STACK    = 0x6474e551,
+	PT_GNU_RELRO    = 0x6474e552,
+};
+
+enum {
+	PT_LOOS   = 0x60000000,
+	PT_HIOS   = 0x6fffffff,
+	PT_LOPROC = 0x70000000,
+	PT_HIPROC = 0x7fffffff,
+};
 
 /**
  * Program segment attributes.
  */
-#define PF_X  1
-#define PF_W  2
-#define PF_R  4
+enum elf_segment_access {
+	PF_X = 1,
+	PF_W = 2,
+	PF_R = 4,
+};
 
 /**
  * ELF data types

--- a/abi/include/abi/ipc/interfaces.h
+++ b/abi/include/abi/ipc/interfaces.h
@@ -39,8 +39,10 @@
 
 #include <abi/fourcc.h>
 
-#define IFACE_EXCHANGE_MASK  0x03
-#define IFACE_MOD_MASK       0x04
+enum {
+	IFACE_EXCHANGE_MASK = 0x03,
+	IFACE_MOD_MASK      = 0x04,
+};
 
 /** Interface exchange management style
  *

--- a/abi/include/abi/ipc/ipc.h
+++ b/abi/include/abi/ipc/ipc.h
@@ -40,59 +40,70 @@
 #include <abi/cap.h>
 #include <_bits/errno.h>
 
-/** Length of data being transferred with IPC call
- *
- * The uspace may not be able to utilize the full length
- *
- */
-#define IPC_CALL_LEN  6
+/* Miscellaneous constants */
+enum {
+	/** Length of data being transferred with IPC call
+	 *
+	 * The uspace may not be able to utilize the full length
+	 *
+	 */
+	IPC_CALL_LEN = 6,
 
-/** Maximum active async calls per phone */
-#define IPC_MAX_ASYNC_CALLS  64
+	/** Maximum active async calls per phone */
+	IPC_MAX_ASYNC_CALLS = 64,
+
+	/**
+	 * Maximum buffer size allowed for IPC_M_DATA_WRITE and
+	 * IPC_M_DATA_READ requests.
+	 */
+	DATA_XFER_LIMIT = 64 * 1024,
+};
 
 /* Flags for calls */
+enum {
+	/** This is answer to a call */
+	IPC_CALL_ANSWERED       = 1 << 0,
 
-/** This is answer to a call */
-#define IPC_CALL_ANSWERED        (1 << 0)
+	/** Answer will not be passed to userspace, will be discarded */
+	IPC_CALL_DISCARD_ANSWER = 1 << 1,
 
-/** Answer will not be passed to userspace, will be discarded */
-#define IPC_CALL_DISCARD_ANSWER  (1 << 1)
+	/** Call was forwarded */
+	IPC_CALL_FORWARDED      = 1 << 2,
 
-/** Call was forwarded */
-#define IPC_CALL_FORWARDED       (1 << 2)
+	/** Interrupt notification */
+	IPC_CALL_NOTIF          = 1 << 3,
 
-/** Interrupt notification */
-#define IPC_CALL_NOTIF           (1 << 3)
-
-/** The call was automatically answered by the kernel due to error */
-#define IPC_CALL_AUTO_REPLY      (1 << 4)
-
-/**
- * Maximum buffer size allowed for IPC_M_DATA_WRITE and
- * IPC_M_DATA_READ requests.
- */
-#define DATA_XFER_LIMIT  (64 * 1024)
+	/** The call was automatically answered by the kernel due to error */
+	IPC_CALL_AUTO_REPLY     = 1 << 4,
+};
 
 /* Forwarding flags. */
-#define IPC_FF_NONE  0
+enum {
+	IPC_FF_NONE = 0,
 
-/**
- * The call will be routed as though it was initially sent via the phone used to
- * forward it. This feature is intended to support the situation in which the
- * forwarded call needs to be handled by the same connection fibril as any other
- * calls that were initially sent by the forwarder to the same destination. This
- * flag has no imapct on routing replies.
- */
-#define IPC_FF_ROUTE_FROM_ME  (1 << 0)
+	/**
+	 * The call will be routed as though it was initially sent via the phone
+	 * used to forward it. This feature is intended to support the situation
+	 * in which the forwarded call needs to be handled by the same
+	 * connection fibril as any other calls that were initially sent by
+	 * the forwarder to the same destination.
+	 * This flag has no imapct on routing replies.
+	 */
+	IPC_FF_ROUTE_FROM_ME = 1 << 0,
+};
 
 /* Data transfer flags. */
-#define IPC_XF_NONE  0
+enum {
+	IPC_XF_NONE = 0,
 
-/** Restrict the transfer size if necessary. */
-#define IPC_XF_RESTRICT  (1 << 0)
+	/** Restrict the transfer size if necessary. */
+	IPC_XF_RESTRICT = 1 << 0,
+};
 
 /** User-defined IPC methods */
-#define IPC_FIRST_USER_METHOD  1024
+enum {
+	IPC_FIRST_USER_METHOD = 1024,
+};
 
 typedef struct {
 	sysarg_t args[IPC_CALL_LEN];

--- a/abi/include/abi/ipc/methods.h
+++ b/abi/include/abi/ipc/methods.h
@@ -38,12 +38,14 @@
 #include <abi/cap.h>
 
 /* Well known phone descriptors */
-#define PHONE_NS  ((cap_phone_handle_t) (CAP_NIL + 1))
+static cap_phone_handle_t const PHONE_NS = (cap_phone_handle_t) (CAP_NIL + 1);
 
 /** Kernel IPC interfaces
  *
  */
-#define IPC_IF_KERNEL  0
+enum {
+	IPC_IF_KERNEL = 0,
+};
 
 /** System-specific IPC methods
  *
@@ -51,7 +53,6 @@
  * have the implicit kernel interface zero (0).
  *
  */
-
 enum {
 	/** This message is sent to answerbox when the phone is hung up
 	 *
@@ -216,7 +217,9 @@ enum {
 };
 
 /** Last system IPC method */
-#define IPC_M_LAST_SYSTEM  511
+enum {
+	IPC_M_LAST_SYSTEM = 511,
+};
 
 #endif
 

--- a/abi/include/abi/kio.h
+++ b/abi/include/abi/kio.h
@@ -36,7 +36,7 @@
 #define _ABI_KIO_H_
 
 enum {
-	KIO_UNKNOW,
+	KIO_UNKNOWN,
 	KIO_WRITE,
 	KIO_UPDATE,
 	KIO_COMMAND

--- a/abi/include/abi/mm/as.h
+++ b/abi/include/abi/mm/as.h
@@ -38,17 +38,18 @@
 #include <abi/cap.h>
 
 /** Address space area flags. */
-#define AS_AREA_READ         0x01
-#define AS_AREA_WRITE        0x02
-#define AS_AREA_EXEC         0x04
-#define AS_AREA_CACHEABLE    0x08
-#define AS_AREA_GUARD        0x10
-#define AS_AREA_LATE_RESERVE 0x20
+enum {
+	AS_AREA_READ         = 0x01,
+	AS_AREA_WRITE        = 0x02,
+	AS_AREA_EXEC         = 0x04,
+	AS_AREA_CACHEABLE    = 0x08,
+	AS_AREA_GUARD        = 0x10,
+	AS_AREA_LATE_RESERVE = 0x20,
+};
 
-#define AS_AREA_ANY    ((void *) -1)
-#define AS_MAP_FAILED  ((void *) -1)
-
-#define AS_AREA_UNPAGED NULL
+static void *const AS_AREA_ANY = (void *) -1;
+static void *const AS_MAP_FAILED = (void *) -1;
+static void *const AS_AREA_UNPAGED = NULL;
 
 /** Address space area info exported to uspace. */
 typedef struct {

--- a/abi/include/abi/synch.h
+++ b/abi/include/abi/synch.h
@@ -35,17 +35,21 @@
 #ifndef _ABI_SYNCH_H_
 #define _ABI_SYNCH_H_
 
-/** Request with no timeout. */
-#define SYNCH_NO_TIMEOUT  0
+enum {
+	/** Request with no timeout. */
+	SYNCH_NO_TIMEOUT = 0,
+};
 
-/** No flags specified. */
-#define SYNCH_FLAGS_NONE           0
-/** Non-blocking operation request. */
-#define SYNCH_FLAGS_NON_BLOCKING   (1 << 0)
-/** Interruptible operation. */
-#define SYNCH_FLAGS_INTERRUPTIBLE  (1 << 1)
-/** Futex operation (makes sleep with timeout composable). */
-#define SYNCH_FLAGS_FUTEX          (1 << 2)
+enum {
+	/** No flags specified. */
+	SYNCH_FLAGS_NONE          = 0,
+	/** Non-blocking operation request. */
+	SYNCH_FLAGS_NON_BLOCKING  = 1 << 0,
+	/** Interruptible operation. */
+	SYNCH_FLAGS_INTERRUPTIBLE = 1 << 1,
+	/** Futex operation (makes sleep with timeout composable). */
+	SYNCH_FLAGS_FUTEX         = 1 << 2,
+};
 
 #endif
 

--- a/abi/include/abi/sysinfo.h
+++ b/abi/include/abi/sysinfo.h
@@ -41,12 +41,14 @@
 #include <abi/proc/thread.h>
 #include <stdint.h>
 
-/** Number of load components */
-#define LOAD_STEPS  3
+enum {
+	/** Number of load components */
+	LOAD_STEPS = 3,
 
-/** Maximum name sizes */
-#define TASK_NAME_BUFLEN  64
-#define EXC_NAME_BUFLEN   20
+	/** Maximum name sizes */
+	TASK_NAME_BUFLEN = 64,
+	EXC_NAME_BUFLEN  = 20,
+};
 
 /** Item value type
  *

--- a/uspace/app/taskdump/symtab.c
+++ b/uspace/app/taskdump/symtab.c
@@ -214,7 +214,7 @@ errno_t symtab_name_to_addr(symtab_t *st, const char *name, uintptr_t *addr)
 		if (st->sym[i].st_name == 0)
 			continue;
 
-		stype = ELF_ST_TYPE(st->sym[i].st_info);
+		stype = elf_st_type(st->sym[i].st_info);
 		if (stype != STT_OBJECT && stype != STT_FUNC)
 			continue;
 
@@ -256,7 +256,7 @@ errno_t symtab_addr_to_name(symtab_t *st, uintptr_t addr, char **name,
 		if (st->sym[i].st_name == 0)
 			continue;
 
-		stype = ELF_ST_TYPE(st->sym[i].st_info);
+		stype = elf_st_type(st->sym[i].st_info);
 		if (stype != STT_OBJECT && stype != STT_FUNC &&
 		    stype != STT_NOTYPE) {
 			continue;

--- a/uspace/lib/c/generic/rtld/symbol.c
+++ b/uspace/lib/c/generic/rtld/symbol.c
@@ -261,7 +261,7 @@ elf_symbol_t *symbol_def_find(const char *name, module_t *origin,
  */
 void *symbol_get_addr(elf_symbol_t *sym, module_t *m, tcb_t *tcb)
 {
-	if (ELF_ST_TYPE(sym->st_info) == STT_TLS) {
+	if (elf_st_type(sym->st_info) == STT_TLS) {
 		if (tcb == NULL)
 			return NULL;
 		return rtld_tls_get_addr(m->rtld, tcb, m->id, sym->st_value);


### PR DESCRIPTION
Builds upon PR#157, converting most of the macros present in `abi/` to C language constructs.