### PR TITLE
Enable window double buffering by default

### DIFF
--- a/HelenOS.config
+++ b/HelenOS.config
@@ -611,7 +611,7 @@
 ! [CONFIG_FB=y] CONFIG_DISP_DOUBLE_BUF (y/n)
 
 % Window double buffering
-! [CONFIG_FB=y] CONFIG_WIN_DOUBLE_BUF (n/y)
+! [CONFIG_FB=y] CONFIG_WIN_DOUBLE_BUF (y/n)
 
 % Start AP processors by the loader
 ! [PLATFORM=sparc64&CONFIG_SMP=y] CONFIG_AP (y/n)


### PR DESCRIPTION
At this moment, this setting results in better user
experience on all platforms.