### PR TITLE
Graphics improvements for the Raspberry PI

### DIFF
--- a/kernel/arch/arm32/src/mach/raspberrypi/raspberrypi.c
+++ b/kernel/arch/arm32/src/mach/raspberrypi/raspberrypi.c
@@ -173,8 +173,15 @@ static void raspberrypi_frame_init(void)
 static void raspberrypi_output_init(void)
 {
 #ifdef CONFIG_FB
+	uint32_t width, height;
 	fb_properties_t prop;
-	if (bcm2835_fb_init(&prop)) {
+
+	if (!bcm2835_mbox_get_fb_size(&width, &height)) {
+		printf("mbox: could not get the framebuffer size\n");
+		width = 640;
+		height = 480;
+	}
+	if (bcm2835_fb_init(&prop, width, height)) {
 		outdev_t *fb_dev = fb_init(&prop);
 		if (fb_dev)
 			stdout_wire(fb_dev);

--- a/kernel/genarch/include/genarch/drivers/bcm2835/mbox.h
+++ b/kernel/genarch/include/genarch/drivers/bcm2835/mbox.h
@@ -67,6 +67,13 @@ enum {
 };
 
 enum {
+	MBOX_TAG_GET_PHYS_W_H	= 0x00040003,
+	MBOX_TAG_SET_PHYS_W_H	= 0x00048003,
+	MBOX_TAG_GET_VIRT_W_H	= 0x00040004,
+	MBOX_TAG_SET_VIRT_W_G	= 0x00048004
+};
+
+enum {
 	MBOX_PROP_CODE_REQ	= 0x00000000,
 	MBOX_PROP_CODE_RESP_OK	= 0x80000000,
 	MBOX_PROP_CODE_RESP_ERR	= 0x80000001
@@ -121,6 +128,16 @@ typedef struct {
 } mbox_getmem_buf_t;
 
 typedef struct {
+	mbox_prop_buf_hdr_t	buf_hdr;
+	mbox_tag_hdr_t		tag_hdr;
+	struct {
+		uint32_t	width;
+		uint32_t	height;
+	} body;
+	uint32_t zero;
+} mbox_getfbsize_buf_t;
+
+typedef struct {
 	ioport32_t width;
 	ioport32_t height;
 	ioport32_t virt_width;
@@ -134,7 +151,8 @@ typedef struct {
 } bcm2835_fb_desc_t;
 
 extern bool bcm2835_prop_get_memory(uint32_t *base, uint32_t *size);
-extern bool bcm2835_fb_init(fb_properties_t *prop);
+extern bool bcm2835_fb_init(fb_properties_t *prop, uint32_t width, uint32_t heigth);
+extern bool bcm2835_mbox_get_fb_size(uint32_t *h, uint32_t *w);
 
 #endif
 

--- a/kernel/genarch/src/drivers/bcm2835/mbox.c
+++ b/kernel/genarch/src/drivers/bcm2835/mbox.c
@@ -85,7 +85,7 @@ bool bcm2835_prop_get_memory(uint32_t *base, uint32_t *size)
 	return ret;
 }
 
-bool bcm2835_fb_init(fb_properties_t *prop)
+bool bcm2835_fb_init(fb_properties_t *prop, uint32_t width, uint32_t height)
 {
 	bcm2835_mbox_t *fb_mbox;
 	bool ret = false;
@@ -94,8 +94,8 @@ bool bcm2835_fb_init(fb_properties_t *prop)
 	fb_mbox = (void *) km_map(BCM2835_MBOX0_ADDR, sizeof(bcm2835_mbox_t),
 	    KM_NATURAL_ALIGNMENT, PAGE_NOT_CACHEABLE);
 
-	fb_desc->width = 640;
-	fb_desc->height = 480;
+	fb_desc->width = width;
+	fb_desc->height = height;
 	fb_desc->virt_width = fb_desc->width;
 	fb_desc->virt_height = fb_desc->height;
 	fb_desc->pitch = 0;			/* Set by VC */
@@ -125,6 +125,32 @@ bool bcm2835_fb_init(fb_properties_t *prop)
 out:
 	km_unmap((uintptr_t)fb_mbox, sizeof(bcm2835_mbox_t));
 	return ret;
+}
+
+bool bcm2835_mbox_get_fb_size(uint32_t *w, uint32_t *h)
+{
+	bool r;
+	MBOX_BUFF_ALLOC(msg, mbox_getfbsize_buf_t);
+
+	msg->buf_hdr.size = sizeof(mbox_getfbsize_buf_t);
+	msg->buf_hdr.code = MBOX_PROP_CODE_REQ;
+	msg->tag_hdr.tag_id = MBOX_TAG_GET_PHYS_W_H;
+	msg->tag_hdr.buf_size = sizeof(msg->body);
+	msg->tag_hdr.val_len  = 0;
+	msg->zero = 0;
+
+	mbox_write((bcm2835_mbox_t *)BCM2835_MBOX0_ADDR,
+	    MBOX_CHAN_PROP_A2V, KA2VCA((uint32_t)msg));
+	mbox_read((bcm2835_mbox_t *)BCM2835_MBOX0_ADDR,
+	    MBOX_CHAN_PROP_A2V);
+
+	r = msg->buf_hdr.code == MBOX_PROP_CODE_RESP_OK;
+	if (r) {
+		*h = msg->body.height;
+		*w = msg->body.width;
+	}
+
+	return r;
 }
 
 /**

--- a/kernel/genarch/src/drivers/bcm2835/mbox.c
+++ b/kernel/genarch/src/drivers/bcm2835/mbox.c
@@ -131,6 +131,11 @@ bool bcm2835_mbox_get_fb_size(uint32_t *w, uint32_t *h)
 {
 	bool r;
 	MBOX_BUFF_ALLOC(msg, mbox_getfbsize_buf_t);
+	bcm2835_mbox_t *mbox;
+
+	mbox = (void *) km_map(BCM2835_MBOX0_ADDR, sizeof(bcm2835_mbox_t),
+	    KM_NATURAL_ALIGNMENT, PAGE_NOT_CACHEABLE);
+	assert(mbox);
 
 	msg->buf_hdr.size = sizeof(mbox_getfbsize_buf_t);
 	msg->buf_hdr.code = MBOX_PROP_CODE_REQ;
@@ -139,10 +144,9 @@ bool bcm2835_mbox_get_fb_size(uint32_t *w, uint32_t *h)
 	msg->tag_hdr.val_len  = 0;
 	msg->zero = 0;
 
-	mbox_write((bcm2835_mbox_t *)BCM2835_MBOX0_ADDR,
+	mbox_write(mbox,
 	    MBOX_CHAN_PROP_A2V, KA2VCA((uint32_t)msg));
-	mbox_read((bcm2835_mbox_t *)BCM2835_MBOX0_ADDR,
-	    MBOX_CHAN_PROP_A2V);
+	mbox_read(mbox, MBOX_CHAN_PROP_A2V);
 
 	r = msg->buf_hdr.code == MBOX_PROP_CODE_RESP_OK;
 	if (r) {
@@ -150,6 +154,7 @@ bool bcm2835_mbox_get_fb_size(uint32_t *w, uint32_t *h)
 		*w = msg->body.width;
 	}
 
+	km_unmap((uintptr_t) mbox, sizeof(bcm2835_mbox_t));
 	return r;
 }
 


### PR DESCRIPTION
Currently, the SPARTAN kernel assumes a display size of 640x480

With this patchset, it will read the correct size from VideoCore,
looks much better on large screens.

http://bsdbackstore.it/misc/IMG_3463.jpg