### PR TITLE
Install meson==0.50.1 to compile correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The safest bet is installing both using `pip3` tool.
 
 ```sh
 $ pip3 install ninja
-$ pip3 install meson
+$ pip3 install meson==0.50.1
 ```
 
 Meson does not support in-tree builds, so you have to create a directory


### PR DESCRIPTION
Running `pip3 install meson` as part of the build instructions installs version `0.57.1` (as of this commit) which causes numerous warnings when running `ninja` causing the build to fail.

Reinstalling a previous version of `meson` (0.50.1 which is also used in the `.travis.yml` build script) fixes the build and rerunning `configure.sh` and `ninja` completes the build successfully