### PR TITLE
Avoid array 'tmap->tasks[32]' accessed at index 32, which is out of bounds.

### DIFF
--- a/boot/generic/src/payload.c
+++ b/boot/generic/src/payload.c
@@ -242,7 +242,7 @@ void extract_payload(taskmap_t *tmap, uint8_t *kernel_dest, uint8_t *mem_end,
 
 	tmap->cnt = 0;
 
-	for (int i = 0; i <= TASKMAP_MAX_RECORDS; i++) {
+	for (int i = 0; i < TASKMAP_MAX_RECORDS; i++) {
 		/*
 		 * `task` holds the location and size of the previous component.
 		 */


### PR DESCRIPTION
Found by cppcheck tool