### PR TITLE
arm32: performance boost on raspberry pi

### DIFF
--- a/kernel/arch/arm32/include/arch/mm/page.h
+++ b/kernel/arch/arm32/include/arch/mm/page.h
@@ -158,6 +158,9 @@ _NO_TRACE static inline void set_ptl0_addr(pte_t *pt)
 	val |= TTBR_RGN_WBWA_CACHE | TTBR_C_FLAG;
 #endif
 	TTBR0_write(val);
+#if defined(PROCESSOR_ARCH_armv6) || defined(PROCESSOR_ARCH_armv7_a)
+	BPIALL_write(0);
+#endif
 }
 
 _NO_TRACE static inline void set_ptl1_addr(pte_t *pt, size_t i, uintptr_t address)

--- a/kernel/arch/arm32/src/cpu/cpu.c
+++ b/kernel/arch/arm32/src/cpu/cpu.c
@@ -169,8 +169,6 @@ void cpu_arch_init(void)
 	 * this flag).
 	 */
 	control_reg |= SCTLR_CACHE_EN_FLAG;
-#endif
-#ifdef PROCESSOR_ARCH_armv7_a
 	/*
 	 * ICache coherency is elaborated on in barrier.h.
 	 * VIPT and PIPT caches need maintenance only on code modify,


### PR DESCRIPTION
* enable the icache and branch prediction for ARMv6
* flush the branch predictor after writing to the TTBR0 register

Before: https://www.youtube.com/watch?v=OiGDSs6Yb6A

After: https://www.youtube.com/watch?v=JThq4GNtN2E