### PR TITLE
fix calculation of TLS size for main fibril

### DIFF
--- a/uspace/lib/c/generic/rtld/module.c
+++ b/uspace/lib/c/generic/rtld/module.c
@@ -402,7 +402,11 @@ void modules_process_tls(rtld_t *rtld)
 	 */
 	rtld->tls_size = ALIGN_UP(rtld->tls_size, rtld->tls_align);
 
-	/* Space for the TCB. */
+	/* Space for the TCB.
+	 * Later, the TLS zero offset is equal to the pointer to tcb_t, so
+	 * adding the sizeof(tcb_t) block AFTER we calculated the alignment
+	 * of the remainder above is correct.
+	 */
 	rtld->tls_size += sizeof(tcb_t);
 #endif
 }

--- a/uspace/lib/c/generic/rtld/module.c
+++ b/uspace/lib/c/generic/rtld/module.c
@@ -397,12 +397,11 @@ void modules_process_tls(rtld_t *rtld)
 	 * We are in negative offsets. In order for the alignments to
 	 * be correct, "zero" offset (i.e. the total size) must be aligned
 	 * to the strictest alignment present.
-	 * Note that the padding is actually in front of the TLS data,
-	 * not after it.
 	 */
 	rtld->tls_size = ALIGN_UP(rtld->tls_size, rtld->tls_align);
 
-	/* Space for the TCB.
+	/*
+	 * Space for the TCB.
 	 * Later, the TLS zero offset is equal to the pointer to tcb_t, so
 	 * adding the sizeof(tcb_t) block AFTER we calculated the alignment
 	 * of the remainder above is correct.

--- a/uspace/lib/c/generic/thread/tls.c
+++ b/uspace/lib/c/generic/thread/tls.c
@@ -58,10 +58,10 @@
 #error Unknown TLS variant.
 #endif
 
-static ptrdiff_t _tcb_data_offset(void)
+static ptrdiff_t _tcb_data_offset(const void* elf)
 {
 	const elf_segment_header_t *tls =
-	    elf_get_phdr(__progsymbols.elfstart, PT_TLS);
+	    elf_get_phdr(elf, PT_TLS);
 
 	size_t tls_align = tls ? tls->p_align : 1;
 
@@ -79,7 +79,7 @@ void *tls_get(void)
 #ifdef CONFIG_RTLD
 	assert(runtime_env == NULL);
 #endif
-	return (uint8_t *)__tcb_get() + _tcb_data_offset();
+	return (uint8_t *)__tcb_get() + _tcb_data_offset(__progsymbols.elfstart);
 }
 
 static tcb_t *tls_make_generic(const void *elf, void *(*alloc)(size_t, size_t))
@@ -113,11 +113,11 @@ static tcb_t *tls_make_generic(const void *elf, void *(*alloc)(size_t, size_t))
 
 #ifdef CONFIG_TLS_VARIANT_1
 	tcb_t *tcb = area;
-	uint8_t *data = (uint8_t *)tcb + _tcb_data_offset();
+	uint8_t *data = (uint8_t *)tcb + _tcb_data_offset(elf);
 	memset(tcb, 0, sizeof(*tcb));
 #else
 	uint8_t *data = area;
-	tcb_t *tcb = (tcb_t *) (data - _tcb_data_offset());
+	tcb_t *tcb = (tcb_t *) (data - _tcb_data_offset(elf));
 	memset(tcb, 0, sizeof(tcb_t));
 	tcb->self = tcb;
 #endif

--- a/uspace/lib/c/generic/thread/tls.c
+++ b/uspace/lib/c/generic/thread/tls.c
@@ -141,6 +141,14 @@ static tcb_t *tls_make_generic(const void *elf, void *(*alloc)(size_t, size_t))
 	 * Now we will copy the initialization data to a position at the start of
 	 * the allocation, so if the padding has nonzero size, if think the initialization
 	 * data is now incorrectly offset by its size?
+	 *
+	 * Maybe a diagram helps explaining this?
+	 * |    allocation   |     |
+	 * | paddding | data | tcb |
+	 *   ^
+	 *   +--- we will copy the initialization data here
+	 *              ^
+	 *              +--- but the data should be actually here?
 	 */
 
 	/* Copy thread local data from the initialization image. */


### PR DESCRIPTION
Before this patch, `_tcb_data_offset` always used `__progsymbols.elfstart`. However, that is wrong when it is being called from the loader server!! This can leave much less space for the TLS data than requested and TLS accesses will corrupt some memory!

Now we pass to it a pointer to the correct ELF, falling back to elfstart in the public tls_get call.

Also added some comments, explaining some confusing parts...