### PR TITLE
Added flex and bison as build deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ dependencies and try again.
 As an example, here are some of the packages you will need for Ubuntu 12.10 (may be out of date):
 
 ```
-$ sudo apt-get install build-essential libgmp-dev libmpfr-dev ppl-dev libmpc-dev zlib1g-dev texinfo libtinfo-dev xutils-dev
+$ sudo apt-get install build-essential libgmp-dev libmpfr-dev ppl-dev libmpc-dev zlib1g-dev texinfo libtinfo-dev xutils-dev flex bison
 ```
 
 Whereas for CentOS/Fedora, you will need:
 
 ```
 # sudo dnf group install 'Development Tools'
-# sudo dnf install wget texinfo libmpc-devel mpfr-devel gmp-devel PyYAML genisoimage
+# sudo dnf install wget texinfo libmpc-devel mpfr-devel gmp-devel PyYAML genisoimage flex bison
 ```
 In case the toolchain script won't work no matter how hard you try, let us know.
 Please supply as many relevant information (your OS and distribution, list of


### PR DESCRIPTION
Built on Fedora 29 and Ubuntu 18.10. Both packages needed to be installed otherwise the toolchain.sh would fail.