### PR TITLE
Cleanup lib rtld&elf

### DIFF
--- a/kernel/generic/include/lib/elf_load.h
+++ b/kernel/generic/include/lib/elf_load.h
@@ -37,18 +37,7 @@
 
 #include <abi/elf.h>
 
-/**
- * ELF error return codes
- */
-#define EE_OK             0  /* No error */
-#define EE_INVALID        1  /* Invalid ELF image */
-#define EE_MEMORY         2  /* Cannot allocate address space */
-#define EE_INCOMPATIBLE   3  /* ELF image is not compatible with current architecture */
-#define EE_UNSUPPORTED    4  /* Non-supported ELF (e.g. dynamic ELFs) */
-#define EE_IRRECOVERABLE  5  /* Irrecoverable error. */
-
-extern unsigned int elf_load(elf_header_t *, as_t *);
-extern const char *elf_error(unsigned int rc);
+extern errno_t elf_load(elf_header_t *, as_t *);
 
 #endif
 

--- a/kernel/generic/include/proc/program.h
+++ b/kernel/generic/include/proc/program.h
@@ -49,7 +49,7 @@ struct thread;
 typedef struct program {
 	struct task *task;           /**< Program task */
 	struct thread *main_thread;  /**< Program main thread */
-	unsigned int loader_status;  /**< Binary loader error status */
+	errno_t loader_status;  /**< Binary loader error status */
 } program_t;
 
 extern void *program_loader;

--- a/kernel/generic/src/main/kinit.c
+++ b/kernel/generic/src/main/kinit.c
@@ -290,8 +290,8 @@ void kinit(void *arg)
 		} else {
 			log(LF_OTHER, LVL_ERROR,
 			    "init[%zu]: Init binary load failed "
-			    "(error %s, loader status %u)", i,
-			    str_error_name(rc), programs[i].loader_status);
+			    "(error %s, loader status %s)", i,
+			    str_error_name(rc), str_error_name(programs[i].loader_status));
 		}
 	}
 

--- a/kernel/generic/src/proc/program.c
+++ b/kernel/generic/src/proc/program.c
@@ -47,7 +47,7 @@
 #include <ipc/ipcrsc.h>
 #include <security/perm.h>
 #include <lib/elf_load.h>
-#include <errno.h>
+#include <str.h>
 #include <log.h>
 #include <syscall/copy.h>
 #include <proc/program.h>
