### PR TITLE
Updates for MSIM >2.0.0

### DIFF
--- a/tools/conf/msim.conf
+++ b/tools/conf/msim.conf
@@ -2,8 +2,8 @@
 # MSIM configuration script
 #
 
-add dcpu cpu0
-add dcpu cpu1
+add dr4kcpu cpu0
+add dr4kcpu cpu1
 
 add rwm mainmem 0x00000000
 mainmem generic 64M

--- a/tools/ew.py
+++ b/tools/ew.py
@@ -78,7 +78,7 @@ def termemu_detect():
 	emus = ['gnome-terminal', 'xfce4-terminal', 'xterm']
 	for termemu in emus:
 		try:
-			subprocess.check_output('which ' + termemu, shell = True)
+			subprocess.check_output('which ' + termemu, shell = True, stderr = subprocess.STDOUT)
 			return termemu
 		except:
 			pass

--- a/tools/ew.py
+++ b/tools/ew.py
@@ -330,7 +330,7 @@ def ski_run(platform, machine, processor):
 
 def msim_run(platform, machine, processor):
 	hdisk_mk()
-	run_in_console('msim -c ' + TOOLS_DIR + '/conf/msim.conf', 'HelenOS/mips32 on msim')
+	run_in_console('msim -n -c ' + TOOLS_DIR + '/conf/msim.conf', 'HelenOS/mips32 on msim')
 
 def spike_run(platform, machine, processor):
 	run_in_console('spike -m1073741824:1073741824 image.boot', 'HelenOS/risvc64 on Spike')


### PR DESCRIPTION
I assume we do not need to keep backward compatibilty and support both pre and post 2.0 versions of MSIM.
