### PR TITLE
Change type of uspace pointers in kernel from pointer type to numeric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -420,3 +420,4 @@ uspace/srv/vfs/vfs
 uspace/srv/vfs/vfs.gz
 uspace/srv/volsrv/test-volsrv
 uspace/srv/volsrv/volsrv
+uspace/drv/block/virtio-blk/virtio-blk

--- a/abi/include/_bits/native.h
+++ b/abi/include/_bits/native.h
@@ -69,6 +69,25 @@ typedef void *uspace_addr_t;
 
 #endif
 
+#define uspace_ptr_as_area_info_t uspace_ptr(as_area_info_t)
+#define uspace_ptr_as_area_pager_info_t uspace_ptr(as_area_pager_info_t)
+#define uspace_ptr_cap_irq_handle_t uspace_ptr(cap_irq_handle_t)
+#define uspace_ptr_cap_phone_handle_t uspace_ptr(cap_phone_handle_t)
+#define uspace_ptr_cap_waitq_handle_t uspace_ptr(cap_waitq_handle_t)
+#define uspace_ptr_char uspace_ptr(char)
+#define uspace_ptr_const_char uspace_ptr(const char)
+#define uspace_ptr_ddi_ioarg_t uspace_ptr(ddi_ioarg_t)
+#define uspace_ptr_ipc_data_t uspace_ptr(ipc_data_t)
+#define uspace_ptr_irq_code_t uspace_ptr(irq_code_t)
+#define uspace_ptr_size_t uspace_ptr(size_t)
+#define uspace_ptr_struct_uspace_arg uspace_ptr(struct uspace_arg)
+#define uspace_ptr_sysarg64_t uspace_ptr(sysarg64_t)
+#define uspace_ptr_task_id_t uspace_ptr(task_id_t)
+#define uspace_ptr_thread_id_t uspace_ptr(thread_id_t)
+#define uspace_ptr_uintptr_t uspace_ptr(uintptr_t)
+#define uspace_ptr_uspace_arg_t uspace_ptr(uspace_arg_t)
+#define uspace_ptr_uspace_thread_function_t uspace_ptr(uspace_thread_function_t)
+
 __HELENOS_DECLS_END;
 
 #endif

--- a/abi/include/_bits/native.h
+++ b/abi/include/_bits/native.h
@@ -55,6 +55,20 @@ typedef uintptr_t ipl_t;
 typedef uintptr_t sysarg_t;
 typedef intptr_t  native_t;
 
+#ifdef KERNEL
+
+typedef sysarg_t uspace_addr_t;
+/* We might implement a way to check validity of the type some day. */
+#define uspace_ptr(type) uspace_addr_t
+#define USPACE_NULL 0
+
+#else /* !KERNEL */
+
+typedef void *uspace_addr_t;
+#define uspace_ptr(type) type *
+
+#endif
+
 __HELENOS_DECLS_END;
 
 #endif

--- a/abi/include/_bits/native.h
+++ b/abi/include/_bits/native.h
@@ -69,6 +69,7 @@ typedef void *uspace_addr_t;
 
 #endif
 
+// TODO: Put this in a better location.
 #define uspace_ptr_as_area_info_t uspace_ptr(as_area_info_t)
 #define uspace_ptr_as_area_pager_info_t uspace_ptr(as_area_pager_info_t)
 #define uspace_ptr_cap_irq_handle_t uspace_ptr(cap_irq_handle_t)

--- a/abi/include/abi/proc/uarg.h
+++ b/abi/include/abi/proc/uarg.h
@@ -36,17 +36,20 @@
 #define _ABI_PROC_UARG_H_
 
 #include <stddef.h>
+#include <_bits/native.h>
+
+typedef void (uspace_thread_function_t)(void *);
 
 /** Structure passed to uinit kernel thread as argument. */
 typedef struct uspace_arg {
-	void *uspace_entry;
-	void *uspace_stack;
+	uspace_addr_t uspace_entry;
+	uspace_addr_t uspace_stack;
 	size_t uspace_stack_size;
 
-	void (*uspace_thread_function)(void *);
-	void *uspace_thread_arg;
+	uspace_ptr(uspace_thread_function_t) uspace_thread_function;
+	uspace_addr_t uspace_thread_arg;
 
-	struct uspace_arg *uspace_uarg;
+	uspace_ptr(struct uspace_arg) uspace_uarg;
 } uspace_arg_t;
 
 #endif

--- a/abi/include/abi/proc/uarg.h
+++ b/abi/include/abi/proc/uarg.h
@@ -46,10 +46,10 @@ typedef struct uspace_arg {
 	uspace_addr_t uspace_stack;
 	size_t uspace_stack_size;
 
-	uspace_ptr(uspace_thread_function_t) uspace_thread_function;
+	uspace_ptr_uspace_thread_function_t uspace_thread_function;
 	uspace_addr_t uspace_thread_arg;
 
-	uspace_ptr(struct uspace_arg) uspace_uarg;
+	uspace_ptr_struct_uspace_arg uspace_uarg;
 } uspace_arg_t;
 
 #endif

--- a/kernel/arch/abs32le/src/abs32le.c
+++ b/kernel/arch/abs32le/src/abs32le.c
@@ -125,12 +125,12 @@ void fpu_context_restore(fpu_context_t *ctx)
 {
 }
 
-uintptr_t memcpy_from_uspace(void *dst, const void *uspace_src, size_t size)
+uintptr_t memcpy_from_uspace(void *dst, uspace_addr_t uspace_src, size_t size)
 {
 	return 0;
 }
 
-uintptr_t memcpy_to_uspace(void *uspace_dst, const void *src, size_t size)
+uintptr_t memcpy_to_uspace(uspace_addr_t uspace_dst, const void *src, size_t size)
 {
 	return 0;
 }

--- a/kernel/arch/amd64/src/debug/stacktrace.c
+++ b/kernel/arch/amd64/src/debug/stacktrace.c
@@ -68,14 +68,14 @@ bool uspace_stack_trace_context_validate(stack_trace_context_t *ctx)
 
 bool uspace_frame_pointer_prev(stack_trace_context_t *ctx, uintptr_t *prev)
 {
-	return !copy_from_uspace((void *) prev,
-	    (uint64_t *) ctx->fp + FRAME_OFFSET_FP_PREV, sizeof(*prev));
+	return !copy_from_uspace(prev,
+	    ctx->fp + sizeof(uintptr_t) * FRAME_OFFSET_FP_PREV, sizeof(*prev));
 }
 
 bool uspace_return_address_get(stack_trace_context_t *ctx, uintptr_t *ra)
 {
-	return !copy_from_uspace((void *) ra,
-	    (uint64_t *) ctx->fp + FRAME_OFFSET_RA, sizeof(*ra));
+	return !copy_from_uspace(ra,
+	    ctx->fp + sizeof(uintptr_t) * FRAME_OFFSET_RA, sizeof(*ra));
 }
 
 /** @}

--- a/kernel/arch/amd64/src/userspace.c
+++ b/kernel/arch/amd64/src/userspace.c
@@ -65,7 +65,7 @@ void userspace(uspace_arg_t *kernel_uarg)
 	    "xorq %%rdi, %%rdi\n"
 	    "iretq\n"
 	    :: [udata_des] "i" (GDT_SELECTOR(UDATA_DES) | PL_USER),
-	      [stack_top] "r" ((uint8_t *) kernel_uarg->uspace_stack +
+	      [stack_top] "r" (kernel_uarg->uspace_stack +
 	      kernel_uarg->uspace_stack_size),
 	      [rflags] "r" (rflags),
 	      [utext_des] "i" (GDT_SELECTOR(UTEXT_DES) | PL_USER),

--- a/kernel/arch/arm32/src/debug/stacktrace.c
+++ b/kernel/arch/arm32/src/debug/stacktrace.c
@@ -67,14 +67,14 @@ bool uspace_stack_trace_context_validate(stack_trace_context_t *ctx)
 
 bool uspace_frame_pointer_prev(stack_trace_context_t *ctx, uintptr_t *prev)
 {
-	return !copy_from_uspace((void *) prev,
-	    (uint32_t *) ctx->fp + FRAME_OFFSET_FP_PREV, sizeof(*prev));
+	return !copy_from_uspace(prev,
+	    ctx->fp + sizeof(uintptr_t) * FRAME_OFFSET_FP_PREV, sizeof(*prev));
 }
 
 bool uspace_return_address_get(stack_trace_context_t *ctx, uintptr_t *ra)
 {
-	return !copy_from_uspace((void *) ra,
-	    (uint32_t *) ctx->fp + FRAME_OFFSET_RA, sizeof(*ra));
+	return !copy_from_uspace(ra,
+	    ctx->fp + sizeof(uintptr_t) * FRAME_OFFSET_RA, sizeof(*ra));
 }
 
 /** @}

--- a/kernel/arch/arm32/src/userspace.c
+++ b/kernel/arch/arm32/src/userspace.c
@@ -70,7 +70,7 @@ void userspace(uspace_arg_t *kernel_uarg)
 	volatile ustate_t ustate;
 
 	/* set first parameter */
-	ustate.r0 = (uintptr_t) kernel_uarg->uspace_uarg;
+	ustate.r0 = kernel_uarg->uspace_uarg;
 
 	/* %r1 is defined to hold pcb_ptr - set it to 0 */
 	ustate.r1 = 0;
@@ -92,11 +92,11 @@ void userspace(uspace_arg_t *kernel_uarg)
 	ustate.lr = 0;
 
 	/* set user stack */
-	ustate.sp = ((uint32_t) kernel_uarg->uspace_stack) +
+	ustate.sp = kernel_uarg->uspace_stack +
 	    kernel_uarg->uspace_stack_size;
 
 	/* set where uspace execution starts */
-	ustate.pc = (uintptr_t) kernel_uarg->uspace_entry;
+	ustate.pc = kernel_uarg->uspace_entry;
 
 	/* status register in user mode */
 	ipl_t user_mode = current_status_reg_read() &

--- a/kernel/arch/arm64/src/arm64.c
+++ b/kernel/arch/arm64/src/arm64.c
@@ -155,11 +155,11 @@ void userspace(uspace_arg_t *kernel_uarg)
 	    SPSR_MODE_ARM64_EL0T);
 
 	/* Set program entry. */
-	ELR_EL1_write((uint64_t) kernel_uarg->uspace_entry);
+	ELR_EL1_write(kernel_uarg->uspace_entry);
 
 	/* Set user stack. */
-	SP_EL0_write(((uint64_t) kernel_uarg->uspace_stack +
-	    kernel_uarg->uspace_stack_size));
+	SP_EL0_write(kernel_uarg->uspace_stack +
+	    kernel_uarg->uspace_stack_size);
 
 	/* Clear Thread ID register. */
 	TPIDR_EL0_write(0);

--- a/kernel/arch/arm64/src/debug/stacktrace.c
+++ b/kernel/arch/arm64/src/debug/stacktrace.c
@@ -67,14 +67,14 @@ bool uspace_stack_trace_context_validate(stack_trace_context_t *ctx)
 
 bool uspace_frame_pointer_prev(stack_trace_context_t *ctx, uintptr_t *prev)
 {
-	return !copy_from_uspace((void *) prev,
-	    (uint64_t *) ctx->fp + FRAME_OFFSET_FP_PREV, sizeof(*prev));
+	return !copy_from_uspace(prev,
+	    ctx->fp + sizeof(uintptr_t) * FRAME_OFFSET_FP_PREV, sizeof(*prev));
 }
 
 bool uspace_return_address_get(stack_trace_context_t *ctx, uintptr_t *ra)
 {
-	return !copy_from_uspace((void *) ra,
-	    (uint64_t *) ctx->fp + FRAME_OFFSET_RA, sizeof(*ra));
+	return !copy_from_uspace(ra,
+	    ctx->fp + sizeof(uintptr_t) * FRAME_OFFSET_RA, sizeof(*ra));
 }
 
 /** @}

--- a/kernel/arch/ia32/src/debug/stacktrace.c
+++ b/kernel/arch/ia32/src/debug/stacktrace.c
@@ -66,14 +66,14 @@ bool uspace_stack_trace_context_validate(stack_trace_context_t *ctx)
 
 bool uspace_frame_pointer_prev(stack_trace_context_t *ctx, uintptr_t *prev)
 {
-	return !copy_from_uspace((void *) prev,
-	    (uint32_t *) ctx->fp + FRAME_OFFSET_FP_PREV, sizeof(*prev));
+	return !copy_from_uspace(prev,
+	    ctx->fp + sizeof(uintptr_t) * FRAME_OFFSET_FP_PREV, sizeof(*prev));
 }
 
 bool uspace_return_address_get(stack_trace_context_t *ctx, uintptr_t *ra)
 {
-	return !copy_from_uspace((void *) ra,
-	    (uint32_t *) ctx->fp + FRAME_OFFSET_RA, sizeof(*ra));
+	return !copy_from_uspace(ra,
+	    ctx->fp + sizeof(uintptr_t) * FRAME_OFFSET_RA, sizeof(*ra));
 }
 
 /** @}

--- a/kernel/arch/ia32/src/userspace.c
+++ b/kernel/arch/ia32/src/userspace.c
@@ -69,7 +69,7 @@ void userspace(uspace_arg_t *kernel_uarg)
 	    :
 	    : [eflags_mask] "i" (~EFLAGS_NT),
 	      [udata_des] "i" (GDT_SELECTOR(UDATA_DES) | PL_USER),
-	      [stack_top] "r" ((uint8_t *) kernel_uarg->uspace_stack +
+	      [stack_top] "r" (kernel_uarg->uspace_stack +
 	      kernel_uarg->uspace_stack_size),
 	      [eflags] "r" ((eflags & ~(EFLAGS_NT)) | EFLAGS_IF),
 	      [utext_des] "i" (GDT_SELECTOR(UTEXT_DES) | PL_USER),

--- a/kernel/arch/ia64/src/ia64.c
+++ b/kernel/arch/ia64/src/ia64.c
@@ -243,13 +243,13 @@ void userspace(uspace_arg_t *kernel_uarg)
 	 * memory stack and the RSE stack. Each occuppies
 	 * uspace_stack_size / 2 bytes.
 	 */
