### PR TITLE
ata_channel_destroy(): free the channel

### DIFF
--- a/uspace/lib/ata/src/ata.c
+++ b/uspace/lib/ata/src/ata.c
@@ -259,12 +259,14 @@ errno_t ata_channel_destroy(ata_channel_t *chan)
 		rc = ata_device_remove(&chan->device[i]);
 		if (rc != EOK) {
 			ata_msg_error(chan, "Unable to remove device %d.", i);
-			break;
+			fibril_mutex_unlock(&chan->lock);
+			return rc;
 		}
 	}
 
 	ata_bd_fini_irq(chan);
 	fibril_mutex_unlock(&chan->lock);
+	free(chan);
 
 	return rc;
 }


### PR DESCRIPTION
While browsing the ATA code again, I noticed that the initial call to calloc() doesn't have a free() pair.