### PR TITLE
Deduplicate identical enums for window resizing

### DIFF
--- a/uspace/lib/display/include/types/display/wndresize.h
+++ b/uspace/lib/display/include/types/display/wndresize.h
@@ -37,6 +37,8 @@
 
 /** Window resize type */
 typedef enum {
+	display_wr_none = 0,
+
 	display_wr_top = 0x1,
 	display_wr_left = 0x2,
 	display_wr_bottom = 0x4,

--- a/uspace/lib/display/src/wndresize.c
+++ b/uspace/lib/display/src/wndresize.c
@@ -74,10 +74,6 @@ display_stock_cursor_t display_cursor_from_wrsz(display_wnd_rsztype_t rsztype)
  */
 bool display_wndrsz_valid(display_wnd_rsztype_t rsztype)
 {
-	bool valid;
-
-	valid = false;
-
 	switch (rsztype) {
 	case display_wr_top:
 	case display_wr_bottom:
@@ -87,11 +83,13 @@ bool display_wndrsz_valid(display_wnd_rsztype_t rsztype)
 	case display_wr_bottom_right:
 	case display_wr_top_right:
 	case display_wr_bottom_left:
-		valid = true;
-		break;
+		return true;
+
+	case display_wr_none:
+		return false;
 	}
 
-	return valid;
+	return false;
 }
 
 /** @}

--- a/uspace/lib/ui/include/types/ui/wdecor.h
+++ b/uspace/lib/ui/include/types/ui/wdecor.h
@@ -39,6 +39,7 @@
 #include <gfx/coord.h>
 #include <types/common.h>
 #include <types/ui/cursor.h>
+#include <types/display/wndresize.h>
 
 struct ui_wdecor;
 typedef struct ui_wdecor ui_wdecor_t;
@@ -66,21 +67,6 @@ typedef enum {
 	    ui_wds_minimize_btn | ui_wds_close_btn
 } ui_wdecor_style_t;
 
-/** Window resize type */
-typedef enum {
-	ui_wr_none = 0,
-
-	ui_wr_top = 0x1,
-	ui_wr_left = 0x2,
-	ui_wr_bottom = 0x4,
-	ui_wr_right = 0x8,
-
-	ui_wr_top_left = ui_wr_top | ui_wr_left,
-	ui_wr_bottom_left = ui_wr_bottom | ui_wr_left,
-	ui_wr_bottom_right = ui_wr_bottom | ui_wr_right,
-	ui_wr_top_right = ui_wr_top | ui_wr_right
-} ui_wdecor_rsztype_t;
-
 /** Window decoration callbacks */
 typedef struct ui_wdecor_cb {
 	void (*sysmenu_open)(ui_wdecor_t *, void *, sysarg_t);
@@ -92,7 +78,7 @@ typedef struct ui_wdecor_cb {
 	void (*unmaximize)(ui_wdecor_t *, void *);
 	void (*close)(ui_wdecor_t *, void *);
 	void (*move)(ui_wdecor_t *, void *, gfx_coord2_t *, sysarg_t);
-	void (*resize)(ui_wdecor_t *, void *, ui_wdecor_rsztype_t,
+	void (*resize)(ui_wdecor_t *, void *, display_wnd_rsztype_t,
 	    gfx_coord2_t *, sysarg_t);
 	void (*set_cursor)(ui_wdecor_t *, void *, ui_stock_cursor_t);
 } ui_wdecor_cb_t;

--- a/uspace/lib/ui/private/wdecor.h
+++ b/uspace/lib/ui/private/wdecor.h
@@ -107,7 +107,7 @@ extern void ui_wdecor_maximize(ui_wdecor_t *);
 extern void ui_wdecor_unmaximize(ui_wdecor_t *);
 extern void ui_wdecor_close(ui_wdecor_t *);
 extern void ui_wdecor_move(ui_wdecor_t *, gfx_coord2_t *, sysarg_t);
-extern void ui_wdecor_resize(ui_wdecor_t *, ui_wdecor_rsztype_t,
+extern void ui_wdecor_resize(ui_wdecor_t *, display_wnd_rsztype_t,
     gfx_coord2_t *, sysarg_t);
 extern void ui_wdecor_set_cursor(ui_wdecor_t *, ui_stock_cursor_t);
 extern void ui_wdecor_get_geom(ui_wdecor_t *, ui_wdecor_geom_t *);
@@ -115,9 +115,9 @@ extern errno_t ui_wdecor_sysmenu_hdl_paint_gfx(ui_wdecor_t *, gfx_rect_t *);
 extern errno_t ui_wdecor_sysmenu_hdl_paint_text(ui_wdecor_t *, gfx_rect_t *);
 extern errno_t ui_wdecor_sysmenu_hdl_paint(ui_wdecor_t *, gfx_rect_t *);
 extern void ui_wdecor_frame_pos_event(ui_wdecor_t *, pos_event_t *);
-extern ui_wdecor_rsztype_t ui_wdecor_get_rsztype(ui_wdecor_t *,
+extern display_wnd_rsztype_t ui_wdecor_get_rsztype(ui_wdecor_t *,
     gfx_coord2_t *);
-extern ui_stock_cursor_t ui_wdecor_cursor_from_rsztype(ui_wdecor_rsztype_t);
+extern ui_stock_cursor_t ui_wdecor_cursor_from_rsztype(display_wnd_rsztype_t);
 
 #endif
 

--- a/uspace/lib/ui/src/wdecor.c
+++ b/uspace/lib/ui/src/wdecor.c
@@ -649,7 +649,7 @@ void ui_wdecor_move(ui_wdecor_t *wdecor, gfx_coord2_t *pos, sysarg_t pos_id)
  * @param pos Position where the button was pressed
  * @param pos_id Positioning device ID
  */
-void ui_wdecor_resize(ui_wdecor_t *wdecor, ui_wdecor_rsztype_t rsztype,
+void ui_wdecor_resize(ui_wdecor_t *wdecor, display_wnd_rsztype_t rsztype,
     gfx_coord2_t *pos, sysarg_t pos_id)
 {
 	if (wdecor->cb != NULL && wdecor->cb->resize != NULL)
@@ -911,7 +911,7 @@ void ui_wdecor_app_from_rect(ui_wdecor_style_t style, gfx_rect_t *rect,
  * @param pos Pointer position
  * @return Resize type
  */
-ui_wdecor_rsztype_t ui_wdecor_get_rsztype(ui_wdecor_t *wdecor,
+display_wnd_rsztype_t ui_wdecor_get_rsztype(ui_wdecor_t *wdecor,
     gfx_coord2_t *pos)
 {
 	bool eleft, eright;
@@ -922,15 +922,15 @@ ui_wdecor_rsztype_t ui_wdecor_get_rsztype(ui_wdecor_t *wdecor,
 
 	/* Window not resizable? */
 	if ((wdecor->style & ui_wds_resizable) == 0)
-		return ui_wr_none;
+		return display_wr_none;
 
 	/* Window is maximized? */
 	if (wdecor->maximized)
-		return ui_wr_none;
+		return display_wr_none;
 
 	/* Position not inside window? */
 	if (!gfx_pix_inside_rect(pos, &wdecor->rect))
-		return ui_wr_none;
+		return display_wr_none;
 
 	/* Position is within edge width from the outside */
 	eleft = (pos->x < wdecor->rect.p0.x + wdecor_edge_w);
@@ -949,37 +949,37 @@ ui_wdecor_rsztype_t ui_wdecor_get_rsztype(ui_wdecor_t *wdecor,
 
 	/* Top-left corner */
 	if (edge && cleft && ctop)
-		return ui_wr_top_left;
+		return display_wr_top_left;
 
 	/* Top-right corner */
 	if (edge && cright && ctop)
-		return ui_wr_top_right;
+		return display_wr_top_right;
 
 	/* Bottom-left corner */
 	if (edge && cleft && cbottom)
-		return ui_wr_bottom_left;
+		return display_wr_bottom_left;
 
 	/* Bottom-right corner */
 	if (edge && cright && cbottom)
-		return ui_wr_bottom_right;
+		return display_wr_bottom_right;
 
 	/* Left edge */
 	if (eleft)
-		return ui_wr_left;
+		return display_wr_left;
 
 	/* Right edge */
 	if (eright)
-		return ui_wr_right;
+		return display_wr_right;
 
 	/* Top edge */
 	if (etop)
-		return ui_wr_top;
+		return display_wr_top;
 
 	/* Bottom edge */
 	if (ebottom)
-		return ui_wr_bottom;
+		return display_wr_bottom;
 
-	return ui_wr_none;
+	return display_wr_none;
 }
 
 /** Get stock cursor to use for the specified window resize type.
@@ -989,26 +989,26 @@ ui_wdecor_rsztype_t ui_wdecor_get_rsztype(ui_wdecor_t *wdecor,
  * @param rsztype Resize type
  * @return Cursor to use for this resize type
  */
-ui_stock_cursor_t ui_wdecor_cursor_from_rsztype(ui_wdecor_rsztype_t rsztype)
+ui_stock_cursor_t ui_wdecor_cursor_from_rsztype(display_wnd_rsztype_t rsztype)
 {
 	switch (rsztype) {
-	case ui_wr_none:
+	case display_wr_none:
 		return ui_curs_arrow;
 
-	case ui_wr_top:
-	case ui_wr_bottom:
+	case display_wr_top:
+	case display_wr_bottom:
 		return ui_curs_size_ud;
 
-	case ui_wr_left:
-	case ui_wr_right:
+	case display_wr_left:
+	case display_wr_right:
 		return ui_curs_size_lr;
 
-	case ui_wr_top_left:
-	case ui_wr_bottom_right:
+	case display_wr_top_left:
+	case display_wr_bottom_right:
 		return ui_curs_size_uldr;
 
-	case ui_wr_top_right:
-	case ui_wr_bottom_left:
+	case display_wr_top_right:
+	case display_wr_bottom_left:
 		return ui_curs_size_urdl;
 
 	default:
@@ -1073,7 +1073,7 @@ void ui_wdecor_frame_pos_event(ui_wdecor_t *wdecor, pos_event_t *event)
 {
 	gfx_coord2_t pos;
 	sysarg_t pos_id;
-	ui_wdecor_rsztype_t rsztype;
+	display_wnd_rsztype_t rsztype;
 	ui_stock_cursor_t cursor;
 
 	pos.x = event->hpos;
@@ -1088,7 +1088,7 @@ void ui_wdecor_frame_pos_event(ui_wdecor_t *wdecor, pos_event_t *event)
 	ui_wdecor_set_cursor(wdecor, cursor);
 
 	/* Press on window border? */
-	if (rsztype != ui_wr_none && event->type == POS_PRESS)
+	if (rsztype != display_wr_none && event->type == POS_PRESS)
 		ui_wdecor_resize(wdecor, rsztype, &pos, pos_id);
 }
 

--- a/uspace/lib/ui/src/window.c
+++ b/uspace/lib/ui/src/window.c
@@ -85,7 +85,7 @@ static void wd_maximize(ui_wdecor_t *, void *);
 static void wd_unmaximize(ui_wdecor_t *, void *);
 static void wd_close(ui_wdecor_t *, void *);
 static void wd_move(ui_wdecor_t *, void *, gfx_coord2_t *, sysarg_t);
-static void wd_resize(ui_wdecor_t *, void *, ui_wdecor_rsztype_t,
+static void wd_resize(ui_wdecor_t *, void *, display_wnd_rsztype_t,
     gfx_coord2_t *, sysarg_t);
 static void wd_set_cursor(ui_wdecor_t *, void *, ui_stock_cursor_t);
 
@@ -1190,13 +1190,12 @@ static void wd_move(ui_wdecor_t *wdecor, void *arg, gfx_coord2_t *pos,
  * @param pos_id Positioning device ID
  */
 static void wd_resize(ui_wdecor_t *wdecor, void *arg,
-    ui_wdecor_rsztype_t rsztype, gfx_coord2_t *pos, sysarg_t pos_id)
+    display_wnd_rsztype_t rsztype, gfx_coord2_t *pos, sysarg_t pos_id)
 {
 	ui_window_t *window = (ui_window_t *) arg;
 
 	if (window->dwindow != NULL) {
-		(void) display_window_resize_req(window->dwindow,
-		    (display_wnd_rsztype_t) rsztype, // Same constants in the enums
+		(void) display_window_resize_req(window->dwindow, rsztype,
 		    pos, pos_id);
 	}
 }

--- a/uspace/lib/ui/test/wdecor.c
+++ b/uspace/lib/ui/test/wdecor.c
@@ -71,7 +71,7 @@ static void test_wdecor_maximize(ui_wdecor_t *, void *);
 static void test_wdecor_unmaximize(ui_wdecor_t *, void *);
 static void test_wdecor_close(ui_wdecor_t *, void *);
 static void test_wdecor_move(ui_wdecor_t *, void *, gfx_coord2_t *, sysarg_t);
-static void test_wdecor_resize(ui_wdecor_t *, void *, ui_wdecor_rsztype_t,
+static void test_wdecor_resize(ui_wdecor_t *, void *, display_wnd_rsztype_t,
     gfx_coord2_t *, sysarg_t);
 static void test_wdecor_set_cursor(ui_wdecor_t *, void *, ui_stock_cursor_t);
 
@@ -124,7 +124,7 @@ typedef struct {
 	sysarg_t idev_id;
 	char32_t accel;
 	bool resize;
-	ui_wdecor_rsztype_t rsztype;
+	display_wnd_rsztype_t rsztype;
 	bool set_cursor;
 	ui_stock_cursor_t cursor;
 } test_cb_resp_t;
@@ -583,14 +583,14 @@ PCUT_TEST(resize)
 	errno_t rc;
 	ui_wdecor_t *wdecor;
 	test_cb_resp_t resp;
-	ui_wdecor_rsztype_t rsztype;
+	display_wnd_rsztype_t rsztype;
 	gfx_coord2_t pos;
 	sysarg_t pos_id;
 
 	rc = ui_wdecor_create(NULL, "Hello", ui_wds_none, &wdecor);
 	PCUT_ASSERT_ERRNO_VAL(EOK, rc);
 
-	rsztype = ui_wr_bottom;
+	rsztype = display_wr_bottom;
 	pos.x = 3;
 	pos.y = 4;
 	pos_id = 5;
@@ -604,7 +604,7 @@ PCUT_TEST(resize)
 
 	/* Resize callback with real callback set */
 	resp.resize = false;
-	resp.rsztype = ui_wr_none;
+	resp.rsztype = display_wr_none;
 	resp.pos.x = 0;
 	resp.pos.y = 0;
 	ui_wdecor_set_cb(wdecor, &test_wdecor_cb, &resp);
@@ -1360,7 +1360,7 @@ PCUT_TEST(get_rsztype)
 	ui_resource_t *resource = NULL;
 	ui_wdecor_t *wdecor;
 	gfx_rect_t rect;
-	ui_wdecor_rsztype_t rsztype;
+	display_wnd_rsztype_t rsztype;
 	gfx_coord2_t pos;
 	errno_t rc;
 
@@ -1386,67 +1386,67 @@ PCUT_TEST(get_rsztype)
 	pos.x = 0;
 	pos.y = -1;
 	rsztype = ui_wdecor_get_rsztype(wdecor, &pos);
-	PCUT_ASSERT_EQUALS(ui_wr_none, rsztype);
+	PCUT_ASSERT_EQUALS(display_wr_none, rsztype);
 
 	/* Middle of the window */
 	pos.x = 50;
 	pos.y = 100;
 	rsztype = ui_wdecor_get_rsztype(wdecor, &pos);
-	PCUT_ASSERT_EQUALS(ui_wr_none, rsztype);
+	PCUT_ASSERT_EQUALS(display_wr_none, rsztype);
 
 	/* Top-left corner, but not on edge */
 	pos.x = 20;
 	pos.y = 30;
 	rsztype = ui_wdecor_get_rsztype(wdecor, &pos);
-	PCUT_ASSERT_EQUALS(ui_wr_none, rsztype);
+	PCUT_ASSERT_EQUALS(display_wr_none, rsztype);
 
 	/* Top-left corner on top edge */
 	pos.x = 20;
 	pos.y = 20;
 	rsztype = ui_wdecor_get_rsztype(wdecor, &pos);
-	PCUT_ASSERT_EQUALS(ui_wr_top_left, rsztype);
+	PCUT_ASSERT_EQUALS(display_wr_top_left, rsztype);
 
 	/* Top-left corner on left edge */
 	pos.x = 10;
 	pos.y = 30;
 	rsztype = ui_wdecor_get_rsztype(wdecor, &pos);
-	PCUT_ASSERT_EQUALS(ui_wr_top_left, rsztype);
+	PCUT_ASSERT_EQUALS(display_wr_top_left, rsztype);
 
 	/* Top-right corner on top edge */
 	pos.x = 90;
 	pos.y = 20;
 	rsztype = ui_wdecor_get_rsztype(wdecor, &pos);
-	PCUT_ASSERT_EQUALS(ui_wr_top_right, rsztype);
+	PCUT_ASSERT_EQUALS(display_wr_top_right, rsztype);
 
 	/* Top-right corner on right edge */
 	pos.x = 99;
 	pos.y = 30;
 	rsztype = ui_wdecor_get_rsztype(wdecor, &pos);
-	PCUT_ASSERT_EQUALS(ui_wr_top_right, rsztype);
+	PCUT_ASSERT_EQUALS(display_wr_top_right, rsztype);
 
 	/* Top edge */
 	pos.x = 50;
 	pos.y = 20;
 	rsztype = ui_wdecor_get_rsztype(wdecor, &pos);
-	PCUT_ASSERT_EQUALS(ui_wr_top, rsztype);
+	PCUT_ASSERT_EQUALS(display_wr_top, rsztype);
 
 	/* Bottom edge */
 	pos.x = 50;
 	pos.y = 199;
 	rsztype = ui_wdecor_get_rsztype(wdecor, &pos);
-	PCUT_ASSERT_EQUALS(ui_wr_bottom, rsztype);
+	PCUT_ASSERT_EQUALS(display_wr_bottom, rsztype);
 
 	/* Left edge */
 	pos.x = 10;
 	pos.y = 100;
 	rsztype = ui_wdecor_get_rsztype(wdecor, &pos);
-	PCUT_ASSERT_EQUALS(ui_wr_left, rsztype);
+	PCUT_ASSERT_EQUALS(display_wr_left, rsztype);
 
 	/* Right edge */
 	pos.x = 99;
 	pos.y = 100;
 	rsztype = ui_wdecor_get_rsztype(wdecor, &pos);
-	PCUT_ASSERT_EQUALS(ui_wr_right, rsztype);
+	PCUT_ASSERT_EQUALS(display_wr_right, rsztype);
 
 	ui_wdecor_destroy(wdecor);
 
@@ -1465,7 +1465,7 @@ PCUT_TEST(get_rsztype)
 	pos.x = 10;
 	pos.y = 20;
 	rsztype = ui_wdecor_get_rsztype(wdecor, &pos);
-	PCUT_ASSERT_EQUALS(ui_wr_none, rsztype);
+	PCUT_ASSERT_EQUALS(display_wr_none, rsztype);
 
 	ui_wdecor_destroy(wdecor);
 	ui_resource_destroy(resource);
@@ -1478,23 +1478,23 @@ PCUT_TEST(get_rsztype)
 PCUT_TEST(cursor_from_rsztype)
 {
 	PCUT_ASSERT_EQUALS(ui_curs_arrow,
-	    ui_wdecor_cursor_from_rsztype(ui_wr_none));
+	    ui_wdecor_cursor_from_rsztype(display_wr_none));
 	PCUT_ASSERT_EQUALS(ui_curs_size_ud,
-	    ui_wdecor_cursor_from_rsztype(ui_wr_top));
+	    ui_wdecor_cursor_from_rsztype(display_wr_top));
 	PCUT_ASSERT_EQUALS(ui_curs_size_ud,
-	    ui_wdecor_cursor_from_rsztype(ui_wr_bottom));
+	    ui_wdecor_cursor_from_rsztype(display_wr_bottom));
 	PCUT_ASSERT_EQUALS(ui_curs_size_lr,
-	    ui_wdecor_cursor_from_rsztype(ui_wr_left));
+	    ui_wdecor_cursor_from_rsztype(display_wr_left));
 	PCUT_ASSERT_EQUALS(ui_curs_size_lr,
-	    ui_wdecor_cursor_from_rsztype(ui_wr_right));
+	    ui_wdecor_cursor_from_rsztype(display_wr_right));
 	PCUT_ASSERT_EQUALS(ui_curs_size_uldr,
-	    ui_wdecor_cursor_from_rsztype(ui_wr_top_left));
+	    ui_wdecor_cursor_from_rsztype(display_wr_top_left));
 	PCUT_ASSERT_EQUALS(ui_curs_size_uldr,
-	    ui_wdecor_cursor_from_rsztype(ui_wr_bottom_right));
+	    ui_wdecor_cursor_from_rsztype(display_wr_bottom_right));
 	PCUT_ASSERT_EQUALS(ui_curs_size_urdl,
-	    ui_wdecor_cursor_from_rsztype(ui_wr_top_right));
+	    ui_wdecor_cursor_from_rsztype(display_wr_top_right));
 	PCUT_ASSERT_EQUALS(ui_curs_size_urdl,
-	    ui_wdecor_cursor_from_rsztype(ui_wr_bottom_left));
+	    ui_wdecor_cursor_from_rsztype(display_wr_bottom_left));
 }
 
 /** Test ui_wdecor_frame_pos_event() */
@@ -1724,7 +1724,7 @@ static void test_wdecor_move(ui_wdecor_t *wdecor, void *arg, gfx_coord2_t *pos,
 }
 
 static void test_wdecor_resize(ui_wdecor_t *wdecor, void *arg,
-    ui_wdecor_rsztype_t rsztype, gfx_coord2_t *pos, sysarg_t pos_id)
+    display_wnd_rsztype_t rsztype, gfx_coord2_t *pos, sysarg_t pos_id)
 {
 	test_cb_resp_t *resp = (test_cb_resp_t *) arg;
 


### PR DESCRIPTION
A newer version of GCC appropriately warns about different enum types being mixed together.
Instead of an explicit typecast, which only hides the underlying issue, I'm thinking there really should not be two identical enums being used like this.

This patch removes `ui_wdecor_rsztype_t` and uses `display_wnd_rsztype_t` in its place.
@jxsvoboda this is your wheelhouse. What do you think?