-	switch_to_userspace((uintptr_t) kernel_uarg->uspace_entry,
-	    ((uintptr_t) kernel_uarg->uspace_stack) +
+	switch_to_userspace(kernel_uarg->uspace_entry,
+	    kernel_uarg->uspace_stack +
 	    kernel_uarg->uspace_stack_size / 2 -
 	    ALIGN_UP(STACK_ITEM_SIZE, STACK_ALIGNMENT),
-	    ((uintptr_t) kernel_uarg->uspace_stack) +
+	    kernel_uarg->uspace_stack +
 	    kernel_uarg->uspace_stack_size / 2,
-	    (uintptr_t) kernel_uarg->uspace_uarg, psr.value, rsc.value);
+	    kernel_uarg->uspace_uarg, psr.value, rsc.value);
 
 	while (true)
 		;

--- a/kernel/arch/mips32/src/mips32.c
+++ b/kernel/arch/mips32/src/mips32.c
@@ -170,11 +170,11 @@ void userspace(uspace_arg_t *kernel_uarg)
 	/* EXL = 1, UM = 1, IE = 1 */
 	cp0_status_write(cp0_status_read() | (cp0_status_exl_exception_bit |
 	    cp0_status_um_bit | cp0_status_ie_enabled_bit));
-	cp0_epc_write((uintptr_t) kernel_uarg->uspace_entry);
-	userspace_asm(((uintptr_t) kernel_uarg->uspace_stack +
-	    kernel_uarg->uspace_stack_size),
-	    (uintptr_t) kernel_uarg->uspace_uarg,
-	    (uintptr_t) kernel_uarg->uspace_entry);
+	cp0_epc_write(kernel_uarg->uspace_entry);
+	userspace_asm(kernel_uarg->uspace_stack +
+	    kernel_uarg->uspace_stack_size,
+	    kernel_uarg->uspace_uarg,
+	    kernel_uarg->uspace_entry);
 
 	while (true)
 		;

--- a/kernel/arch/ppc32/src/debug/stacktrace.c
+++ b/kernel/arch/ppc32/src/debug/stacktrace.c
@@ -66,14 +66,14 @@ bool uspace_stack_trace_context_validate(stack_trace_context_t *ctx)
 
 bool uspace_frame_pointer_prev(stack_trace_context_t *ctx, uintptr_t *prev)
 {
-	return !copy_from_uspace((void *) prev,
-	    (uint32_t *) ctx->fp + FRAME_OFFSET_FP_PREV, sizeof(*prev));
+	return !copy_from_uspace(prev,
+	    ctx->fp + sizeof(uintptr_t) * FRAME_OFFSET_FP_PREV, sizeof(*prev));
 }
 
 bool uspace_return_address_get(stack_trace_context_t *ctx, uintptr_t *ra)
 {
-	return !copy_from_uspace((void *) ra,
-	    (uint32_t *) ctx->fp + FRAME_OFFSET_RA, sizeof(*ra));
+	return !copy_from_uspace(ra,
+	    ctx->fp + sizeof(uintptr_t) * FRAME_OFFSET_RA, sizeof(*ra));
 }
 
 /** @}

--- a/kernel/arch/ppc32/src/ppc32.c
+++ b/kernel/arch/ppc32/src/ppc32.c
@@ -291,10 +291,10 @@ void calibrate_delay_loop(void)
 
 void userspace(uspace_arg_t *kernel_uarg)
 {
-	userspace_asm((uintptr_t) kernel_uarg->uspace_uarg,
-	    (uintptr_t) kernel_uarg->uspace_stack +
+	userspace_asm(kernel_uarg->uspace_uarg,
+	    kernel_uarg->uspace_stack +
 	    kernel_uarg->uspace_stack_size - SP_DELTA,
-	    (uintptr_t) kernel_uarg->uspace_entry);
+	    kernel_uarg->uspace_entry);
 
 	unreachable();
 }

--- a/kernel/arch/riscv64/src/riscv64.c
+++ b/kernel/arch/riscv64/src/riscv64.c
@@ -142,12 +142,12 @@ void fpu_context_restore(fpu_context_t *ctx)
 {
 }
 
-uintptr_t memcpy_from_uspace(void *dst, const void *uspace_src, size_t size)
+uintptr_t memcpy_from_uspace(void *dst, uspace_addr_t uspace_src, size_t size)
 {
 	return 0;
 }
 
-uintptr_t memcpy_to_uspace(void *uspace_dst, const void *src, size_t size)
+uintptr_t memcpy_to_uspace(uspace_addr_t uspace_dst, const void *src, size_t size)
 {
 	return 0;
 }

--- a/kernel/arch/sparc64/src/sun4u/sparc64.c
+++ b/kernel/arch/sparc64/src/sun4u/sparc64.c
@@ -162,11 +162,11 @@ void asm_delay_loop(const uint32_t usec)
 void userspace(uspace_arg_t *kernel_uarg)
 {
 	(void) interrupts_disable();
-	switch_to_userspace((uintptr_t) kernel_uarg->uspace_entry,
-	    ((uintptr_t) kernel_uarg->uspace_stack) +
+	switch_to_userspace(kernel_uarg->uspace_entry,
+	    kernel_uarg->uspace_stack +
 	    kernel_uarg->uspace_stack_size -
 	    (ALIGN_UP(STACK_ITEM_SIZE, STACK_ALIGNMENT) + STACK_BIAS),
-	    (uintptr_t) kernel_uarg->uspace_uarg);
+	    kernel_uarg->uspace_uarg);
 
 	/* Not reached */
 	while (true)

--- a/kernel/arch/sparc64/src/sun4v/sparc64.c
+++ b/kernel/arch/sparc64/src/sun4v/sparc64.c
@@ -160,11 +160,11 @@ void asm_delay_loop(const uint32_t usec)
 void userspace(uspace_arg_t *kernel_uarg)
 {
 	(void) interrupts_disable();
-	switch_to_userspace((uintptr_t) kernel_uarg->uspace_entry,
-	    ((uintptr_t) kernel_uarg->uspace_stack) +
+	switch_to_userspace(kernel_uarg->uspace_entry,
+	    kernel_uarg->uspace_stack +
 	    kernel_uarg->uspace_stack_size -
 	    (ALIGN_UP(STACK_ITEM_SIZE, STACK_ALIGNMENT) + STACK_BIAS),
-	    (uintptr_t) kernel_uarg->uspace_uarg);
+	    kernel_uarg->uspace_uarg);
 
 	/* Not reached */
 	while (true)

--- a/kernel/generic/include/console/console.h
+++ b/kernel/generic/include/console/console.h
@@ -70,7 +70,7 @@ SPINLOCK_EXTERN(kio_lock);
 
 extern wchar_t getc(indev_t *indev);
 extern size_t gets(indev_t *indev, char *buf, size_t buflen);
-extern sys_errno_t sys_kio(int cmd, const void *buf, size_t size);
+extern sys_errno_t sys_kio(int cmd, uspace_ptr(void) buf, size_t size);
 
 extern void grab_console(void);
 extern void release_console(void);

--- a/kernel/generic/include/console/console.h
+++ b/kernel/generic/include/console/console.h
@@ -70,7 +70,7 @@ SPINLOCK_EXTERN(kio_lock);
 
 extern wchar_t getc(indev_t *indev);
 extern size_t gets(indev_t *indev, char *buf, size_t buflen);
-extern sys_errno_t sys_kio(int cmd, uspace_ptr(void) buf, size_t size);
+extern sys_errno_t sys_kio(int cmd, uspace_addr_t buf, size_t size);
 
 extern void grab_console(void);
 extern void release_console(void);

--- a/kernel/generic/include/ddi/ddi.h
+++ b/kernel/generic/include/ddi/ddi.h
@@ -62,12 +62,12 @@ extern void ddi_parea_register(parea_t *);
 extern void *pio_map(void *, size_t);
 extern void pio_unmap(void *, void *, size_t);
 
-extern sys_errno_t sys_physmem_map(uintptr_t, size_t, unsigned int, uspace_addr_t,
+extern sys_errno_t sys_physmem_map(uintptr_t, size_t, unsigned int, uspace_ptr_uintptr_t,
     uintptr_t);
 extern sys_errno_t sys_physmem_unmap(uintptr_t);
 
-extern sys_errno_t sys_dmamem_map(size_t, unsigned int, unsigned int, uspace_addr_t,
-    uspace_addr_t, uintptr_t);
+extern sys_errno_t sys_dmamem_map(size_t, unsigned int, unsigned int, uspace_ptr_uintptr_t,
+    uspace_ptr_uintptr_t, uintptr_t);
 extern sys_errno_t sys_dmamem_unmap(uintptr_t, size_t, unsigned int);
 
 extern sys_errno_t sys_iospace_enable(uspace_ptr_ddi_ioarg_t);

--- a/kernel/generic/include/ddi/ddi.h
+++ b/kernel/generic/include/ddi/ddi.h
@@ -70,8 +70,8 @@ extern sys_errno_t sys_dmamem_map(size_t, unsigned int, unsigned int, uspace_add
     uspace_addr_t, uintptr_t);
 extern sys_errno_t sys_dmamem_unmap(uintptr_t, size_t, unsigned int);
 
-extern sys_errno_t sys_iospace_enable(uspace_ptr(ddi_ioarg_t));
-extern sys_errno_t sys_iospace_disable(uspace_ptr(ddi_ioarg_t));
+extern sys_errno_t sys_iospace_enable(uspace_ptr_ddi_ioarg_t);
+extern sys_errno_t sys_iospace_disable(uspace_ptr_ddi_ioarg_t);
 
 /*
  * Interface to be implemented by all architectures.

--- a/kernel/generic/include/ddi/ddi.h
+++ b/kernel/generic/include/ddi/ddi.h
@@ -62,16 +62,16 @@ extern void ddi_parea_register(parea_t *);
 extern void *pio_map(void *, size_t);
 extern void pio_unmap(void *, void *, size_t);
 
-extern sys_errno_t sys_physmem_map(uintptr_t, size_t, unsigned int, void *,
+extern sys_errno_t sys_physmem_map(uintptr_t, size_t, unsigned int, uspace_ptr(void),
     uintptr_t);
 extern sys_errno_t sys_physmem_unmap(uintptr_t);
 
-extern sys_errno_t sys_dmamem_map(size_t, unsigned int, unsigned int, void *,
-    void *, uintptr_t);
+extern sys_errno_t sys_dmamem_map(size_t, unsigned int, unsigned int, uspace_ptr(void),
+    uspace_ptr(void), uintptr_t);
 extern sys_errno_t sys_dmamem_unmap(uintptr_t, size_t, unsigned int);
 
-extern sys_errno_t sys_iospace_enable(ddi_ioarg_t *);
-extern sys_errno_t sys_iospace_disable(ddi_ioarg_t *);
+extern sys_errno_t sys_iospace_enable(uspace_ptr(ddi_ioarg_t));
+extern sys_errno_t sys_iospace_disable(uspace_ptr(ddi_ioarg_t));
 
 /*
  * Interface to be implemented by all architectures.

--- a/kernel/generic/include/ddi/ddi.h
+++ b/kernel/generic/include/ddi/ddi.h
@@ -62,12 +62,12 @@ extern void ddi_parea_register(parea_t *);
 extern void *pio_map(void *, size_t);
 extern void pio_unmap(void *, void *, size_t);
 
-extern sys_errno_t sys_physmem_map(uintptr_t, size_t, unsigned int, uspace_ptr(void),
+extern sys_errno_t sys_physmem_map(uintptr_t, size_t, unsigned int, uspace_addr_t,
     uintptr_t);
 extern sys_errno_t sys_physmem_unmap(uintptr_t);
 
-extern sys_errno_t sys_dmamem_map(size_t, unsigned int, unsigned int, uspace_ptr(void),
-    uspace_ptr(void), uintptr_t);
+extern sys_errno_t sys_dmamem_map(size_t, unsigned int, unsigned int, uspace_addr_t,
+    uspace_addr_t, uintptr_t);
 extern sys_errno_t sys_dmamem_unmap(uintptr_t, size_t, unsigned int);
 
 extern sys_errno_t sys_iospace_enable(uspace_ptr(ddi_ioarg_t));

--- a/kernel/generic/include/ipc/irq.h
+++ b/kernel/generic/include/ipc/irq.h
@@ -49,8 +49,8 @@
 extern irq_ownership_t ipc_irq_top_half_claim(irq_t *);
 extern void ipc_irq_top_half_handler(irq_t *);
 
-extern errno_t ipc_irq_subscribe(answerbox_t *, inr_t, sysarg_t, uspace_ptr(irq_code_t),
-    uspace_ptr(cap_irq_handle_t));
+extern errno_t ipc_irq_subscribe(answerbox_t *, inr_t, sysarg_t, uspace_ptr_irq_code_t,
+    uspace_ptr_cap_irq_handle_t);
 extern errno_t ipc_irq_unsubscribe(answerbox_t *, cap_irq_handle_t);
 
 /*

--- a/kernel/generic/include/ipc/irq.h
+++ b/kernel/generic/include/ipc/irq.h
@@ -49,8 +49,8 @@
 extern irq_ownership_t ipc_irq_top_half_claim(irq_t *);
 extern void ipc_irq_top_half_handler(irq_t *);
 
-extern errno_t ipc_irq_subscribe(answerbox_t *, inr_t, sysarg_t, irq_code_t *,
-    cap_irq_handle_t *);
+extern errno_t ipc_irq_subscribe(answerbox_t *, inr_t, sysarg_t, uspace_ptr(irq_code_t),
+    uspace_ptr(cap_irq_handle_t));
 extern errno_t ipc_irq_unsubscribe(answerbox_t *, cap_irq_handle_t);
 
 /*

--- a/kernel/generic/include/ipc/sysipc.h
+++ b/kernel/generic/include/ipc/sysipc.h
@@ -43,24 +43,24 @@ extern errno_t ipc_req_internal(cap_phone_handle_t, ipc_data_t *, sysarg_t);
 
 extern sys_errno_t sys_ipc_call_async_fast(cap_phone_handle_t, sysarg_t,
     sysarg_t, sysarg_t, sysarg_t, sysarg_t);
-extern sys_errno_t sys_ipc_call_async_slow(cap_phone_handle_t, uspace_ptr(ipc_data_t),
+extern sys_errno_t sys_ipc_call_async_slow(cap_phone_handle_t, uspace_ptr_ipc_data_t,
     sysarg_t);
 extern sys_errno_t sys_ipc_answer_fast(cap_call_handle_t, sysarg_t, sysarg_t,
     sysarg_t, sysarg_t, sysarg_t);
-extern sys_errno_t sys_ipc_answer_slow(cap_call_handle_t, uspace_ptr(ipc_data_t));
-extern sys_errno_t sys_ipc_wait_for_call(uspace_ptr(ipc_data_t), uint32_t, unsigned int);
+extern sys_errno_t sys_ipc_answer_slow(cap_call_handle_t, uspace_ptr_ipc_data_t);
+extern sys_errno_t sys_ipc_wait_for_call(uspace_ptr_ipc_data_t, uint32_t, unsigned int);
 extern sys_errno_t sys_ipc_poke(void);
 extern sys_errno_t sys_ipc_forward_fast(cap_call_handle_t, cap_phone_handle_t,
     sysarg_t, sysarg_t, sysarg_t, unsigned int);
 extern sys_errno_t sys_ipc_forward_slow(cap_call_handle_t, cap_phone_handle_t,
-    uspace_ptr(ipc_data_t), unsigned int);
+    uspace_ptr_ipc_data_t, unsigned int);
 extern sys_errno_t sys_ipc_hangup(cap_phone_handle_t);
 
-extern sys_errno_t sys_ipc_irq_subscribe(inr_t, sysarg_t, uspace_ptr(irq_code_t),
-    uspace_ptr(cap_irq_handle_t));
+extern sys_errno_t sys_ipc_irq_subscribe(inr_t, sysarg_t, uspace_ptr_irq_code_t,
+    uspace_ptr_cap_irq_handle_t);
 extern sys_errno_t sys_ipc_irq_unsubscribe(cap_irq_handle_t);
 
-extern sys_errno_t sys_ipc_connect_kbox(uspace_ptr(task_id_t), uspace_ptr(cap_phone_handle_t));
+extern sys_errno_t sys_ipc_connect_kbox(uspace_ptr_task_id_t, uspace_ptr_cap_phone_handle_t);
 
 #endif
 

--- a/kernel/generic/include/ipc/sysipc.h
+++ b/kernel/generic/include/ipc/sysipc.h
@@ -43,24 +43,24 @@ extern errno_t ipc_req_internal(cap_phone_handle_t, ipc_data_t *, sysarg_t);
 
 extern sys_errno_t sys_ipc_call_async_fast(cap_phone_handle_t, sysarg_t,
     sysarg_t, sysarg_t, sysarg_t, sysarg_t);
-extern sys_errno_t sys_ipc_call_async_slow(cap_phone_handle_t, ipc_data_t *,
+extern sys_errno_t sys_ipc_call_async_slow(cap_phone_handle_t, uspace_ptr(ipc_data_t),
     sysarg_t);
 extern sys_errno_t sys_ipc_answer_fast(cap_call_handle_t, sysarg_t, sysarg_t,
     sysarg_t, sysarg_t, sysarg_t);
-extern sys_errno_t sys_ipc_answer_slow(cap_call_handle_t, ipc_data_t *);
-extern sys_errno_t sys_ipc_wait_for_call(ipc_data_t *, uint32_t, unsigned int);
+extern sys_errno_t sys_ipc_answer_slow(cap_call_handle_t, uspace_ptr(ipc_data_t));
+extern sys_errno_t sys_ipc_wait_for_call(uspace_ptr(ipc_data_t), uint32_t, unsigned int);
 extern sys_errno_t sys_ipc_poke(void);
 extern sys_errno_t sys_ipc_forward_fast(cap_call_handle_t, cap_phone_handle_t,
     sysarg_t, sysarg_t, sysarg_t, unsigned int);
 extern sys_errno_t sys_ipc_forward_slow(cap_call_handle_t, cap_phone_handle_t,
-    ipc_data_t *, unsigned int);
+    uspace_ptr(ipc_data_t), unsigned int);
 extern sys_errno_t sys_ipc_hangup(cap_phone_handle_t);
 
-extern sys_errno_t sys_ipc_irq_subscribe(inr_t, sysarg_t, irq_code_t *,
-    cap_irq_handle_t *);
+extern sys_errno_t sys_ipc_irq_subscribe(inr_t, sysarg_t, uspace_ptr(irq_code_t),
+    uspace_ptr(cap_irq_handle_t));
 extern sys_errno_t sys_ipc_irq_unsubscribe(cap_irq_handle_t);
 
-extern sys_errno_t sys_ipc_connect_kbox(task_id_t *, cap_phone_handle_t *);
+extern sys_errno_t sys_ipc_connect_kbox(uspace_ptr(task_id_t), uspace_ptr(cap_phone_handle_t));
 
 #endif
 

--- a/kernel/generic/include/log.h
+++ b/kernel/generic/include/log.h
@@ -51,7 +51,7 @@ extern int log_printf(const char *, ...)
 extern int log(log_facility_t, log_level_t, const char *, ...)
     _HELENOS_PRINTF_ATTRIBUTE(3, 4);
 
-extern sys_errno_t sys_klog(sysarg_t, uspace_ptr(void) buf, size_t size,
+extern sys_errno_t sys_klog(sysarg_t, uspace_addr_t buf, size_t size,
     sysarg_t level, uspace_ptr(size_t) uspace_nread);
 
 #endif /* KERN_LOG_H_ */

--- a/kernel/generic/include/log.h
+++ b/kernel/generic/include/log.h
@@ -52,7 +52,7 @@ extern int log(log_facility_t, log_level_t, const char *, ...)
     _HELENOS_PRINTF_ATTRIBUTE(3, 4);
 
 extern sys_errno_t sys_klog(sysarg_t, uspace_addr_t buf, size_t size,
-    sysarg_t level, uspace_ptr(size_t) uspace_nread);
+    sysarg_t level, uspace_ptr_size_t uspace_nread);
 
 #endif /* KERN_LOG_H_ */
 

--- a/kernel/generic/include/log.h
+++ b/kernel/generic/include/log.h
@@ -51,8 +51,8 @@ extern int log_printf(const char *, ...)
 extern int log(log_facility_t, log_level_t, const char *, ...)
     _HELENOS_PRINTF_ATTRIBUTE(3, 4);
 
-extern sys_errno_t sys_klog(sysarg_t, void *buf, size_t size,
-    sysarg_t level, size_t *uspace_nread);
+extern sys_errno_t sys_klog(sysarg_t, uspace_ptr(void) buf, size_t size,
+    sysarg_t level, uspace_ptr(size_t) uspace_nread);
 
 #endif /* KERN_LOG_H_ */
 

--- a/kernel/generic/include/mm/as.h
+++ b/kernel/generic/include/mm/as.h
@@ -372,10 +372,10 @@ extern mem_backend_t user_backend;
 
 /* Address space area related syscalls. */
 extern sysarg_t sys_as_area_create(uintptr_t, size_t, unsigned int, uintptr_t,
-    as_area_pager_info_t *);
+    uspace_ptr(as_area_pager_info_t));
 extern sys_errno_t sys_as_area_resize(uintptr_t, size_t, unsigned int);
 extern sys_errno_t sys_as_area_change_flags(uintptr_t, unsigned int);
