### PR TITLE
Make HelenOS compilable when detailed kernel logging is enabled

### DIFF
--- a/kernel/generic/include/debug.h
+++ b/kernel/generic/include/debug.h
@@ -37,6 +37,7 @@
 
 #include <log.h>
 #include <printf/verify.h>
+#include <symtab.h>
 
 #define CALLER  ((uintptr_t) __builtin_return_address(0))
 


### PR DESCRIPTION
When "Detailed kernel logging" is enabled, HelenOS won't compile showing the following error message:

`../../helenos/kernel/generic/src/main/main.c: In function 'main_bsp_separated_stack':                                                   
../../helenos/kernel/generic/include/debug.h:62:21: error: implicit declaration of function 'symtab_fmt_name_lookup' [-Werror=implicit-$
unction-declaration]                                                                                                                    
   62 |                     symtab_fmt_name_lookup(CALLER), __FILE__, __LINE__, \                                                       
      |                     ^~~~~~~~~~~~~~~~~~~~~~                                                                                      
../../helenos/kernel/generic/src/main/main.c:193:9: note: in expansion of macro 'LOG'                                                   
  193 |         LOG("\nconfig.base=%p config.kernel_size=%zu",      
      |         ^~~   `

