### PR TITLE
AArch64 post-merge clean up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@
 /Makefile.common
 /Makefile.config
 /PKG
-/QEMU_EFI_ARM64.fd
 /common.h
 /config.h
 /cscope.out

--- a/boot/arch/arm64/src/main.c
+++ b/boot/arch/arm64/src/main.c
@@ -190,12 +190,10 @@ efi_status_t bootstrap(void *efi_handle_in,
 	 */
 
 	/* Statically check PAGE_SIZE and BOOT_OFFSET. */
-#if PAGE_SIZE != 4096
-#error Unsupported PAGE_SIZE
-#endif
-#if !IS_ALIGNED(BOOT_OFFSET, PAGE_SIZE)
-#error Unsupported BOOT_OFFSET
-#endif
+	_Static_assert(PAGE_SIZE == 4096, "PAGE_SIZE must be equal to 4096");
+	_Static_assert(IS_ALIGNED(BOOT_OFFSET, PAGE_SIZE),
+	    "BOOT_OFFSET must be a multiple of PAGE_SIZE");
+
 	/*
 	 * Dynamically check the memory base. The condition should be always
 	 * true because UEFI guarantees each physical/virtual address in the

--- a/kernel/arch/arm64/src/interrupt.c
+++ b/kernel/arch/arm64/src/interrupt.c
@@ -52,7 +52,7 @@ ipl_t interrupts_disable(void)
 
 	DAIF_write(daif | DAIF_IRQ_FLAG);
 
-	return (daif >> DAIF_IRQ_SHIFT) & 1;
+	return daif & DAIF_IRQ_FLAG;
 }
 
 /** Enable interrupts.
@@ -65,7 +65,7 @@ ipl_t interrupts_enable(void)
 
 	DAIF_write(daif & ~DAIF_IRQ_FLAG);
 
-	return (daif >> DAIF_IRQ_SHIFT) & 1;
+	return daif & DAIF_IRQ_FLAG;
 }
 
 /** Restore interrupt priority level.
@@ -76,8 +76,7 @@ void interrupts_restore(ipl_t ipl)
 {
 	uint64_t daif = DAIF_read();
 
-	DAIF_write((daif & ~DAIF_IRQ_FLAG) |
-	    ((ipl & 1) << DAIF_IRQ_SHIFT));
+	DAIF_write((daif & ~DAIF_IRQ_FLAG) | (ipl & DAIF_IRQ_FLAG));
 }
 
 /** Read interrupt priority level.
@@ -86,7 +85,7 @@ void interrupts_restore(ipl_t ipl)
  */
 ipl_t interrupts_read(void)
 {
-	return (DAIF_read() >> DAIF_IRQ_SHIFT) & 1;
+	return DAIF_read() & DAIF_IRQ_FLAG;
 }
 
 /** Check interrupts state.


### PR DESCRIPTION
A few clean-up patches to address review comments in https://github.com/HelenOS/helenos/pull/165.

Note: The second patch in the series unifies firmware search in `tools/ew.py` for arm64 and sun4v. It changes the script to first search for firmware binaries by checking an environment variable, `EW_QEMU_EFI_AARCH64` for arm64 and `OPENSPARC_BINARIES` for sun4v. If this fails then the script tries finding the binaries in their expected default locations. If this also fails then an error is reported on stderr and the script exits.

However, I'm thinking this might not be the best approach. Perhaps, it would be better to introduce a similar scheme to how the HelenOS toolchain is searched first in `CROSS_PREFIX` and then `/usr/local/cross/`.

In case of `tools/ew.py`, firmware binaries could be first searched in something like `CROSS_FIRMWARE` + `/usr/local/firmware/` and then default locations for a specific firmware (i.e. Fedora installs AArch64 EDK2 as `/usr/share/edk2/aarch64/QEMU_EFI.fd`).

Script `contrib/qemu/build-from-scratch.sh` could be then updated to download+install arm64 and sun4v firmware in `CROSS_FIRMWARE` (if set) or `/usr/local/firmware/`.