-extern sys_errno_t sys_as_area_get_info(uintptr_t, as_area_info_t *);
+extern sys_errno_t sys_as_area_get_info(uintptr_t, uspace_ptr(as_area_info_t));
 extern sys_errno_t sys_as_area_destroy(uintptr_t);
 
 /* Introspection functions. */

--- a/kernel/generic/include/mm/as.h
+++ b/kernel/generic/include/mm/as.h
@@ -372,10 +372,10 @@ extern mem_backend_t user_backend;
 
 /* Address space area related syscalls. */
 extern sysarg_t sys_as_area_create(uintptr_t, size_t, unsigned int, uintptr_t,
-    uspace_ptr(as_area_pager_info_t));
+    uspace_ptr_as_area_pager_info_t);
 extern sys_errno_t sys_as_area_resize(uintptr_t, size_t, unsigned int);
 extern sys_errno_t sys_as_area_change_flags(uintptr_t, unsigned int);
-extern sys_errno_t sys_as_area_get_info(uintptr_t, uspace_ptr(as_area_info_t));
+extern sys_errno_t sys_as_area_get_info(uintptr_t, uspace_ptr_as_area_info_t);
 extern sys_errno_t sys_as_area_destroy(uintptr_t);
 
 /* Introspection functions. */

--- a/kernel/generic/include/mm/page.h
+++ b/kernel/generic/include/mm/page.h
@@ -67,7 +67,7 @@ extern pte_t *page_table_create(unsigned int);
 extern void page_table_destroy(pte_t *);
 
 extern errno_t page_find_mapping(uintptr_t, uintptr_t *);
-extern sys_errno_t sys_page_find_mapping(uintptr_t, uspace_ptr(uintptr_t));
+extern sys_errno_t sys_page_find_mapping(uintptr_t, uspace_ptr_uintptr_t);
 
 #endif
 

--- a/kernel/generic/include/mm/page.h
+++ b/kernel/generic/include/mm/page.h
@@ -67,7 +67,7 @@ extern pte_t *page_table_create(unsigned int);
 extern void page_table_destroy(pte_t *);
 
 extern errno_t page_find_mapping(uintptr_t, uintptr_t *);
-extern sys_errno_t sys_page_find_mapping(uintptr_t, uintptr_t *);
+extern sys_errno_t sys_page_find_mapping(uintptr_t, uspace_ptr(uintptr_t));
 
 #endif
 

