### PR TITLE
Allow bitmap to be used in userspace

### DIFF
--- a/common/adt/bitmap.c
+++ b/common/adt/bitmap.c
@@ -26,7 +26,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/** @addtogroup kernel_generic_adt
+/** @addtogroup libc
  * @{
  */
 /**
@@ -42,7 +42,6 @@
 #include <align.h>
 #include <assert.h>
 #include <macros.h>
-#include <typedefs.h>
 
 #define ALL_ONES    0xff
 #define ALL_ZEROES  0x00

--- a/common/include/adt/bitmap.h
+++ b/common/include/adt/bitmap.h
@@ -26,14 +26,14 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/** @addtogroup kernel_generic_adt
+/** @addtogroup libc
  * @{
  */
 /** @file
  */
 
-#ifndef KERN_BITMAP_H_
-#define KERN_BITMAP_H_
+#ifndef _LIBC_BITMAP_H_
+#define _LIBC_BITMAP_H_
 
 #include <stddef.h>
 #include <stdbool.h>

--- a/uspace/lib/c/meson.build
+++ b/uspace/lib/c/meson.build
@@ -58,6 +58,7 @@ endforeach
 src = [ arch_src ]
 
 src += files(
+	'common/adt/bitmap.c',
 	'common/adt/checksum.c',
 	'common/adt/circ_buf.c',
 	'common/adt/list.c',


### PR DESCRIPTION
Hi,

I happen to need to use a bitmap for my project, but the one in HelenOS is
not available in libc, only for the kernel...

So I included it to be built in libc, but then userspace doesn't see <[typedefs.h](https://github.com/HelenOS/helenos/blob/master/kernel/generic/include/typedefs.h)>
kernel header, which seems to not be needed by the bitmap.

Objections? Ok?