### PR TITLE
Simplify timeout implementation in kernel

### DIFF
--- a/kernel/generic/include/cpu.h
+++ b/kernel/generic/include/cpu.h
@@ -73,6 +73,7 @@ typedef struct cpu {
 	 */
 	size_t missed_clock_ticks;
 
+	/** Can only be accessed when interrupts are disabled. */
 	uint64_t current_clock_tick;
 
 	/**

--- a/kernel/generic/include/cpu.h
+++ b/kernel/generic/include/cpu.h
@@ -73,6 +73,8 @@ typedef struct cpu {
 	 */
 	size_t missed_clock_ticks;
 
+	uint64_t current_clock_tick;
+
 	/**
 	 * Processor cycle accounting.
 	 */

--- a/kernel/generic/include/time/timeout.h
+++ b/kernel/generic/include/time/timeout.h
@@ -42,8 +42,6 @@
 typedef void (*timeout_handler_t)(void *arg);
 
 typedef struct {
-	IRQ_SPINLOCK_DECLARE(lock);
-
 	/** Link to the list of active timeouts on timeout->cpu */
 	link_t link;
 	/** Timeout will be activated when current clock tick reaches this value. */

--- a/kernel/generic/include/time/timeout.h
+++ b/kernel/generic/include/time/timeout.h
@@ -46,8 +46,8 @@ typedef struct {
 
 	/** Link to the list of active timeouts on CURRENT->cpu */
 	link_t link;
-	/** Timeout will be activated in this amount of clock() ticks. */
-	uint64_t ticks;
+	/** Timeout will be activated when current clock tick reaches this value. */
+	uint64_t deadline;
 	/** Function that will be called on timeout activation. */
 	timeout_handler_t handler;
 	/** Argument to be passed to handler() function. */

--- a/kernel/generic/include/time/timeout.h
+++ b/kernel/generic/include/time/timeout.h
@@ -44,7 +44,7 @@ typedef void (*timeout_handler_t)(void *arg);
 typedef struct {
 	IRQ_SPINLOCK_DECLARE(lock);
 
-	/** Link to the list of active timeouts on CURRENT->cpu */
+	/** Link to the list of active timeouts on timeout->cpu */
 	link_t link;
 	/** Timeout will be activated when current clock tick reaches this value. */
 	uint64_t deadline;
@@ -60,7 +60,6 @@ typedef struct {
 
 extern void timeout_init(void);
 extern void timeout_initialize(timeout_t *);
-extern void timeout_reinitialize(timeout_t *);
 extern void timeout_register(timeout_t *, uint64_t, timeout_handler_t, void *);
 extern bool timeout_unregister(timeout_t *);
 

--- a/kernel/generic/src/time/clock.c
+++ b/kernel/generic/src/time/clock.c
@@ -162,9 +162,7 @@ void clock(void)
 			timeout_t *timeout = list_get_instance(cur, timeout_t,
 			    link);
 
-			irq_spinlock_lock(&timeout->lock, false);
 			if (current_clock_tick <= timeout->deadline) {
-				irq_spinlock_unlock(&timeout->lock, false);
 				break;
 			}
 
@@ -172,7 +170,6 @@ void clock(void)
 			timeout_handler_t handler = timeout->handler;
 			void *arg = timeout->arg;
 
-			irq_spinlock_unlock(&timeout->lock, false);
 			irq_spinlock_unlock(&CPU->timeoutlock, false);
 
 			handler(arg);

--- a/kernel/generic/src/time/clock.c
+++ b/kernel/generic/src/time/clock.c
@@ -171,7 +171,6 @@ void clock(void)
 			list_remove(cur);
 			timeout_handler_t handler = timeout->handler;
 			void *arg = timeout->arg;
-			timeout_reinitialize(timeout);
 
 			irq_spinlock_unlock(&timeout->lock, false);
 			irq_spinlock_unlock(&CPU->timeoutlock, false);

--- a/kernel/generic/src/time/clock.c
+++ b/kernel/generic/src/time/clock.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2001-2004 Jakub Jermar
+ * Copyright (c) 2022 Jiří Zárevúcky
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/kernel/generic/src/time/clock.c
+++ b/kernel/generic/src/time/clock.c
@@ -163,7 +163,7 @@ void clock(void)
 			    link);
 
 			irq_spinlock_lock(&timeout->lock, false);
-			if (timeout->ticks-- != 0) {
+			if (current_clock_tick <= timeout->deadline) {
 				irq_spinlock_unlock(&timeout->lock, false);
 				break;
 			}

--- a/kernel/generic/src/time/timeout.c
+++ b/kernel/generic/src/time/timeout.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2001-2004 Jakub Jermar
+ * Copyright (c) 2022 Jiří Zárevúcky
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Replaces countdown with an immutable deadline, which allows us to remove `timeout->lock` and simplify the code quite a bit.