--- a/kernel/generic/include/proc/program.h
+++ b/kernel/generic/include/proc/program.h
@@ -54,12 +54,12 @@ typedef struct program {
 
 extern void *program_loader;
 
-extern errno_t program_create(as_t *, uintptr_t, char *, program_t *);
+extern errno_t program_create(as_t *, uspace_addr_t, char *, program_t *);
 extern errno_t program_create_from_image(void *, char *, program_t *);
 extern errno_t program_create_loader(program_t *, char *);
 extern void program_ready(program_t *);
 
-extern sys_errno_t sys_program_spawn_loader(char *, size_t);
+extern sys_errno_t sys_program_spawn_loader(uspace_ptr(char), size_t);
 
 #endif
 

--- a/kernel/generic/include/proc/program.h
+++ b/kernel/generic/include/proc/program.h
@@ -59,7 +59,7 @@ extern errno_t program_create_from_image(void *, char *, program_t *);
 extern errno_t program_create_loader(program_t *, char *);
 extern void program_ready(program_t *);
 
-extern sys_errno_t sys_program_spawn_loader(uspace_ptr(char), size_t);
+extern sys_errno_t sys_program_spawn_loader(uspace_ptr_char, size_t);
 
 #endif
 

--- a/kernel/generic/include/proc/task.h
+++ b/kernel/generic/include/proc/task.h
@@ -163,15 +163,15 @@ extern void task_destroy_arch(task_t *);
 #endif
 
 #ifdef __32_BITS__
-extern sys_errno_t sys_task_get_id(uspace_ptr(sysarg64_t));
+extern sys_errno_t sys_task_get_id(uspace_ptr_sysarg64_t);
 #endif
 
 #ifdef __64_BITS__
 extern sysarg_t sys_task_get_id(void);
 #endif
 
-extern sys_errno_t sys_task_set_name(uspace_ptr(const char), size_t);
-extern sys_errno_t sys_task_kill(uspace_ptr(task_id_t));
+extern sys_errno_t sys_task_set_name(uspace_ptr_const_char, size_t);
+extern sys_errno_t sys_task_kill(uspace_ptr_task_id_t);
 extern sys_errno_t sys_task_exit(sysarg_t);
 
 #endif

--- a/kernel/generic/include/proc/task.h
+++ b/kernel/generic/include/proc/task.h
@@ -163,15 +163,15 @@ extern void task_destroy_arch(task_t *);
 #endif
 
 #ifdef __32_BITS__
-extern sys_errno_t sys_task_get_id(sysarg64_t *);
+extern sys_errno_t sys_task_get_id(uspace_ptr(sysarg64_t));
 #endif
 
 #ifdef __64_BITS__
 extern sysarg_t sys_task_get_id(void);
 #endif
 
-extern sys_errno_t sys_task_set_name(const char *, size_t);
-extern sys_errno_t sys_task_kill(task_id_t *);
+extern sys_errno_t sys_task_set_name(uspace_ptr(const char), size_t);
+extern sys_errno_t sys_task_kill(uspace_ptr(task_id_t));
 extern sys_errno_t sys_task_exit(sysarg_t);
 
 #endif

--- a/kernel/generic/include/proc/thread.h
+++ b/kernel/generic/include/proc/thread.h
@@ -264,10 +264,10 @@ extern void thread_stack_trace(thread_id_t);
 extern slab_cache_t *fpu_context_cache;
 
 /* Thread syscall prototypes. */
-extern sys_errno_t sys_thread_create(uspace_ptr(uspace_arg_t), uspace_ptr(char), size_t,
-    uspace_ptr(thread_id_t));
+extern sys_errno_t sys_thread_create(uspace_ptr_uspace_arg_t, uspace_ptr_char, size_t,
+    uspace_ptr_thread_id_t);
 extern sys_errno_t sys_thread_exit(int);
-extern sys_errno_t sys_thread_get_id(uspace_ptr(thread_id_t));
+extern sys_errno_t sys_thread_get_id(uspace_ptr_thread_id_t);
 extern sys_errno_t sys_thread_usleep(uint32_t);
 extern sys_errno_t sys_thread_udelay(uint32_t);
 

--- a/kernel/generic/include/proc/thread.h
+++ b/kernel/generic/include/proc/thread.h
@@ -264,10 +264,10 @@ extern void thread_stack_trace(thread_id_t);
 extern slab_cache_t *fpu_context_cache;
 
 /* Thread syscall prototypes. */
-extern sys_errno_t sys_thread_create(uspace_arg_t *, char *, size_t,
-    thread_id_t *);
+extern sys_errno_t sys_thread_create(uspace_ptr(uspace_arg_t), uspace_ptr(char), size_t,
+    uspace_ptr(thread_id_t));
 extern sys_errno_t sys_thread_exit(int);
-extern sys_errno_t sys_thread_get_id(thread_id_t *);
+extern sys_errno_t sys_thread_get_id(uspace_ptr(thread_id_t));
 extern sys_errno_t sys_thread_usleep(uint32_t);
 extern sys_errno_t sys_thread_udelay(uint32_t);
 

--- a/kernel/generic/include/security/perm.h
+++ b/kernel/generic/include/security/perm.h
@@ -74,8 +74,8 @@ typedef uint32_t perm_t;
 
 #ifdef __32_BITS__
 
-extern sys_errno_t sys_perm_grant(sysarg64_t *, perm_t);
-extern sys_errno_t sys_perm_revoke(sysarg64_t *, perm_t);
+extern sys_errno_t sys_perm_grant(uspace_ptr(sysarg64_t), perm_t);
+extern sys_errno_t sys_perm_revoke(uspace_ptr(sysarg64_t), perm_t);
 
 #endif  /* __32_BITS__ */
 

--- a/kernel/generic/include/security/perm.h
+++ b/kernel/generic/include/security/perm.h
@@ -74,8 +74,8 @@ typedef uint32_t perm_t;
 
 #ifdef __32_BITS__
 
-extern sys_errno_t sys_perm_grant(uspace_ptr(sysarg64_t), perm_t);
-extern sys_errno_t sys_perm_revoke(uspace_ptr(sysarg64_t), perm_t);
+extern sys_errno_t sys_perm_grant(uspace_ptr_sysarg64_t, perm_t);
+extern sys_errno_t sys_perm_revoke(uspace_ptr_sysarg64_t, perm_t);
 
 #endif  /* __32_BITS__ */
 

--- a/kernel/generic/include/synch/syswaitq.h
+++ b/kernel/generic/include/synch/syswaitq.h
@@ -42,7 +42,7 @@ extern void sys_waitq_init(void);
 
 extern void sys_waitq_task_cleanup(void);
 
-extern sys_errno_t sys_waitq_create(cap_waitq_handle_t *);
+extern sys_errno_t sys_waitq_create(uspace_ptr(cap_waitq_handle_t));
 extern sys_errno_t sys_waitq_sleep(cap_waitq_handle_t, uint32_t, unsigned int);
 extern sys_errno_t sys_waitq_wakeup(cap_waitq_handle_t);
 extern sys_errno_t sys_waitq_destroy(cap_waitq_handle_t);

--- a/kernel/generic/include/synch/syswaitq.h
+++ b/kernel/generic/include/synch/syswaitq.h
@@ -42,7 +42,7 @@ extern void sys_waitq_init(void);
 
 extern void sys_waitq_task_cleanup(void);
 
-extern sys_errno_t sys_waitq_create(uspace_ptr(cap_waitq_handle_t));
+extern sys_errno_t sys_waitq_create(uspace_ptr_cap_waitq_handle_t);
 extern sys_errno_t sys_waitq_sleep(cap_waitq_handle_t, uint32_t, unsigned int);
 extern sys_errno_t sys_waitq_wakeup(cap_waitq_handle_t);
 extern sys_errno_t sys_waitq_destroy(cap_waitq_handle_t);

--- a/kernel/generic/include/syscall/copy.h
+++ b/kernel/generic/include/syscall/copy.h
@@ -43,15 +43,15 @@ extern char memcpy_from_uspace_failover_address;
 /** Label within memcpy_to_uspace() that contains return -1. */
 extern char memcpy_to_uspace_failover_address;
 
-extern errno_t copy_from_uspace(void *dst, const void *uspace_src, size_t size);
-extern errno_t copy_to_uspace(void *dst_uspace, const void *src, size_t size);
+extern errno_t copy_from_uspace(void *dst, uspace_addr_t uspace_src, size_t size);
+extern errno_t copy_to_uspace(uspace_addr_t dst_uspace, const void *src, size_t size);
 
 /*
  * This interface must be implemented by each architecture.
  * The functions return zero on failure and nonzero on success.
  */
-extern uintptr_t memcpy_from_uspace(void *dst, const void *uspace_src, size_t size);
-extern uintptr_t memcpy_to_uspace(void *uspace_dst, const void *src, size_t size);
+extern uintptr_t memcpy_from_uspace(void *dst, uspace_addr_t uspace_src, size_t size);
+extern uintptr_t memcpy_to_uspace(uspace_addr_t uspace_dst, const void *src, size_t size);
 
 #endif
 

--- a/kernel/generic/include/sysinfo/sysinfo.h
+++ b/kernel/generic/include/sysinfo/sysinfo.h
@@ -162,11 +162,11 @@ extern void sysinfo_init(void);
 extern void sysinfo_dump(sysinfo_item_t *);
 
 extern sys_errno_t sys_sysinfo_get_keys_size(uspace_addr_t, size_t, uspace_addr_t);
-extern sys_errno_t sys_sysinfo_get_keys(uspace_addr_t, size_t, uspace_addr_t, size_t, uspace_ptr(size_t));
+extern sys_errno_t sys_sysinfo_get_keys(uspace_addr_t, size_t, uspace_addr_t, size_t, uspace_ptr_size_t);
 extern sysarg_t sys_sysinfo_get_val_type(uspace_addr_t, size_t);
 extern sys_errno_t sys_sysinfo_get_value(uspace_addr_t, size_t, uspace_addr_t);
 extern sys_errno_t sys_sysinfo_get_data_size(uspace_addr_t, size_t, uspace_addr_t);
-extern sys_errno_t sys_sysinfo_get_data(uspace_addr_t, size_t, uspace_addr_t, size_t, uspace_ptr(size_t));
+extern sys_errno_t sys_sysinfo_get_data(uspace_addr_t, size_t, uspace_addr_t, size_t, uspace_ptr_size_t);
 
 #endif
 

--- a/kernel/generic/include/sysinfo/sysinfo.h
+++ b/kernel/generic/include/sysinfo/sysinfo.h
@@ -161,12 +161,12 @@ extern void sysinfo_set_subtree_fn(const char *, sysinfo_item_t **,
 extern void sysinfo_init(void);
 extern void sysinfo_dump(sysinfo_item_t *);
 
-extern sys_errno_t sys_sysinfo_get_keys_size(void *, size_t, void *);
-extern sys_errno_t sys_sysinfo_get_keys(void *, size_t, void *, size_t, size_t *);
-extern sysarg_t sys_sysinfo_get_val_type(void *, size_t);
-extern sys_errno_t sys_sysinfo_get_value(void *, size_t, void *);
-extern sys_errno_t sys_sysinfo_get_data_size(void *, size_t, void *);
-extern sys_errno_t sys_sysinfo_get_data(void *, size_t, void *, size_t, size_t *);
+extern sys_errno_t sys_sysinfo_get_keys_size(uspace_ptr(void), size_t, uspace_ptr(void));
+extern sys_errno_t sys_sysinfo_get_keys(uspace_ptr(void), size_t, uspace_ptr(void), size_t, uspace_ptr(size_t));
+extern sysarg_t sys_sysinfo_get_val_type(uspace_ptr(void), size_t);
+extern sys_errno_t sys_sysinfo_get_value(uspace_ptr(void), size_t, uspace_ptr(void));
+extern sys_errno_t sys_sysinfo_get_data_size(uspace_ptr(void), size_t, uspace_ptr(void));
+extern sys_errno_t sys_sysinfo_get_data(uspace_ptr(void), size_t, uspace_ptr(void), size_t, uspace_ptr(size_t));
 
 #endif
 

--- a/kernel/generic/include/sysinfo/sysinfo.h
+++ b/kernel/generic/include/sysinfo/sysinfo.h
@@ -161,12 +161,12 @@ extern void sysinfo_set_subtree_fn(const char *, sysinfo_item_t **,
 extern void sysinfo_init(void);
 extern void sysinfo_dump(sysinfo_item_t *);
 
-extern sys_errno_t sys_sysinfo_get_keys_size(uspace_ptr(void), size_t, uspace_ptr(void));
-extern sys_errno_t sys_sysinfo_get_keys(uspace_ptr(void), size_t, uspace_ptr(void), size_t, uspace_ptr(size_t));
-extern sysarg_t sys_sysinfo_get_val_type(uspace_ptr(void), size_t);
-extern sys_errno_t sys_sysinfo_get_value(uspace_ptr(void), size_t, uspace_ptr(void));
-extern sys_errno_t sys_sysinfo_get_data_size(uspace_ptr(void), size_t, uspace_ptr(void));
-extern sys_errno_t sys_sysinfo_get_data(uspace_ptr(void), size_t, uspace_ptr(void), size_t, uspace_ptr(size_t));
+extern sys_errno_t sys_sysinfo_get_keys_size(uspace_addr_t, size_t, uspace_addr_t);
+extern sys_errno_t sys_sysinfo_get_keys(uspace_addr_t, size_t, uspace_addr_t, size_t, uspace_ptr(size_t));
+extern sysarg_t sys_sysinfo_get_val_type(uspace_addr_t, size_t);
+extern sys_errno_t sys_sysinfo_get_value(uspace_addr_t, size_t, uspace_addr_t);
+extern sys_errno_t sys_sysinfo_get_data_size(uspace_addr_t, size_t, uspace_addr_t);
+extern sys_errno_t sys_sysinfo_get_data(uspace_addr_t, size_t, uspace_addr_t, size_t, uspace_ptr(size_t));
 
 #endif
 

--- a/kernel/generic/include/udebug/udebug_ops.h
+++ b/kernel/generic/include/udebug/udebug_ops.h
@@ -54,7 +54,7 @@ errno_t udebug_args_read(thread_t *t, void **buffer);
 
 errno_t udebug_regs_read(thread_t *t, void **buffer);
 
-errno_t udebug_mem_read(sysarg_t uspace_addr, size_t n, void **buffer);
+errno_t udebug_mem_read(uspace_ptr(void) uspace_addr, size_t n, void **buffer);
 
 #endif
 

--- a/kernel/generic/include/udebug/udebug_ops.h
+++ b/kernel/generic/include/udebug/udebug_ops.h
@@ -54,7 +54,7 @@ errno_t udebug_args_read(thread_t *t, void **buffer);
 
 errno_t udebug_regs_read(thread_t *t, void **buffer);
 
-errno_t udebug_mem_read(uspace_ptr(void) uspace_addr, size_t n, void **buffer);
+errno_t udebug_mem_read(uspace_addr_t uspace_addr, size_t n, void **buffer);
 
 #endif
 

--- a/kernel/generic/src/console/console.c
+++ b/kernel/generic/src/console/console.c
@@ -394,7 +394,7 @@ void putwchar(const wchar_t ch)
  * Print to kernel log.
  *
  */
-sys_errno_t sys_kio(int cmd, uspace_ptr(void) buf, size_t size)
+sys_errno_t sys_kio(int cmd, uspace_addr_t buf, size_t size)
 {
 	char *data;
 	errno_t rc;

--- a/kernel/generic/src/console/console.c
+++ b/kernel/generic/src/console/console.c
@@ -394,7 +394,7 @@ void putwchar(const wchar_t ch)
  * Print to kernel log.
  *
  */
-sys_errno_t sys_kio(int cmd, const void *buf, size_t size)
+sys_errno_t sys_kio(int cmd, uspace_ptr(void) buf, size_t size)
 {
 	char *data;
 	errno_t rc;

--- a/kernel/generic/src/ddi/ddi.c
+++ b/kernel/generic/src/ddi/ddi.c
@@ -247,7 +247,7 @@ _NO_TRACE static errno_t physmem_unmap(uintptr_t virt)
  *
  */
 sys_errno_t sys_physmem_map(uintptr_t phys, size_t pages, unsigned int flags,
-    void *virt_ptr, uintptr_t bound)
+    uspace_ptr(void) virt_ptr, uintptr_t bound)
 {
 	uintptr_t virt;
 	errno_t rc = copy_from_uspace(&virt, virt_ptr, sizeof(virt));
@@ -261,7 +261,7 @@ sys_errno_t sys_physmem_map(uintptr_t phys, size_t pages, unsigned int flags,
 
 	rc = copy_to_uspace(virt_ptr, &virt, sizeof(virt));
 	if (rc != EOK) {
-		physmem_unmap((uintptr_t) virt);
+		physmem_unmap(virt);
 		return rc;
 	}
 
@@ -392,7 +392,7 @@ _NO_TRACE static errno_t iospace_disable(task_id_t id, uintptr_t ioaddr, size_t 
  * @return 0 on success, otherwise it returns error code found in errno.h
  *
  */
-sys_errno_t sys_iospace_enable(ddi_ioarg_t *uspace_io_arg)
+sys_errno_t sys_iospace_enable(uspace_ptr(ddi_ioarg_t) uspace_io_arg)
 {
 	ddi_ioarg_t arg;
 	errno_t rc = copy_from_uspace(&arg, uspace_io_arg, sizeof(ddi_ioarg_t));
@@ -403,7 +403,7 @@ sys_errno_t sys_iospace_enable(ddi_ioarg_t *uspace_io_arg)
 	    (uintptr_t) arg.ioaddr, (size_t) arg.size);
 }
 
-sys_errno_t sys_iospace_disable(ddi_ioarg_t *uspace_io_arg)
+sys_errno_t sys_iospace_disable(uspace_ptr(ddi_ioarg_t) uspace_io_arg)
 {
 	ddi_ioarg_t arg;
 	errno_t rc = copy_from_uspace(&arg, uspace_io_arg, sizeof(ddi_ioarg_t));
@@ -464,7 +464,7 @@ _NO_TRACE static errno_t dmamem_unmap_anonymous(uintptr_t virt)
 }
 
 sys_errno_t sys_dmamem_map(size_t size, unsigned int map_flags, unsigned int flags,
-    void *phys_ptr, void *virt_ptr, uintptr_t bound)
+    uspace_ptr(void) phys_ptr, uspace_ptr(void) virt_ptr, uintptr_t bound)
 {
 	if ((flags & DMAMEM_FLAGS_ANONYMOUS) == 0) {
 		/*
@@ -472,7 +472,7 @@ sys_errno_t sys_dmamem_map(size_t size, unsigned int map_flags, unsigned int fla
 		 */
 
 		uintptr_t phys;
-		errno_t rc = dmamem_map((uintptr_t) virt_ptr, size, map_flags,
+		errno_t rc = dmamem_map(virt_ptr, size, map_flags,
 		    flags, &phys);
 
 		if (rc != EOK)
@@ -480,7 +480,7 @@ sys_errno_t sys_dmamem_map(size_t size, unsigned int map_flags, unsigned int fla
 
 		rc = copy_to_uspace(phys_ptr, &phys, sizeof(phys));
 		if (rc != EOK) {
-			dmamem_unmap((uintptr_t) virt_ptr, size);
+			dmamem_unmap(virt_ptr, size);
 			return rc;
 		}
 	} else {
@@ -507,13 +507,13 @@ sys_errno_t sys_dmamem_map(size_t size, unsigned int map_flags, unsigned int fla
 
 		rc = copy_to_uspace(phys_ptr, &phys, sizeof(phys));
 		if (rc != EOK) {
-			dmamem_unmap_anonymous((uintptr_t) virt);
+			dmamem_unmap_anonymous(virt);
 			return rc;
 		}
 
 		rc = copy_to_uspace(virt_ptr, &virt, sizeof(virt));
 		if (rc != EOK) {
-			dmamem_unmap_anonymous((uintptr_t) virt);
+			dmamem_unmap_anonymous(virt);
 			return rc;
 		}
 	}

--- a/kernel/generic/src/ddi/ddi.c
+++ b/kernel/generic/src/ddi/ddi.c
@@ -247,7 +247,7 @@ _NO_TRACE static errno_t physmem_unmap(uintptr_t virt)
  *
  */
 sys_errno_t sys_physmem_map(uintptr_t phys, size_t pages, unsigned int flags,
-    uspace_addr_t virt_ptr, uintptr_t bound)
+    uspace_ptr_uintptr_t virt_ptr, uintptr_t bound)
 {
 	uintptr_t virt;
 	errno_t rc = copy_from_uspace(&virt, virt_ptr, sizeof(virt));
@@ -464,7 +464,7 @@ _NO_TRACE static errno_t dmamem_unmap_anonymous(uintptr_t virt)
 }
 
 sys_errno_t sys_dmamem_map(size_t size, unsigned int map_flags, unsigned int flags,
-    uspace_addr_t phys_ptr, uspace_addr_t virt_ptr, uintptr_t bound)
+    uspace_ptr_uintptr_t phys_ptr, uspace_ptr_uintptr_t virt_ptr, uintptr_t bound)
 {
 	if ((flags & DMAMEM_FLAGS_ANONYMOUS) == 0) {
 		/*

--- a/kernel/generic/src/ddi/ddi.c
+++ b/kernel/generic/src/ddi/ddi.c
@@ -247,7 +247,7 @@ _NO_TRACE static errno_t physmem_unmap(uintptr_t virt)
  *
  */
 sys_errno_t sys_physmem_map(uintptr_t phys, size_t pages, unsigned int flags,
-    uspace_ptr(void) virt_ptr, uintptr_t bound)
+    uspace_addr_t virt_ptr, uintptr_t bound)
 {
 	uintptr_t virt;
 	errno_t rc = copy_from_uspace(&virt, virt_ptr, sizeof(virt));
@@ -464,7 +464,7 @@ _NO_TRACE static errno_t dmamem_unmap_anonymous(uintptr_t virt)
 }
 
 sys_errno_t sys_dmamem_map(size_t size, unsigned int map_flags, unsigned int flags,
-    uspace_ptr(void) phys_ptr, uspace_ptr(void) virt_ptr, uintptr_t bound)
+    uspace_addr_t phys_ptr, uspace_addr_t virt_ptr, uintptr_t bound)
 {
 	if ((flags & DMAMEM_FLAGS_ANONYMOUS) == 0) {
 		/*

--- a/kernel/generic/src/ddi/ddi.c
+++ b/kernel/generic/src/ddi/ddi.c
@@ -392,7 +392,7 @@ _NO_TRACE static errno_t iospace_disable(task_id_t id, uintptr_t ioaddr, size_t 
  * @return 0 on success, otherwise it returns error code found in errno.h
  *
  */
-sys_errno_t sys_iospace_enable(uspace_ptr(ddi_ioarg_t) uspace_io_arg)
+sys_errno_t sys_iospace_enable(uspace_ptr_ddi_ioarg_t uspace_io_arg)
 {
 	ddi_ioarg_t arg;
 	errno_t rc = copy_from_uspace(&arg, uspace_io_arg, sizeof(ddi_ioarg_t));
@@ -403,7 +403,7 @@ sys_errno_t sys_iospace_enable(uspace_ptr(ddi_ioarg_t) uspace_io_arg)
 	    (uintptr_t) arg.ioaddr, (size_t) arg.size);
 }
 
-sys_errno_t sys_iospace_disable(uspace_ptr(ddi_ioarg_t) uspace_io_arg)
+sys_errno_t sys_iospace_disable(uspace_ptr_ddi_ioarg_t uspace_io_arg)
 {
 	ddi_ioarg_t arg;
 	errno_t rc = copy_from_uspace(&arg, uspace_io_arg, sizeof(ddi_ioarg_t));

--- a/kernel/generic/src/ipc/irq.c
+++ b/kernel/generic/src/ipc/irq.c
@@ -222,7 +222,7 @@ static void code_free(irq_code_t *code)
  * @return Kernel address of the copied IRQ code.
  *
  */
-static irq_code_t *code_from_uspace(uspace_ptr(irq_code_t) ucode)
+static irq_code_t *code_from_uspace(uspace_ptr_irq_code_t ucode)
 {
 	irq_pio_range_t *ranges = NULL;
 	irq_cmd_t *cmds = NULL;
@@ -322,7 +322,7 @@ static kobject_ops_t irq_kobject_ops = {
  *
  */
 errno_t ipc_irq_subscribe(answerbox_t *box, inr_t inr, sysarg_t imethod,
-    uspace_ptr(irq_code_t) ucode, uspace_ptr(cap_irq_handle_t) uspace_handle)
+    uspace_ptr_irq_code_t ucode, uspace_ptr_cap_irq_handle_t uspace_handle)
 {
 	if ((inr < 0) || (inr > last_inr))
 		return ELIMIT;

--- a/kernel/generic/src/ipc/irq.c
+++ b/kernel/generic/src/ipc/irq.c
@@ -222,7 +222,7 @@ static void code_free(irq_code_t *code)
  * @return Kernel address of the copied IRQ code.
  *
  */
-static irq_code_t *code_from_uspace(irq_code_t *ucode)
+static irq_code_t *code_from_uspace(uspace_ptr(irq_code_t) ucode)
 {
 	irq_pio_range_t *ranges = NULL;
 	irq_cmd_t *cmds = NULL;
@@ -241,7 +241,7 @@ static irq_code_t *code_from_uspace(irq_code_t *ucode)
 	ranges = malloc(sizeof(code->ranges[0]) * code->rangecount);
 	if (!ranges)
 		goto error;
-	rc = copy_from_uspace(ranges, code->ranges,
+	rc = copy_from_uspace(ranges, (uintptr_t) code->ranges,
 	    sizeof(code->ranges[0]) * code->rangecount);
 	if (rc != EOK)
 		goto error;
@@ -249,7 +249,7 @@ static irq_code_t *code_from_uspace(irq_code_t *ucode)
 	cmds = malloc(sizeof(code->cmds[0]) * code->cmdcount);
 	if (!cmds)
 		goto error;
-	rc = copy_from_uspace(cmds, code->cmds,
+	rc = copy_from_uspace(cmds, (uintptr_t) code->cmds,
 	    sizeof(code->cmds[0]) * code->cmdcount);
 	if (rc != EOK)
 		goto error;
@@ -322,7 +322,7 @@ static kobject_ops_t irq_kobject_ops = {
  *
  */
 errno_t ipc_irq_subscribe(answerbox_t *box, inr_t inr, sysarg_t imethod,
-    irq_code_t *ucode, cap_irq_handle_t *uspace_handle)
+    uspace_ptr(irq_code_t) ucode, uspace_ptr(cap_irq_handle_t) uspace_handle)
 {
 	if ((inr < 0) || (inr > last_inr))
 		return ELIMIT;

--- a/kernel/generic/src/ipc/ops/dataread.c
+++ b/kernel/generic/src/ipc/ops/dataread.c
@@ -62,8 +62,8 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 
 	if (!ipc_get_retval(&answer->data)) {
 		/* The recipient agreed to send data. */
-		uintptr_t src = ipc_get_arg1(&answer->data);
-		uintptr_t dst = ipc_get_arg1(olddata);
+		uspace_addr_t src = ipc_get_arg1(&answer->data);
+		uspace_addr_t dst = ipc_get_arg1(olddata);
 		size_t max_size = ipc_get_arg2(olddata);
 		size_t size = ipc_get_arg2(&answer->data);
 
@@ -80,7 +80,7 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 				return EOK;
 			}
 			errno_t rc = copy_from_uspace(answer->buffer,
-			    (void *) src, size);
+			    src, size);
 			if (rc) {
 				ipc_set_retval(&answer->data, rc);
 				/*
@@ -102,11 +102,11 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 static errno_t answer_process(call_t *answer)
 {
 	if (answer->buffer) {
-		uintptr_t dst = ipc_get_arg1(&answer->data);
+		uspace_addr_t dst = ipc_get_arg1(&answer->data);
 		size_t size = ipc_get_arg2(&answer->data);
 		errno_t rc;
 
-		rc = copy_to_uspace((void *) dst, answer->buffer, size);
+		rc = copy_to_uspace(dst, answer->buffer, size);
 		if (rc)
 			ipc_set_retval(&answer->data, rc);
 	}

--- a/kernel/generic/src/ipc/ops/datawrite.c
+++ b/kernel/generic/src/ipc/ops/datawrite.c
@@ -42,7 +42,7 @@
 
 static errno_t request_preprocess(call_t *call, phone_t *phone)
 {
-	uintptr_t src = ipc_get_arg1(&call->data);
+	uspace_addr_t src = ipc_get_arg1(&call->data);
 	size_t size = ipc_get_arg2(&call->data);
 
 	if (size > DATA_XFER_LIMIT) {
@@ -58,7 +58,7 @@ static errno_t request_preprocess(call_t *call, phone_t *phone)
 	call->buffer = (uint8_t *) malloc(size);
 	if (!call->buffer)
 		return ENOMEM;
-	errno_t rc = copy_from_uspace(call->buffer, (void *) src, size);
+	errno_t rc = copy_from_uspace(call->buffer, src, size);
 	if (rc != EOK) {
 		/*
 		 * call->buffer will be cleaned up in ipc_call_free() at the
@@ -76,12 +76,12 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 
 	if (!ipc_get_retval(&answer->data)) {
 		/* The recipient agreed to receive data. */
-		uintptr_t dst = (uintptr_t)ipc_get_arg1(&answer->data);
-		size_t size = (size_t)ipc_get_arg2(&answer->data);
-		size_t max_size = (size_t)ipc_get_arg2(olddata);
+		uspace_addr_t dst = ipc_get_arg1(&answer->data);
+		size_t size = ipc_get_arg2(&answer->data);
+		size_t max_size = ipc_get_arg2(olddata);
 
 		if (size <= max_size) {
-			errno_t rc = copy_to_uspace((void *) dst,
+			errno_t rc = copy_to_uspace(dst,
 			    answer->buffer, size);
 			if (rc)
 				ipc_set_retval(&answer->data, rc);

--- a/kernel/generic/src/ipc/ops/debug.c
+++ b/kernel/generic/src/ipc/ops/debug.c
@@ -46,11 +46,11 @@ static int request_process(call_t *call, answerbox_t *box)
 static errno_t answer_process(call_t *answer)
 {
 	if (answer->buffer) {
-		uintptr_t dst = ipc_get_arg1(&answer->data);
+		uspace_addr_t dst = ipc_get_arg1(&answer->data);
 		size_t size = ipc_get_arg2(&answer->data);
 		errno_t rc;
 
-		rc = copy_to_uspace((void *) dst, answer->buffer, size);
+		rc = copy_to_uspace(dst, answer->buffer, size);
 		if (rc)
 			ipc_set_retval(&answer->data, rc);
 	}

--- a/kernel/generic/src/ipc/ops/shareout.c
+++ b/kernel/generic/src/ipc/ops/shareout.c
@@ -69,7 +69,7 @@ static errno_t answer_preprocess(call_t *answer, ipc_data_t *olddata)
 		    &dst_base, ipc_get_arg1(&answer->data));
 
 		if (rc == EOK) {
-			rc = copy_to_uspace((void *) ipc_get_arg2(&answer->data),
+			rc = copy_to_uspace(ipc_get_arg2(&answer->data),
 			    &dst_base, sizeof(dst_base));
 		}
 

--- a/kernel/generic/src/ipc/sysipc.c
+++ b/kernel/generic/src/ipc/sysipc.c
@@ -418,7 +418,7 @@ sys_errno_t sys_ipc_call_async_fast(cap_phone_handle_t handle, sysarg_t imethod,
  * @return See sys_ipc_call_async_fast().
  *
  */
-sys_errno_t sys_ipc_call_async_slow(cap_phone_handle_t handle, ipc_data_t *data,
+sys_errno_t sys_ipc_call_async_slow(cap_phone_handle_t handle, uspace_ptr(ipc_data_t) data,
     sysarg_t label)
 {
 	kobject_t *kobj = kobject_get(TASK, handle, KOBJECT_TYPE_PHONE);
@@ -436,7 +436,7 @@ sys_errno_t sys_ipc_call_async_slow(cap_phone_handle_t handle, ipc_data_t *data,
 		return ENOMEM;
 	}
 
-	errno_t rc = copy_from_uspace(&call->data.args, &data->args,
+	errno_t rc = copy_from_uspace(&call->data.args, data + offsetof(ipc_data_t, args),
 	    sizeof(call->data.args));
 	if (rc != EOK) {
 		kobject_put(call->kobject);
@@ -622,10 +622,10 @@ sys_errno_t sys_ipc_forward_fast(cap_call_handle_t chandle,
  *
  */
 sys_errno_t sys_ipc_forward_slow(cap_call_handle_t chandle,
-    cap_phone_handle_t phandle, ipc_data_t *data, unsigned int mode)
+    cap_phone_handle_t phandle, uspace_ptr(ipc_data_t) data, unsigned int mode)
 {
 	ipc_data_t newdata;
-	errno_t rc = copy_from_uspace(&newdata.args, &data->args,
+	errno_t rc = copy_from_uspace(&newdata.args, data + offsetof(ipc_data_t, args),
 	    sizeof(newdata.args));
 	if (rc != EOK)
 		return (sys_errno_t) rc;
@@ -699,7 +699,7 @@ sys_errno_t sys_ipc_answer_fast(cap_call_handle_t chandle, sysarg_t retval,
  * @return 0 on success, otherwise an error code.
  *
  */
-sys_errno_t sys_ipc_answer_slow(cap_call_handle_t chandle, ipc_data_t *data)
+sys_errno_t sys_ipc_answer_slow(cap_call_handle_t chandle, uspace_ptr(ipc_data_t) data)
 {
 	kobject_t *kobj = cap_unpublish(TASK, chandle, KOBJECT_TYPE_CALL);
 	if (!kobj)
@@ -717,7 +717,7 @@ sys_errno_t sys_ipc_answer_slow(cap_call_handle_t chandle, ipc_data_t *data)
 	} else
 		saved = false;
 
-	errno_t rc = copy_from_uspace(&call->data.args, &data->args,
+	errno_t rc = copy_from_uspace(&call->data.args, data + offsetof(ipc_data_t, args),
 	    sizeof(call->data.args));
 	if (rc != EOK) {
 		/*
@@ -765,7 +765,7 @@ sys_errno_t sys_ipc_hangup(cap_phone_handle_t handle)
  *
  * @return An error code on error.
  */
-sys_errno_t sys_ipc_wait_for_call(ipc_data_t *calldata, uint32_t usec,
+sys_errno_t sys_ipc_wait_for_call(uspace_ptr(ipc_data_t) calldata, uint32_t usec,
     unsigned int flags)
 {
 	call_t *call = NULL;
@@ -887,7 +887,7 @@ sys_errno_t sys_ipc_poke(void)
  *
  */
 sys_errno_t sys_ipc_irq_subscribe(inr_t inr, sysarg_t imethod,
-    irq_code_t *ucode, cap_irq_handle_t *uspace_handle)
+    uspace_ptr(irq_code_t) ucode, uspace_ptr(cap_irq_handle_t) uspace_handle)
 {
 	if (!(perm_get(TASK) & PERM_IRQ_REG))
 		return EPERM;
@@ -917,8 +917,8 @@ sys_errno_t sys_ipc_irq_unsubscribe(cap_irq_handle_t handle)
  * @return Error code.
  *
  */
-sys_errno_t sys_ipc_connect_kbox(task_id_t *uspace_taskid,
-    cap_phone_handle_t *uspace_phone)
+sys_errno_t sys_ipc_connect_kbox(uspace_ptr(task_id_t) uspace_taskid,
+    uspace_ptr(cap_phone_handle_t) uspace_phone)
 {
 #ifdef CONFIG_UDEBUG
 	task_id_t taskid;

--- a/kernel/generic/src/ipc/sysipc.c
+++ b/kernel/generic/src/ipc/sysipc.c
@@ -418,7 +418,7 @@ sys_errno_t sys_ipc_call_async_fast(cap_phone_handle_t handle, sysarg_t imethod,
  * @return See sys_ipc_call_async_fast().
  *
  */
-sys_errno_t sys_ipc_call_async_slow(cap_phone_handle_t handle, uspace_ptr(ipc_data_t) data,
+sys_errno_t sys_ipc_call_async_slow(cap_phone_handle_t handle, uspace_ptr_ipc_data_t data,
     sysarg_t label)
 {
 	kobject_t *kobj = kobject_get(TASK, handle, KOBJECT_TYPE_PHONE);
@@ -622,7 +622,7 @@ sys_errno_t sys_ipc_forward_fast(cap_call_handle_t chandle,
  *
  */
 sys_errno_t sys_ipc_forward_slow(cap_call_handle_t chandle,
-    cap_phone_handle_t phandle, uspace_ptr(ipc_data_t) data, unsigned int mode)
+    cap_phone_handle_t phandle, uspace_ptr_ipc_data_t data, unsigned int mode)
 {
 	ipc_data_t newdata;
 	errno_t rc = copy_from_uspace(&newdata.args, data + offsetof(ipc_data_t, args),
@@ -699,7 +699,7 @@ sys_errno_t sys_ipc_answer_fast(cap_call_handle_t chandle, sysarg_t retval,
  * @return 0 on success, otherwise an error code.
  *
  */
-sys_errno_t sys_ipc_answer_slow(cap_call_handle_t chandle, uspace_ptr(ipc_data_t) data)
+sys_errno_t sys_ipc_answer_slow(cap_call_handle_t chandle, uspace_ptr_ipc_data_t data)
 {
 	kobject_t *kobj = cap_unpublish(TASK, chandle, KOBJECT_TYPE_CALL);
 	if (!kobj)
@@ -765,7 +765,7 @@ sys_errno_t sys_ipc_hangup(cap_phone_handle_t handle)
  *
  * @return An error code on error.
  */
-sys_errno_t sys_ipc_wait_for_call(uspace_ptr(ipc_data_t) calldata, uint32_t usec,
+sys_errno_t sys_ipc_wait_for_call(uspace_ptr_ipc_data_t calldata, uint32_t usec,
     unsigned int flags)
 {
 	call_t *call = NULL;
@@ -887,7 +887,7 @@ sys_errno_t sys_ipc_poke(void)
  *
  */
 sys_errno_t sys_ipc_irq_subscribe(inr_t inr, sysarg_t imethod,
-    uspace_ptr(irq_code_t) ucode, uspace_ptr(cap_irq_handle_t) uspace_handle)
+    uspace_ptr_irq_code_t ucode, uspace_ptr_cap_irq_handle_t uspace_handle)
 {
 	if (!(perm_get(TASK) & PERM_IRQ_REG))
 		return EPERM;
@@ -917,8 +917,8 @@ sys_errno_t sys_ipc_irq_unsubscribe(cap_irq_handle_t handle)
  * @return Error code.
  *
  */
-sys_errno_t sys_ipc_connect_kbox(uspace_ptr(task_id_t) uspace_taskid,
-    uspace_ptr(cap_phone_handle_t) uspace_phone)
+sys_errno_t sys_ipc_connect_kbox(uspace_ptr_task_id_t uspace_taskid,
+    uspace_ptr_cap_phone_handle_t uspace_phone)
 {
 #ifdef CONFIG_UDEBUG
 	task_id_t taskid;

--- a/kernel/generic/src/log/log.c
+++ b/kernel/generic/src/log/log.c
@@ -294,8 +294,8 @@ int log(log_facility_t fac, log_level_t level, const char *fmt, ...)
 /** Control of the log from uspace
  *
  */
-sys_errno_t sys_klog(sysarg_t operation, void *buf, size_t size,
-    sysarg_t level, size_t *uspace_nread)
+sys_errno_t sys_klog(sysarg_t operation, uspace_ptr(void) buf, size_t size,
+    sysarg_t level, uspace_ptr(size_t) uspace_nread)
 {
 	char *data;
 	errno_t rc;

--- a/kernel/generic/src/log/log.c
+++ b/kernel/generic/src/log/log.c
@@ -294,7 +294,7 @@ int log(log_facility_t fac, log_level_t level, const char *fmt, ...)
 /** Control of the log from uspace
  *
  */
-sys_errno_t sys_klog(sysarg_t operation, uspace_ptr(void) buf, size_t size,
+sys_errno_t sys_klog(sysarg_t operation, uspace_addr_t buf, size_t size,
     sysarg_t level, uspace_ptr(size_t) uspace_nread)
 {
 	char *data;

--- a/kernel/generic/src/log/log.c
+++ b/kernel/generic/src/log/log.c
@@ -295,7 +295,7 @@ int log(log_facility_t fac, log_level_t level, const char *fmt, ...)
  *
  */
 sys_errno_t sys_klog(sysarg_t operation, uspace_addr_t buf, size_t size,
-    sysarg_t level, uspace_ptr(size_t) uspace_nread)
+    sysarg_t level, uspace_ptr_size_t uspace_nread)
 {
 	char *data;
 	errno_t rc;

--- a/kernel/generic/src/main/uinit.c
+++ b/kernel/generic/src/main/uinit.c
@@ -69,15 +69,15 @@ void uinit(void *arg)
 	udebug_stoppable_end();
 #endif
 
-	uspace_arg_t *uarg = (uspace_arg_t *) arg;
+	uspace_arg_t *uarg = arg;
 	uspace_arg_t local_uarg;
 
 	local_uarg.uspace_entry = uarg->uspace_entry;
 	local_uarg.uspace_stack = uarg->uspace_stack;
 	local_uarg.uspace_stack_size = uarg->uspace_stack_size;
 	local_uarg.uspace_uarg = uarg->uspace_uarg;
-	local_uarg.uspace_thread_function = NULL;
-	local_uarg.uspace_thread_arg = NULL;
+	local_uarg.uspace_thread_function = USPACE_NULL;
+	local_uarg.uspace_thread_arg = USPACE_NULL;
 
 	free(uarg);
 

--- a/kernel/generic/src/mm/as.c
+++ b/kernel/generic/src/mm/as.c
@@ -2127,6 +2127,10 @@ sys_errno_t sys_as_area_change_flags(uintptr_t address, unsigned int flags)
 sys_errno_t sys_as_area_get_info(uintptr_t address, uspace_ptr_as_area_info_t dest)
 {
 	as_area_t *area;
+	as_area_info_t info;
+
+	/* Prevent leaking stack bytes via structure padding. */
+	memset(&info, 0, sizeof(info));
 
 	mutex_lock(&AS->lock);
 	area = find_area_and_lock(AS, address);
@@ -2135,11 +2139,9 @@ sys_errno_t sys_as_area_get_info(uintptr_t address, uspace_ptr_as_area_info_t de
 		return ENOENT;
 	}
 
-	as_area_info_t info = {
-		.start_addr = area->base,
-		.size = P2SZ(area->pages),
-		.flags = area->flags,
-	};
+	info.start_addr = area->base;
+	info.size = P2SZ(area->pages);
+	info.flags = area->flags;
 
 	mutex_unlock(&area->lock);
 	mutex_unlock(&AS->lock);

--- a/kernel/generic/src/mm/as.c
+++ b/kernel/generic/src/mm/as.c
@@ -2091,7 +2091,7 @@ bool used_space_insert(used_space_t *used_space, uintptr_t page, size_t count)
  */
 
 sysarg_t sys_as_area_create(uintptr_t base, size_t size, unsigned int flags,
-    uintptr_t bound, uspace_ptr(as_area_pager_info_t) pager_info)
+    uintptr_t bound, uspace_ptr_as_area_pager_info_t pager_info)
 {
 	uintptr_t virt = base;
 	mem_backend_t *backend;
@@ -2124,7 +2124,7 @@ sys_errno_t sys_as_area_change_flags(uintptr_t address, unsigned int flags)
 	return (sys_errno_t) as_area_change_flags(AS, flags, address);
 }
 
-sys_errno_t sys_as_area_get_info(uintptr_t address, uspace_ptr(as_area_info_t) dest)
+sys_errno_t sys_as_area_get_info(uintptr_t address, uspace_ptr_as_area_info_t dest)
 {
 	as_area_t *area;
 

--- a/kernel/generic/src/mm/page.c
+++ b/kernel/generic/src/mm/page.c
@@ -214,7 +214,7 @@ errno_t page_find_mapping(uintptr_t virt, uintptr_t *phys)
  * @return ENOENT if no virtual address mapping found.
  *
  */
-sys_errno_t sys_page_find_mapping(uintptr_t virt, uintptr_t *phys_ptr)
+sys_errno_t sys_page_find_mapping(uintptr_t virt, uspace_ptr(uintptr_t) phys_ptr)
 {
 	uintptr_t phys;
 	errno_t rc = page_find_mapping(virt, &phys);

--- a/kernel/generic/src/mm/page.c
+++ b/kernel/generic/src/mm/page.c
@@ -214,7 +214,7 @@ errno_t page_find_mapping(uintptr_t virt, uintptr_t *phys)
  * @return ENOENT if no virtual address mapping found.
  *
  */
-sys_errno_t sys_page_find_mapping(uintptr_t virt, uspace_ptr(uintptr_t) phys_ptr)
+sys_errno_t sys_page_find_mapping(uintptr_t virt, uspace_ptr_uintptr_t phys_ptr)
 {
 	uintptr_t phys;
 	errno_t rc = page_find_mapping(virt, &phys);

--- a/kernel/generic/src/proc/program.c
+++ b/kernel/generic/src/proc/program.c
@@ -217,7 +217,7 @@ void program_ready(program_t *prg)
  * @return EOK on success or an error code from @ref errno.h.
  *
  */
-sys_errno_t sys_program_spawn_loader(uspace_ptr(char) uspace_name, size_t name_len)
+sys_errno_t sys_program_spawn_loader(uspace_ptr_char uspace_name, size_t name_len)
 {
 	/* Cap length of name and copy it from userspace. */
 	if (name_len > TASK_NAME_BUFLEN - 1)

--- a/kernel/generic/src/proc/program.c
+++ b/kernel/generic/src/proc/program.c
@@ -68,7 +68,7 @@ void *program_loader = NULL;
  * @return EOK on success or an error code.
  *
  */
-errno_t program_create(as_t *as, uintptr_t entry_addr, char *name, program_t *prg)
+errno_t program_create(as_t *as, uspace_addr_t entry_addr, char *name, program_t *prg)
 {
 	uspace_arg_t *kernel_uarg = (uspace_arg_t *)
 	    malloc(sizeof(uspace_arg_t));
@@ -85,7 +85,7 @@ errno_t program_create(as_t *as, uintptr_t entry_addr, char *name, program_t *pr
 	/*
 	 * Create the stack address space area.
 	 */
-	uintptr_t virt = (uintptr_t) -1;
+	uintptr_t virt = (uintptr_t) AS_AREA_ANY;
 	uintptr_t bound = USER_ADDRESS_SPACE_END - (STACK_SIZE_USER - 1);
 
 	/* Adjust bound to create space for the desired guard page. */
@@ -102,12 +102,12 @@ errno_t program_create(as_t *as, uintptr_t entry_addr, char *name, program_t *pr
 		return ENOMEM;
 	}
 
-	kernel_uarg->uspace_entry = (void *) entry_addr;
-	kernel_uarg->uspace_stack = (void *) virt;
+	kernel_uarg->uspace_entry = entry_addr;
+	kernel_uarg->uspace_stack = virt;
 	kernel_uarg->uspace_stack_size = STACK_SIZE_USER;
-	kernel_uarg->uspace_thread_function = NULL;
-	kernel_uarg->uspace_thread_arg = NULL;
-	kernel_uarg->uspace_uarg = NULL;
+	kernel_uarg->uspace_thread_function = USPACE_NULL;
+	kernel_uarg->uspace_thread_arg = USPACE_NULL;
+	kernel_uarg->uspace_uarg = USPACE_NULL;
 
 	/*
 	 * Create the main thread.
@@ -217,7 +217,7 @@ void program_ready(program_t *prg)
  * @return EOK on success or an error code from @ref errno.h.
  *
  */
-sys_errno_t sys_program_spawn_loader(char *uspace_name, size_t name_len)
+sys_errno_t sys_program_spawn_loader(uspace_ptr(char) uspace_name, size_t name_len)
 {
 	/* Cap length of name and copy it from userspace. */
 	if (name_len > TASK_NAME_BUFLEN - 1)

--- a/kernel/generic/src/proc/task.c
+++ b/kernel/generic/src/proc/task.c
@@ -322,7 +322,7 @@ void task_release(task_t *task)
  * @return Zero on success or an error code from @ref errno.h.
  *
  */
-sys_errno_t sys_task_get_id(uspace_ptr(sysarg64_t) uspace_taskid)
+sys_errno_t sys_task_get_id(uspace_ptr_sysarg64_t uspace_taskid)
 {
 	/*
 	 * No need to acquire lock on TASK because taskid remains constant for
@@ -362,7 +362,7 @@ sysarg_t sys_task_get_id(void)
  * @return 0 on success or an error code from @ref errno.h.
  *
  */
-sys_errno_t sys_task_set_name(const uspace_ptr(char) uspace_name, size_t name_len)
+sys_errno_t sys_task_set_name(const uspace_ptr_char uspace_name, size_t name_len)
 {
 	char namebuf[TASK_NAME_BUFLEN];
 
@@ -403,7 +403,7 @@ sys_errno_t sys_task_set_name(const uspace_ptr(char) uspace_name, size_t name_le
  * @return 0 on success or an error code from @ref errno.h.
  *
  */
-sys_errno_t sys_task_kill(uspace_ptr(task_id_t) uspace_taskid)
+sys_errno_t sys_task_kill(uspace_ptr_task_id_t uspace_taskid)
 {
 	task_id_t taskid;
 	errno_t rc = copy_from_uspace(&taskid, uspace_taskid, sizeof(taskid));

--- a/kernel/generic/src/proc/task.c
+++ b/kernel/generic/src/proc/task.c
@@ -322,7 +322,7 @@ void task_release(task_t *task)
  * @return Zero on success or an error code from @ref errno.h.
  *
  */
-sys_errno_t sys_task_get_id(sysarg64_t *uspace_taskid)
+sys_errno_t sys_task_get_id(uspace_ptr(sysarg64_t) uspace_taskid)
 {
 	/*
 	 * No need to acquire lock on TASK because taskid remains constant for
@@ -362,7 +362,7 @@ sysarg_t sys_task_get_id(void)
  * @return 0 on success or an error code from @ref errno.h.
  *
  */
-sys_errno_t sys_task_set_name(const char *uspace_name, size_t name_len)
+sys_errno_t sys_task_set_name(const uspace_ptr(char) uspace_name, size_t name_len)
 {
 	char namebuf[TASK_NAME_BUFLEN];
 
@@ -403,7 +403,7 @@ sys_errno_t sys_task_set_name(const char *uspace_name, size_t name_len)
  * @return 0 on success or an error code from @ref errno.h.
  *
  */
-sys_errno_t sys_task_kill(task_id_t *uspace_taskid)
+sys_errno_t sys_task_kill(uspace_ptr(task_id_t) uspace_taskid)
 {
 	task_id_t taskid;
 	errno_t rc = copy_from_uspace(&taskid, uspace_taskid, sizeof(taskid));

--- a/kernel/generic/src/proc/thread.c
+++ b/kernel/generic/src/proc/thread.c
@@ -997,8 +997,8 @@ static int threads_cmp(void *a, void *b)
 /** Process syscall to create new thread.
  *
  */
-sys_errno_t sys_thread_create(uspace_ptr(uspace_arg_t) uspace_uarg, uspace_ptr(char) uspace_name,
-    size_t name_len, uspace_ptr(thread_id_t) uspace_thread_id)
+sys_errno_t sys_thread_create(uspace_ptr_uspace_arg_t uspace_uarg, uspace_ptr_char uspace_name,
+    size_t name_len, uspace_ptr_thread_id_t uspace_thread_id)
 {
 	if (name_len > THREAD_NAME_BUFLEN - 1)
 		name_len = THREAD_NAME_BUFLEN - 1;
@@ -1087,7 +1087,7 @@ sys_errno_t sys_thread_exit(int uspace_status)
  * @return 0 on success or an error code from @ref errno.h.
  *
  */
-sys_errno_t sys_thread_get_id(uspace_ptr(thread_id_t) uspace_thread_id)
+sys_errno_t sys_thread_get_id(uspace_ptr_thread_id_t uspace_thread_id)
 {
 	/*
 	 * No need to acquire lock on THREAD because tid

--- a/kernel/generic/src/proc/thread.c
+++ b/kernel/generic/src/proc/thread.c
@@ -997,8 +997,8 @@ static int threads_cmp(void *a, void *b)
 /** Process syscall to create new thread.
  *
  */
-sys_errno_t sys_thread_create(uspace_arg_t *uspace_uarg, char *uspace_name,
-    size_t name_len, thread_id_t *uspace_thread_id)
+sys_errno_t sys_thread_create(uspace_ptr(uspace_arg_t) uspace_uarg, uspace_ptr(char) uspace_name,
+    size_t name_len, uspace_ptr(thread_id_t) uspace_thread_id)
 {
 	if (name_len > THREAD_NAME_BUFLEN - 1)
 		name_len = THREAD_NAME_BUFLEN - 1;
@@ -1028,7 +1028,7 @@ sys_errno_t sys_thread_create(uspace_arg_t *uspace_uarg, char *uspace_name,
 	thread_t *thread = thread_create(uinit, kernel_uarg, TASK,
 	    THREAD_FLAG_USPACE | THREAD_FLAG_NOATTACH, namebuf);
 	if (thread) {
-		if (uspace_thread_id != NULL) {
+		if (uspace_thread_id) {
 			rc = copy_to_uspace(uspace_thread_id, &thread->tid,
 			    sizeof(thread->tid));
 			if (rc != EOK) {
@@ -1087,7 +1087,7 @@ sys_errno_t sys_thread_exit(int uspace_status)
  * @return 0 on success or an error code from @ref errno.h.
  *
  */
-sys_errno_t sys_thread_get_id(thread_id_t *uspace_thread_id)
+sys_errno_t sys_thread_get_id(uspace_ptr(thread_id_t) uspace_thread_id)
 {
 	/*
 	 * No need to acquire lock on THREAD because tid

--- a/kernel/generic/src/security/perm.c
+++ b/kernel/generic/src/security/perm.c
@@ -157,7 +157,7 @@ static errno_t perm_revoke(task_id_t taskid, perm_t perms)
  * @return Zero on success or an error code from @ref errno.h.
  *
  */
-sys_errno_t sys_perm_grant(uspace_ptr(sysarg64_t) uspace_taskid, perm_t perms)
+sys_errno_t sys_perm_grant(uspace_ptr_sysarg64_t uspace_taskid, perm_t perms)
 {
 	sysarg64_t taskid;
 	errno_t rc = copy_from_uspace(&taskid, uspace_taskid, sizeof(sysarg64_t));
@@ -178,7 +178,7 @@ sys_errno_t sys_perm_grant(uspace_ptr(sysarg64_t) uspace_taskid, perm_t perms)
  * @return Zero on success or an error code from @ref errno.h.
  *
  */
-sys_errno_t sys_perm_revoke(uspace_ptr(sysarg64_t) uspace_taskid, perm_t perms)
+sys_errno_t sys_perm_revoke(uspace_ptr_sysarg64_t uspace_taskid, perm_t perms)
 {
 	sysarg64_t taskid;
 	errno_t rc = copy_from_uspace(&taskid, uspace_taskid, sizeof(sysarg64_t));

--- a/kernel/generic/src/security/perm.c
+++ b/kernel/generic/src/security/perm.c
@@ -157,7 +157,7 @@ static errno_t perm_revoke(task_id_t taskid, perm_t perms)
  * @return Zero on success or an error code from @ref errno.h.
  *
  */
-sys_errno_t sys_perm_grant(sysarg64_t *uspace_taskid, perm_t perms)
+sys_errno_t sys_perm_grant(uspace_ptr(sysarg64_t) uspace_taskid, perm_t perms)
 {
 	sysarg64_t taskid;
 	errno_t rc = copy_from_uspace(&taskid, uspace_taskid, sizeof(sysarg64_t));
@@ -178,7 +178,7 @@ sys_errno_t sys_perm_grant(sysarg64_t *uspace_taskid, perm_t perms)
  * @return Zero on success or an error code from @ref errno.h.
  *
  */
-sys_errno_t sys_perm_revoke(sysarg64_t *uspace_taskid, perm_t perms)
+sys_errno_t sys_perm_revoke(uspace_ptr(sysarg64_t) uspace_taskid, perm_t perms)
 {
 	sysarg64_t taskid;
 	errno_t rc = copy_from_uspace(&taskid, uspace_taskid, sizeof(sysarg64_t));

--- a/kernel/generic/src/synch/syswaitq.c
+++ b/kernel/generic/src/synch/syswaitq.c
@@ -87,7 +87,7 @@ void sys_waitq_task_cleanup(void)
  *
  * @return              Error code.
  */
-sys_errno_t sys_waitq_create(cap_waitq_handle_t *whandle)
+sys_errno_t sys_waitq_create(uspace_ptr(cap_waitq_handle_t) whandle)
 {
 	waitq_t *wq = slab_alloc(waitq_cache, FRAME_ATOMIC);
 	if (!wq)

--- a/kernel/generic/src/synch/syswaitq.c
+++ b/kernel/generic/src/synch/syswaitq.c
@@ -87,7 +87,7 @@ void sys_waitq_task_cleanup(void)
  *
  * @return              Error code.
  */
-sys_errno_t sys_waitq_create(uspace_ptr(cap_waitq_handle_t) whandle)
+sys_errno_t sys_waitq_create(uspace_ptr_cap_waitq_handle_t whandle)
 {
 	waitq_t *wq = slab_alloc(waitq_cache, FRAME_ATOMIC);
 	if (!wq)

--- a/kernel/generic/src/syscall/copy.c
+++ b/kernel/generic/src/syscall/copy.c
@@ -58,7 +58,7 @@
  *
  * @return EOK on success or an error code from @ref errno.h.
  */
-errno_t copy_from_uspace(void *dst, const void *uspace_src, size_t size)
+errno_t copy_from_uspace(void *dst, uspace_addr_t uspace_src, size_t size)
 {
 	ipl_t ipl;
 	errno_t rc;
@@ -67,7 +67,7 @@ errno_t copy_from_uspace(void *dst, const void *uspace_src, size_t size)
 	assert(!THREAD->in_copy_from_uspace);
 
 	if (!KERNEL_ADDRESS_SPACE_SHADOWED) {
-		if (overlaps((uintptr_t) uspace_src, size,
+		if (overlaps(uspace_src, size,
 		    KERNEL_ADDRESS_SPACE_START,
 		    KERNEL_ADDRESS_SPACE_END - KERNEL_ADDRESS_SPACE_START)) {
 			/*
@@ -81,7 +81,7 @@ errno_t copy_from_uspace(void *dst, const void *uspace_src, size_t size)
 	/*
 	 * Check whether the address is outside the address space hole.
 	 */
-	if (overlaps((uintptr_t) uspace_src, size, ADDRESS_SPACE_HOLE_START,
+	if (overlaps(uspace_src, size, ADDRESS_SPACE_HOLE_START,
 	    ADDRESS_SPACE_HOLE_END - ADDRESS_SPACE_HOLE_START))
 		return EPERM;
 #endif
@@ -109,7 +109,7 @@ errno_t copy_from_uspace(void *dst, const void *uspace_src, size_t size)
  *
  * @return 0 on success or an error code from @ref errno.h.
  */
-errno_t copy_to_uspace(void *uspace_dst, const void *src, size_t size)
+errno_t copy_to_uspace(uspace_addr_t uspace_dst, const void *src, size_t size)
 {
 	ipl_t ipl;
 	errno_t rc;
@@ -118,7 +118,7 @@ errno_t copy_to_uspace(void *uspace_dst, const void *src, size_t size)
 	assert(!THREAD->in_copy_to_uspace);
 
 	if (!KERNEL_ADDRESS_SPACE_SHADOWED) {
-		if (overlaps((uintptr_t) uspace_dst, size,
+		if (overlaps(uspace_dst, size,
 		    KERNEL_ADDRESS_SPACE_START,
 		    KERNEL_ADDRESS_SPACE_END - KERNEL_ADDRESS_SPACE_START)) {
 			/*
@@ -132,7 +132,7 @@ errno_t copy_to_uspace(void *uspace_dst, const void *src, size_t size)
 	/*
 	 * Check whether the address is outside the address space hole.
 	 */
-	if (overlaps((uintptr_t) uspace_dst, size, ADDRESS_SPACE_HOLE_START,
+	if (overlaps(uspace_dst, size, ADDRESS_SPACE_HOLE_START,
 	    ADDRESS_SPACE_HOLE_END - ADDRESS_SPACE_HOLE_START))
 		return EPERM;
 #endif

--- a/kernel/generic/src/sysinfo/sysinfo.c
+++ b/kernel/generic/src/sysinfo/sysinfo.c
@@ -676,7 +676,7 @@ _NO_TRACE static sysinfo_return_t sysinfo_get_item(const char *name,
  *                binary data, just calculate the size.
  *
  */
-_NO_TRACE static sysinfo_return_t sysinfo_get_item_uspace(uspace_ptr(void) ptr, size_t size,
+_NO_TRACE static sysinfo_return_t sysinfo_get_item_uspace(uspace_addr_t ptr, size_t size,
     bool dry_run)
 {
 	sysinfo_return_t ret;
@@ -785,7 +785,7 @@ _NO_TRACE static sysinfo_return_t sysinfo_get_keys(const char *name,
  *                binary data, just calculate the size.
  *
  */
-_NO_TRACE static sysinfo_return_t sysinfo_get_keys_uspace(uspace_ptr(void) ptr, size_t size,
+_NO_TRACE static sysinfo_return_t sysinfo_get_keys_uspace(uspace_addr_t ptr, size_t size,
     bool dry_run)
 {
 	sysinfo_return_t ret;
@@ -830,8 +830,8 @@ _NO_TRACE static sysinfo_return_t sysinfo_get_keys_uspace(uspace_ptr(void) ptr, 
  * @return Error code (EOK in case of no error).
  *
  */
-sys_errno_t sys_sysinfo_get_keys_size(uspace_ptr(void) path_ptr, size_t path_size,
-    uspace_ptr(void) size_ptr)
+sys_errno_t sys_sysinfo_get_keys_size(uspace_addr_t path_ptr, size_t path_size,
+    uspace_addr_t size_ptr)
 {
 	errno_t rc;
 
@@ -878,8 +878,8 @@ sys_errno_t sys_sysinfo_get_keys_size(uspace_ptr(void) path_ptr, size_t path_siz
  * @return Error code (EOK in case of no error).
  *
  */
-sys_errno_t sys_sysinfo_get_keys(uspace_ptr(void) path_ptr, size_t path_size,
-    uspace_ptr(void) buffer_ptr, size_t buffer_size, uspace_ptr(size_t) size_ptr)
+sys_errno_t sys_sysinfo_get_keys(uspace_addr_t path_ptr, size_t path_size,
+    uspace_addr_t buffer_ptr, size_t buffer_size, uspace_ptr(size_t) size_ptr)
 {
 	errno_t rc;
 
@@ -913,7 +913,7 @@ sys_errno_t sys_sysinfo_get_keys(uspace_ptr(void) path_ptr, size_t path_size,
  * @return Item value type.
  *
  */
-sysarg_t sys_sysinfo_get_val_type(uspace_ptr(void) path_ptr, size_t path_size)
+sysarg_t sys_sysinfo_get_val_type(uspace_addr_t path_ptr, size_t path_size)
 {
 	/*
 	 * Get the item.
@@ -949,8 +949,8 @@ sysarg_t sys_sysinfo_get_val_type(uspace_ptr(void) path_ptr, size_t path_size)
  * @return Error code (EOK in case of no error).
  *
  */
-sys_errno_t sys_sysinfo_get_value(uspace_ptr(void) path_ptr, size_t path_size,
-    uspace_ptr(void) value_ptr)
+sys_errno_t sys_sysinfo_get_value(uspace_addr_t path_ptr, size_t path_size,
+    uspace_addr_t value_ptr)
 {
 	errno_t rc;
 
@@ -985,8 +985,8 @@ sys_errno_t sys_sysinfo_get_value(uspace_ptr(void) path_ptr, size_t path_size,
  * @return Error code (EOK in case of no error).
  *
  */
-sys_errno_t sys_sysinfo_get_data_size(uspace_ptr(void) path_ptr, size_t path_size,
-    uspace_ptr(void) size_ptr)
+sys_errno_t sys_sysinfo_get_data_size(uspace_addr_t path_ptr, size_t path_size,
+    uspace_addr_t size_ptr)
 {
 	errno_t rc;
 
@@ -1035,8 +1035,8 @@ sys_errno_t sys_sysinfo_get_data_size(uspace_ptr(void) path_ptr, size_t path_siz
  * @return Error code (EOK in case of no error).
  *
  */
-sys_errno_t sys_sysinfo_get_data(uspace_ptr(void) path_ptr, size_t path_size,
-    uspace_ptr(void) buffer_ptr, size_t buffer_size, uspace_ptr(size_t) size_ptr)
+sys_errno_t sys_sysinfo_get_data(uspace_addr_t path_ptr, size_t path_size,
+    uspace_addr_t buffer_ptr, size_t buffer_size, uspace_ptr(size_t) size_ptr)
 {
 	errno_t rc;
 

--- a/kernel/generic/src/sysinfo/sysinfo.c
+++ b/kernel/generic/src/sysinfo/sysinfo.c
@@ -676,7 +676,7 @@ _NO_TRACE static sysinfo_return_t sysinfo_get_item(const char *name,
  *                binary data, just calculate the size.
  *
  */
-_NO_TRACE static sysinfo_return_t sysinfo_get_item_uspace(void *ptr, size_t size,
+_NO_TRACE static sysinfo_return_t sysinfo_get_item_uspace(uspace_ptr(void) ptr, size_t size,
     bool dry_run)
 {
 	sysinfo_return_t ret;
@@ -785,7 +785,7 @@ _NO_TRACE static sysinfo_return_t sysinfo_get_keys(const char *name,
  *                binary data, just calculate the size.
  *
  */
-_NO_TRACE static sysinfo_return_t sysinfo_get_keys_uspace(void *ptr, size_t size,
+_NO_TRACE static sysinfo_return_t sysinfo_get_keys_uspace(uspace_ptr(void) ptr, size_t size,
     bool dry_run)
 {
 	sysinfo_return_t ret;
@@ -830,8 +830,8 @@ _NO_TRACE static sysinfo_return_t sysinfo_get_keys_uspace(void *ptr, size_t size
  * @return Error code (EOK in case of no error).
  *
  */
-sys_errno_t sys_sysinfo_get_keys_size(void *path_ptr, size_t path_size,
-    void *size_ptr)
+sys_errno_t sys_sysinfo_get_keys_size(uspace_ptr(void) path_ptr, size_t path_size,
+    uspace_ptr(void) size_ptr)
 {
 	errno_t rc;
 
@@ -878,8 +878,8 @@ sys_errno_t sys_sysinfo_get_keys_size(void *path_ptr, size_t path_size,
  * @return Error code (EOK in case of no error).
  *
  */
-sys_errno_t sys_sysinfo_get_keys(void *path_ptr, size_t path_size,
-    void *buffer_ptr, size_t buffer_size, size_t *size_ptr)
+sys_errno_t sys_sysinfo_get_keys(uspace_ptr(void) path_ptr, size_t path_size,
+    uspace_ptr(void) buffer_ptr, size_t buffer_size, uspace_ptr(size_t) size_ptr)
 {
 	errno_t rc;
 
@@ -913,7 +913,7 @@ sys_errno_t sys_sysinfo_get_keys(void *path_ptr, size_t path_size,
  * @return Item value type.
  *
  */
-sysarg_t sys_sysinfo_get_val_type(void *path_ptr, size_t path_size)
+sysarg_t sys_sysinfo_get_val_type(uspace_ptr(void) path_ptr, size_t path_size)
 {
 	/*
 	 * Get the item.
@@ -949,8 +949,8 @@ sysarg_t sys_sysinfo_get_val_type(void *path_ptr, size_t path_size)
  * @return Error code (EOK in case of no error).
  *
  */
-sys_errno_t sys_sysinfo_get_value(void *path_ptr, size_t path_size,
-    void *value_ptr)
+sys_errno_t sys_sysinfo_get_value(uspace_ptr(void) path_ptr, size_t path_size,
+    uspace_ptr(void) value_ptr)
 {
 	errno_t rc;
 
@@ -985,8 +985,8 @@ sys_errno_t sys_sysinfo_get_value(void *path_ptr, size_t path_size,
  * @return Error code (EOK in case of no error).
  *
  */
-sys_errno_t sys_sysinfo_get_data_size(void *path_ptr, size_t path_size,
-    void *size_ptr)
+sys_errno_t sys_sysinfo_get_data_size(uspace_ptr(void) path_ptr, size_t path_size,
+    uspace_ptr(void) size_ptr)
 {
 	errno_t rc;
 
@@ -1035,8 +1035,8 @@ sys_errno_t sys_sysinfo_get_data_size(void *path_ptr, size_t path_size,
  * @return Error code (EOK in case of no error).
  *
  */
-sys_errno_t sys_sysinfo_get_data(void *path_ptr, size_t path_size,
-    void *buffer_ptr, size_t buffer_size, size_t *size_ptr)
+sys_errno_t sys_sysinfo_get_data(uspace_ptr(void) path_ptr, size_t path_size,
+    uspace_ptr(void) buffer_ptr, size_t buffer_size, uspace_ptr(size_t) size_ptr)
 {
 	errno_t rc;
 

--- a/kernel/generic/src/sysinfo/sysinfo.c
+++ b/kernel/generic/src/sysinfo/sysinfo.c
@@ -879,7 +879,7 @@ sys_errno_t sys_sysinfo_get_keys_size(uspace_addr_t path_ptr, size_t path_size,
  *
  */
 sys_errno_t sys_sysinfo_get_keys(uspace_addr_t path_ptr, size_t path_size,
-    uspace_addr_t buffer_ptr, size_t buffer_size, uspace_ptr(size_t) size_ptr)
+    uspace_addr_t buffer_ptr, size_t buffer_size, uspace_ptr_size_t size_ptr)
 {
 	errno_t rc;
 
@@ -1036,7 +1036,7 @@ sys_errno_t sys_sysinfo_get_data_size(uspace_addr_t path_ptr, size_t path_size,
  *
  */
 sys_errno_t sys_sysinfo_get_data(uspace_addr_t path_ptr, size_t path_size,
-    uspace_addr_t buffer_ptr, size_t buffer_size, uspace_ptr(size_t) size_ptr)
+    uspace_addr_t buffer_ptr, size_t buffer_size, uspace_ptr_size_t size_ptr)
 {
 	errno_t rc;
 

--- a/kernel/generic/src/udebug/udebug_ipc.c
+++ b/kernel/generic/src/udebug/udebug_ipc.c
@@ -397,8 +397,8 @@ static void udebug_receive_regs_read(call_t *call)
  */
 static void udebug_receive_mem_read(call_t *call)
 {
-	uspace_ptr(void) uspace_dst;
-	uspace_ptr(void) uspace_src;
+	uspace_addr_t uspace_dst;
+	uspace_addr_t uspace_src;
 	unsigned size;
 	void *buffer = NULL;
 	errno_t rc;

--- a/kernel/generic/src/udebug/udebug_ipc.c
+++ b/kernel/generic/src/udebug/udebug_ipc.c
@@ -397,8 +397,8 @@ static void udebug_receive_regs_read(call_t *call)
  */
 static void udebug_receive_mem_read(call_t *call)
 {
-	sysarg_t uspace_dst;
-	sysarg_t uspace_src;
+	uspace_ptr(void) uspace_dst;
+	uspace_ptr(void) uspace_src;
 	unsigned size;
 	void *buffer = NULL;
 	errno_t rc;

--- a/kernel/generic/src/udebug/udebug_ops.c
+++ b/kernel/generic/src/udebug/udebug_ops.c
@@ -547,7 +547,7 @@ errno_t udebug_regs_read(thread_t *thread, void **buffer)
  * @param buffer      For storing a pointer to the allocated buffer.
  *
  */
-errno_t udebug_mem_read(sysarg_t uspace_addr, size_t n, void **buffer)
+errno_t udebug_mem_read(uspace_addr_t uspace_addr, size_t n, void **buffer)
 {
 	/* Verify task state */
 	mutex_lock(&TASK->udebug.lock);
@@ -568,7 +568,7 @@ errno_t udebug_mem_read(sysarg_t uspace_addr, size_t n, void **buffer)
 	 * be a problem
 	 *
 	 */
-	errno_t rc = copy_from_uspace(data_buffer, (void *) uspace_addr, n);
+	errno_t rc = copy_from_uspace(data_buffer, uspace_addr, n);
 	mutex_unlock(&TASK->udebug.lock);
 
 	if (rc != EOK)


### PR DESCRIPTION
Unresolved issue: `ccheck` does not allow the `uspace_ptr(type)` construct.

Commit message:
> From kernel's perspective, userspace addresses are not valid pointers,
and can only be used in calls to `copy_to/from_uspace()`.
Therefore, we change the type of those arguments and variables to
`uspace_addr_t` which is an alias for `sysarg_t`.
>
>This allows the compiler to catch accidental direct accesses to
userspace addresses.
>
>Additionally, to avoid losing the type information in code,
a macro `uspace_ptr(type)` is used that translates to `uspace_addr_t`.
It makes no functional difference, but allows keeping the type information
in code in case we implement some sort of static checking for it in the future.