### PR TITLE
Add cppcheck extra target to allow static analysis.

### DIFF
--- a/meson/part/extra_targets/meson.build
+++ b/meson/part/extra_targets/meson.build
@@ -81,6 +81,12 @@ if doxygen.found()
 	])
 endif
 
+if cppcheck.found()
+	run_target('cppcheck', command: ['cppcheck', '--project=' +
+		join_paths(meson.build_root(), 'compile_commands.json'),
+		' -q --force --file-list=*.c* --platform=unix32 --enable=all' ])
+endif
+
 # TODO text-xcw
 #ifeq ($(CONFIG_DEVEL_FILES),y)
 #	export PATH=$$PATH:$(abspath tools/xcw/bin) && $(MAKE) -r -C tools/xcw/demo

--- a/meson/part/tools/meson.build
+++ b/meson/part/tools/meson.build
@@ -53,6 +53,7 @@ sed = find_program('sed')
 unzip = find_program('unzip')
 which = find_program('which')
 cpc = find_program(_tools_dir / 'cc.sh')
+cppcheck = find_program('cppcheck', required: false)
 
 sh = [ find_program('sh'), '-u', '-e' ]
 if debug_shell_scripts


### PR DESCRIPTION
Cppcheck is a static analysis tool for C/C++ code. It provides unique code analysis to detect bugs and focuses on detecting undefined behaviour and dangerous coding constructs. The goal is to detect only real errors in the code (i.e. have very few false positives). 
The original name of this program was "C++check", but it was later changed to "Cppcheck".
Despite the name, Cppcheck is designed for both C and C++.

To run target just type:
ninja cppcheck > /dev/null
Note: There is a problem with memory.cpp so cppcheck analysis ends about 30% completed.

[helenos_cppcheck_without_memory.cpp.txt](https://github.com/HelenOS/helenos/files/4312297/helenos_cppcheck_without_memory.cpp.txt)


