### PR TITLE
Configure NS16550 transmission format settings on initialization.

### DIFF
--- a/kernel/arch/amd64/src/amd64.c
+++ b/kernel/arch/amd64/src/amd64.c
@@ -223,6 +223,8 @@ void amd64_post_smp_init(void)
 	    ns16550_init(NS16550_BASE, 0, IRQ_NS16550, NULL, NULL,
 	    ns16550_out_ptr);
 	if (ns16550_instance) {
+		ns16550_format_set(ns16550_instance, 38400,
+		    LCR_PARITY_NONE | LCR_STOP_BIT_TWO | LCR_WORD_LEN_8);
 #ifdef CONFIG_NS16550
 		srln_instance_t *srln_instance = srln_init();
 		if (srln_instance) {

--- a/kernel/arch/ia32/src/ia32.c
+++ b/kernel/arch/ia32/src/ia32.c
@@ -208,6 +208,8 @@ void ia32_post_smp_init(void)
 	    ns16550_init(NS16550_BASE, 0, IRQ_NS16550, NULL, NULL,
 	    ns16550_out_ptr);
 	if (ns16550_instance) {
+		ns16550_format_set(ns16550_instance, 38400,
+		    LCR_PARITY_NONE | LCR_STOP_BIT_TWO | LCR_WORD_LEN_8);
 #ifdef CONFIG_NS16550
 		srln_instance_t *srln_instance = srln_init();
 		if (srln_instance) {

--- a/kernel/genarch/include/genarch/drivers/ns16550/ns16550.h
+++ b/kernel/genarch/include/genarch/drivers/ns16550/ns16550.h
@@ -42,17 +42,35 @@
 #include <typedefs.h>
 #include <console/chardev.h>
 
-#define IER_ERBFI  0x01  /** Enable Receive Buffer Full Interrupt. */
+#define NS156440_CLOCK    115200 /** Internal clock speed, max. baud rate. */
 
-#define LCR_DLAB   0x80  /** Divisor Latch Access bit. */
+#define IER_ERBFI         0x01   /** Enable Receive Buffer Full Interrupt. */
+#define MCR_OUT2          0x08   /** OUT2. */
 
-#define MCR_OUT2   0x08  /** OUT2. */
+#define LCR_DLAB          0x80   /** Divisor Latch Access bit. */
+#define LCR_SBE           0x40   /** RS-232 Break Signal bit. */
+
+#define LCR_PARITY_NONE   0x00   /** No parity bit. */
+#define LCR_PARITY_ODD    0x08   /** Odd parity. */
+#define LCR_PARITY_EVEN   0x18   /** Even parity. */
+#define LCR_PARITY_MARK   0x28   /** Parity bit always one. */
+#define LCR_PARITY_SPACE  0x38   /** Parity bit always zero. */
+
+#define LCR_STOP_BIT_ONE  0x00   /** One stop bit. */
+#define LCR_STOP_BIT_TWO  0x04   /** Two stop bits. */
+
+#define LCR_WORD_LEN_5    0x00   /** 5-bit word length. */
+#define LCR_WORD_LEN_6    0x01   /** 6-bit word length. */
+#define LCR_WORD_LEN_7    0x02   /** 7-bit word length. */
+#define LCR_WORD_LEN_8    0x03   /** 8-bit word length. */
 
 /** NS16550 registers. */
 typedef enum {
 	NS16550_REG_RBR = 0,  /**< Receiver Buffer Register (read). */
 	NS16550_REG_THR = 0,  /**< Transmitter Holder Register (write). */
+	NS16550_REG_DLL = 0,  /**< Baud rate divisor latch low byte (write). */
 	NS16550_REG_IER = 1,  /**< Interrupt Enable Register. */
+	NS16550_REG_DLH = 1,  /**< Baud rate divisor latch high byte (write). */
 	NS16550_REG_IIR = 2,  /**< Interrupt Ident Register (read). */
 	NS16550_REG_FCR = 2,  /**< FIFO control register (write). */
 	NS16550_REG_LCR = 3,  /**< Line Control register. */
@@ -72,6 +90,7 @@ typedef struct {
 
 extern ns16550_instance_t *ns16550_init(ioport8_t *, unsigned, inr_t, cir_t,
     void *, outdev_t **);
+extern void ns16550_format_set(ns16550_instance_t *, unsigned, uint8_t);
 extern void ns16550_wire(ns16550_instance_t *, indev_t *);
 
 #endif

--- a/kernel/genarch/src/drivers/ns16550/ns16550.c
+++ b/kernel/genarch/src/drivers/ns16550/ns16550.c
@@ -131,6 +131,30 @@ static outdev_operations_t ns16550_ops = {
 	.redraw = NULL
 };
 
+/** Configure ns16550 transmission format.
+ *
+ * @param instance   NS 16550 driver instance.
+ * @param baud_rate  Transmission speed in bits per second, also known as baud,
+ *                   maximum value is 115200.
+ * @param lcr_format Line Control Register configuration bits, as defined by
+ *                   the @c LCR_ macros.  These configure the word width,
+ *                   parity type, and stop bit count.
+ */
+void ns16550_format_set(ns16550_instance_t *instance,
+    unsigned baud_rate, uint8_t lcr_format)
+{
+	uint16_t divisor;
+
+	divisor = (uint16_t)(NS156440_CLOCK / baud_rate);
+	if (divisor == 0)
+		divisor = 1;  /* Avoid division by zero. */
+
+	ns16550_reg_write(instance, NS16550_REG_LCR, LCR_DLAB);
+	ns16550_reg_write(instance, NS16550_REG_DLL, divisor & 0xFF);
+	ns16550_reg_write(instance, NS16550_REG_DLH, (divisor >> 8) & 0xFF);
+	ns16550_reg_write(instance, NS16550_REG_LCR, lcr_format & ~LCR_DLAB);
+}
+
 /** Initialize ns16550.
  *
  * @param dev        Address of the beginning of the device in I/O space.


### PR DESCRIPTION
Currently, the NS116550 serial line controller is left with its settings as it was left by the boot firmware and/or bootloader.  On my computer, this was an invalid configuration, and it left me with a really slow booting system, since each output character had to go through the full timeout loop in ns16550_sendb().

This patch adds the necessary bit and register descriptions to configure the baud rate and transmission settings, as well as configuring them on initialization, currently with values matching the ns8250 userspace character device driver (38400 baud, 8-bit words, 2 stop bits, no parity).

This could perhaps be changed to be adjustable with a kernel command-line argument, or through the configuration system.

This change does not affect emulators, since those largely ignore these settings.