### PR TITLE
Change internal UUID representation and use correct GPT UUID endianness

### DIFF
--- a/uspace/lib/c/generic/rndgen.c
+++ b/uspace/lib/c/generic/rndgen.c
@@ -91,6 +91,32 @@ errno_t rndgen_uint8(rndgen_t *rndgen, uint8_t *rb)
 	return EOK;
 }
 
+/** Generate random 16-bit integer.
+ *
+ * @param rndgen Random number generator
+ * @param rw Place to store random 16-bit integer
+ * @return EOK on success or error code
+ */
+errno_t rndgen_uint16(rndgen_t *rndgen, uint16_t *rw)
+{
+	int i;
+	uint8_t b;
+	uint16_t w;
+	errno_t rc;
+
+	w = 0;
+	for (i = 0; i < 2; i++) {
+		rc = rndgen_uint8(rndgen, &b);
+		if (rc != EOK)
+			return rc;
+
+		w = (w << 8) | b;
+	}
+
+	*rw = w;
+	return EOK;
+}
+
 /** Generate random 32-bit integer.
  *
  * @param rndgen Random number generator

--- a/uspace/lib/c/include/rndgen.h
+++ b/uspace/lib/c/include/rndgen.h
@@ -46,6 +46,7 @@ typedef struct {
 extern errno_t rndgen_create(rndgen_t **);
 extern void rndgen_destroy(rndgen_t *);
 extern errno_t rndgen_uint8(rndgen_t *, uint8_t *);
+extern errno_t rndgen_uint16(rndgen_t *, uint16_t *);
 extern errno_t rndgen_uint32(rndgen_t *, uint32_t *);
 
 #endif

--- a/uspace/lib/c/include/types/uuid.h
+++ b/uspace/lib/c/include/types/uuid.h
@@ -37,13 +37,17 @@
 
 #include <stdint.h>
 
-enum {
-	uuid_bytes = 16
-};
+#define _UUID_NODE_LEN 6
 
 /** Universally Unique Identifier */
+
 typedef struct {
-	uint8_t b[uuid_bytes];
+	uint32_t time_low;
+	uint16_t time_mid;
+	uint16_t time_hi_and_version;
+	uint8_t clock_seq_hi_and_reserved;
+	uint8_t clock_seq_low;
+	uint8_t node[_UUID_NODE_LEN];
 } uuid_t;
 
 #endif

--- a/uspace/lib/c/include/uuid.h
+++ b/uspace/lib/c/include/uuid.h
@@ -42,6 +42,8 @@
 extern errno_t uuid_generate(uuid_t *);
 extern void uuid_encode(uuid_t *, uint8_t *);
 extern void uuid_decode(uint8_t *, uuid_t *);
+extern void uuid_encode_le(uuid_t *, uint8_t *);
+extern void uuid_decode_le(uint8_t *, uuid_t *);
 extern errno_t uuid_parse(const char *, uuid_t *, const char **);
 extern errno_t uuid_format(uuid_t *, char **, bool);
 

--- a/uspace/lib/c/test/uuid.c
+++ b/uspace/lib/c/test/uuid.c
@@ -49,12 +49,12 @@ static const char *uuids[] = {
 
 static bool uuid_valid(uuid_t uuid)
 {
-	if (!(uuid.b[6] & 0x40)) {
+	if (!((uuid.time_hi_and_version & 0xf000) & 0x4000)) {
 		return false;
 	}
 
-	int f = (uuid.b[8] & 0x80) || (uuid.b[8] & 0x90);
-	f = f || (uuid.b[8] & 0xA0) || (uuid.b[8] & 0xB0);
+	int f = (uuid.clock_seq_hi_and_reserved & 0x80) || (uuid.clock_seq_hi_and_reserved & 0x90);
+	f = f || (uuid.clock_seq_hi_and_reserved & 0xA0) || (uuid.clock_seq_hi_and_reserved & 0xB0);
 	if (!f) {
 		return false;
 	}

--- a/uspace/lib/label/src/gpt.c
+++ b/uspace/lib/label/src/gpt.c
@@ -442,7 +442,7 @@ static errno_t gpt_create(label_bd_t *bd, label_t **rlabel)
 		gpt_hdr->alternate_lba = host2uint64_t_le(hdr_ba[1 - i]);
 		gpt_hdr->first_usable_lba = host2uint64_t_le(ba_min);
 		gpt_hdr->last_usable_lba = host2uint64_t_le(ba_max);
-		uuid_encode(&disk_uuid, gpt_hdr->disk_guid);
+		uuid_encode_le(&disk_uuid, gpt_hdr->disk_guid);
 		gpt_hdr->entry_lba = host2uint64_t_le(ptba[i]);
 		gpt_hdr->num_entries = host2uint32_t_le(num_entries);
 		gpt_hdr->entry_size = host2uint32_t_le(esize);
@@ -811,8 +811,8 @@ static errno_t gpt_part_to_pte(label_part_t *part, gpt_entry_t *pte)
 		return EINVAL;
 
 	memset(pte, 0, sizeof(gpt_entry_t));
-	uuid_encode(&part->ptype.t.uuid, pte->part_type);
-	uuid_encode(&part->part_uuid, pte->part_id);
+	uuid_encode_le(&part->ptype.t.uuid, pte->part_type);
+	uuid_encode_le(&part->part_uuid, pte->part_id);
 	pte->start_lba = host2uint64_t_le(part->block0);
 	pte->end_lba = host2uint64_t_le(eblock);
 	//pte->attributes
@@ -848,8 +848,8 @@ static errno_t gpt_pte_to_part(label_t *label, gpt_entry_t *pte, int index)
 	part->block0 = b0;
 	part->nblocks = b1 - b0 + 1;
 	part->ptype.fmt = lptf_uuid;
-	uuid_decode(pte->part_type, &part->ptype.t.uuid);
-	uuid_decode(pte->part_id, &part->part_uuid);
+	uuid_decode_le(pte->part_type, &part->ptype.t.uuid);
+	uuid_decode_le(pte->part_id, &part->part_uuid);
 
 	part->label = label;
 	list_append(&part->lparts, &label->parts);


### PR DESCRIPTION
### Representation part
Change the UUID internal representation so that it has named fields.

### GPT part
Encode the partition type UUID in little-endian format so that the type of GPT partition created within HelenOS can be recognized outside of HelenOS.

I haven't found anything regarding the byte order in the UEFI spec, but this is the way it is done.

sections[1]:
 - time_low, time_mid, time_hi_and_version are stored in little-endian
 - clock_seq_hi_and_reserved, clock_seq_low, node are stored in big-endian.

Actually it is all little-endian, but because of missing hyphens it appears that the second half is big-endian. [2] [3]

[1] https://www.rfc-editor.org/rfc/rfc4122#section-4.1.2
[2] https://en.wikipedia.org/wiki/Universally_unique_identifier#Encoding
[3] https://devblogs.microsoft.com/oldnewthing/20220928-00/?p=107221