@@ -75,7 +75,7 @@ errno_t program_create(as_t *as, uintptr_t entry_addr, char *name, program_t *pr
 	if (!kernel_uarg)
 		return ENOMEM;
 
-	prg->loader_status = EE_OK;
+	prg->loader_status = EOK;
 	prg->task = task_create(as, name);
 	if (!prg->task) {
 		free(kernel_uarg);
@@ -148,7 +148,7 @@ errno_t program_create_from_image(void *image_addr, char *name, program_t *prg)
 		return ENOMEM;
 
 	prg->loader_status = elf_load((elf_header_t *) image_addr, as);
-	if (prg->loader_status != EE_OK) {
+	if (prg->loader_status != EOK) {
 		as_release(as);
 		prg->task = NULL;
 		prg->main_thread = NULL;
@@ -182,10 +182,10 @@ errno_t program_create_loader(program_t *prg, char *name)
 	}
 
 	prg->loader_status = elf_load((elf_header_t *) program_loader, as);
-	if (prg->loader_status != EE_OK) {
+	if (prg->loader_status != EOK) {
 		as_release(as);
 		log(LF_OTHER, LVL_ERROR, "Cannot spawn loader (%s)",
-		    elf_error(prg->loader_status));
+		    str_error(prg->loader_status));
 		return ENOENT;
 	}
 

--- a/uspace/lib/c/generic/dlfcn.c
+++ b/uspace/lib/c/generic/dlfcn.c
@@ -53,6 +53,10 @@ void *dlopen(const char *path, int flag)
 	m = module_find(runtime_env, path);
 	if (m == NULL) {
 		m = module_load(runtime_env, path, mlf_local);
+		if (m == NULL) {
+			return NULL;
+		}
+
 		if (module_load_deps(m, mlf_local) != EOK) {
 			return NULL;
 		}

--- a/uspace/lib/c/generic/dlfcn.c
+++ b/uspace/lib/c/generic/dlfcn.c
@@ -34,6 +34,7 @@
  * @file
  */
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stddef.h>
@@ -52,7 +53,10 @@ void *dlopen(const char *path, int flag)
 	m = module_find(runtime_env, path);
 	if (m == NULL) {
 		m = module_load(runtime_env, path, mlf_local);
-		module_load_deps(m, mlf_local);
+		if (module_load_deps(m, mlf_local) != EOK) {
+			return NULL;
+		}
+
 		/* Now relocate. */
 		module_process_relocs(m);
 	}

--- a/uspace/lib/c/generic/rtld/module.c
+++ b/uspace/lib/c/generic/rtld/module.c
@@ -64,8 +64,10 @@ errno_t module_create_static_exec(rtld_t *rtld, module_t **rmodule)
 	module_t *module;
 
 	module = calloc(1, sizeof(module_t));
-	if (module == NULL)
+	if (module == NULL) {
+		DPRINTF("malloc failed\n");
 		return ENOMEM;
+	}
 
 	module->id = rtld_get_next_id(rtld);
 	module->dyn.soname = "[program]";
@@ -181,11 +183,11 @@ module_t *module_load(rtld_t *rtld, const char *name, mlflags_t flags)
 	elf_finfo_t info;
 	char name_buf[NAME_BUF_SIZE];
 	module_t *m;
-	int rc;
+	errno_t rc;
 
 	m = calloc(1, sizeof(module_t));
 	if (m == NULL) {
-		printf("malloc failed\n");
+		DPRINTF("malloc failed\n");
 		goto error;
 	}
 
@@ -196,7 +198,7 @@ module_t *module_load(rtld_t *rtld, const char *name, mlflags_t flags)
 		m->local = true;
 
 	if (str_size(name) > NAME_BUF_SIZE - 2) {
-		printf("soname too long. increase NAME_BUF_SIZE\n");
+		DPRINTF("soname too long. increase NAME_BUF_SIZE\n");
 		goto error;
 	}
 
@@ -207,8 +209,8 @@ module_t *module_load(rtld_t *rtld, const char *name, mlflags_t flags)
 	DPRINTF("filename:'%s'\n", name_buf);
 
 	rc = elf_load_file_name(name_buf, RTLD_MODULE_LDF, &info);
-	if (rc != EE_OK) {
-		printf("Failed to load '%s'\n", name_buf);
+	if (rc != EOK) {
+		DPRINTF("Failed to load '%s'\n", name_buf);
 		goto error;
 	}
 
@@ -217,7 +219,7 @@ module_t *module_load(rtld_t *rtld, const char *name, mlflags_t flags)
 	DPRINTF("loaded '%s' at 0x%zx\n", name_buf, m->bias);
 
 	if (info.dynamic == NULL) {
-		printf("Error: '%s' is not a dynamically-linked object.\n",
+		DPRINTF("Error: '%s' is not a dynamically-linked object.\n",
 		    name_buf);
 		goto error;
 	}
@@ -284,7 +286,7 @@ errno_t module_load_deps(module_t *m, mlflags_t flags)
 
 	m->deps = malloc(n * sizeof(module_t *));
 	if (!m->deps) {
-		printf("malloc failed\n");
+		DPRINTF("malloc failed\n");
 		return ENOMEM;
 	}
 

--- a/uspace/lib/c/generic/rtld/module.c
+++ b/uspace/lib/c/generic/rtld/module.c
@@ -301,6 +301,10 @@ errno_t module_load_deps(module_t *m, mlflags_t flags)
 			dm = module_find(m->rtld, dep_name);
 			if (!dm) {
 				dm = module_load(m->rtld, dep_name, flags);
+				if (!dm) {
+					return EINVAL;
+				}
+
 				errno_t rc = module_load_deps(dm, flags);
 				if (rc != EOK) {
 					return rc;

--- a/uspace/lib/c/generic/rtld/rtld.c
+++ b/uspace/lib/c/generic/rtld/rtld.c
@@ -124,7 +124,10 @@ errno_t rtld_prog_process(elf_finfo_t *p_info, rtld_t **rre)
 	 */
 
 	DPRINTF("Load all program dependencies\n");
-	module_load_deps(prog, 0);
+	errno_t rc = module_load_deps(prog, 0);
+	if (rc != EOK) {
+		return rc;
+	}
 
 	/* Compute static TLS size */
 	modules_process_tls(env);

--- a/uspace/lib/c/include/elf/elf_load.h
+++ b/uspace/lib/c/include/elf/elf_load.h
@@ -44,7 +44,7 @@ typedef struct {
 	struct rtld *env;
 } elf_info_t;
 
-extern int elf_load(int, elf_info_t *);
+extern errno_t elf_load(int, elf_info_t *);
 extern void elf_set_pcb(elf_info_t *, pcb_t *);
 
 #endif

--- a/uspace/lib/c/include/elf/elf_mod.h
+++ b/uspace/lib/c/include/elf/elf_mod.h
@@ -42,17 +42,6 @@
 #include <stdint.h>
 #include <loader/pcb.h>
 
-/**
- * ELF error return codes
- */
-#define EE_OK			0	/* No error */
-#define EE_INVALID		1	/* Invalid ELF image */
-#define EE_MEMORY		2	/* Cannot allocate address space */
-#define EE_INCOMPATIBLE		3	/* ELF image is not compatible with current architecture */
-#define EE_UNSUPPORTED		4	/* Non-supported ELF (e.g. dynamic ELFs) */
-#define EE_IRRECOVERABLE	5
-#define EE_IO			6	/* Could not read file. */
-
 typedef enum {
 	/** Leave all segments in RW access mode. */
 	ELDF_RW = 1
@@ -109,9 +98,8 @@ typedef struct {
 	elf_finfo_t *info;
 } elf_ld_t;
 
-extern const char *elf_error(unsigned int);
-extern int elf_load_file(int, eld_flags_t, elf_finfo_t *);
-extern int elf_load_file_name(const char *, eld_flags_t, elf_finfo_t *);
+extern errno_t elf_load_file(int, eld_flags_t, elf_finfo_t *);
+extern errno_t elf_load_file_name(const char *, eld_flags_t, elf_finfo_t *);
 
 #endif
 

--- a/uspace/lib/c/include/rtld/module.h
+++ b/uspace/lib/c/include/rtld/module.h
@@ -44,7 +44,7 @@ extern errno_t module_create_static_exec(rtld_t *, module_t **);
 extern void module_process_relocs(module_t *);
 extern module_t *module_find(rtld_t *, const char *);
 extern module_t *module_load(rtld_t *, const char *, mlflags_t);
-extern void module_load_deps(module_t *, mlflags_t);
+extern errno_t module_load_deps(module_t *, mlflags_t);
 extern module_t *module_by_id(rtld_t *, unsigned long);
 
 extern void modules_process_relocs(rtld_t *, module_t *);

--- a/uspace/srv/loader/main.c
+++ b/uspace/srv/loader/main.c
@@ -289,8 +289,8 @@ static int ldr_load(ipc_call_t *req)
 {
 	DPRINTF("LOADER_LOAD()\n");
 
-	int rc = elf_load(program_fd, &prog_info);
-	if (rc != EE_OK) {
+	errno_t rc = elf_load(program_fd, &prog_info);
+	if (rc != EOK) {
 		DPRINTF("Failed to load executable for '%s'.\n", progname);
 		async_answer_0(req, EINVAL);
 		return 1;


### PR DESCRIPTION
- corrects a null pointer failure in dlopen()
- prevents lib/rtld to call exit()
- corrects lib/elf to return errno_t instead of it's own error codes