### PR TITLE
init RTLD runtime at load time even for statically linked binaries

### DIFF
--- a/uspace/app/dltest/dltest.c
+++ b/uspace/app/dltest/dltest.c
@@ -943,7 +943,7 @@ static int test_dlfcn(void)
 	if (!test_dlfcn_read_public_uvar())
 		return 1;
 
-#ifndef STATIC_EXE
+#ifndef STATIC_EXE // FIXME: this define is not set anywhere
 
 	if (!test_dlfcn_dl_get_private_fib_var())
 		return 1;

--- a/uspace/lib/c/generic/elf/elf_load.c
+++ b/uspace/lib/c/generic/elf/elf_load.c
@@ -64,7 +64,7 @@ errno_t elf_load(int file, elf_info_t *info)
 
 	rc = elf_load_file(file, 0, finfo);
 	if (rc != EOK) {
-		DPRINTF("Failed to load executable '%s'.\n", file_name);
+		DPRINTF("Failed to load executable.\n");
 		return rc;
 	}
 
@@ -72,7 +72,7 @@ errno_t elf_load(int file, elf_info_t *info)
 	DPRINTF("- prog dynamic: %p\n", finfo->dynamic);
 	rc = rtld_prog_process(finfo, &env);
 	if (rc != EOK) {
-		DPRINTF("Failed to process executable '%s'.\n", file_name);
+		DPRINTF("Failed to process executable.\n");
 		return rc;
 	}
 	info->env = env;

--- a/uspace/lib/c/generic/elf/elf_load.c
+++ b/uspace/lib/c/generic/elf/elf_load.c
@@ -56,10 +56,7 @@
  */
 errno_t elf_load(int file, elf_info_t *info)
 {
-#ifdef CONFIG_RTLD
-	rtld_t *env;
-#endif
-	errno_t rc;
+	errno_t rc = EOK;
 
 	rc = elf_load_file(file, 0, &info->finfo);
 	if (rc != EOK) {
@@ -67,17 +64,8 @@ errno_t elf_load(int file, elf_info_t *info)
 		return rc;
 	}
 
-	if (info->finfo.dynamic == NULL) {
-		/* Statically linked program */
-		DPRINTF("Binary is statically linked.\n");
-		info->env = NULL;
-		return EOK;
-	}
-
-	DPRINTF("Binary is dynamically linked.\n");
 #ifdef CONFIG_RTLD
-	DPRINTF("- prog dynamic: %p\n", info->finfo.dynamic);
-
+	rtld_t *env;
 	rc = rtld_prog_process(&info->finfo, &env);
 	info->env = env;
 #else

--- a/uspace/lib/c/generic/libc.c
+++ b/uspace/lib/c/generic/libc.c
@@ -100,8 +100,6 @@ void __libc_main(void *pcb_ptr)
 		 * A binary loaded by kernel, not the loader.
 		 * Noop - code loaded by kernel doesn't need RTLD.
 		 */
-		// errno_t rtld_init_result = rtld_init_static();
-		// assert(rtld_init_result == EOK);
 	} else {
 		assert(__pcb->rtld_runtime != NULL);
 		runtime_env = (rtld_t *) __pcb->rtld_runtime;

--- a/uspace/lib/c/generic/libc.c
+++ b/uspace/lib/c/generic/libc.c
@@ -98,10 +98,10 @@ void __libc_main(void *pcb_ptr)
 	if (__pcb == NULL) {
 		/*
 		 * A binary loaded by kernel, not the loader.
-		 * Init some rudimentary rtld runtime environment.
+		 * Noop - code loaded by kernel doesn't need RTLD.
 		 */
-		errno_t rtld_init_result = rtld_init_static();
-		assert(rtld_init_result == EOK);
+		// errno_t rtld_init_result = rtld_init_static();
+		// assert(rtld_init_result == EOK);
 	} else {
 		assert(__pcb->rtld_runtime != NULL);
 		runtime_env = (rtld_t *) __pcb->rtld_runtime;

--- a/uspace/lib/c/generic/libc.c
+++ b/uspace/lib/c/generic/libc.c
@@ -95,11 +95,16 @@ void __libc_main(void *pcb_ptr)
 	__malloc_init();
 
 #ifdef CONFIG_RTLD
-	if (__pcb != NULL && __pcb->rtld_runtime != NULL) {
-		runtime_env = (rtld_t *) __pcb->rtld_runtime;
+	if (__pcb == NULL) {
+		/*
+		 * A binary loaded by kernel, not the loader.
+		 * Init some rudimentary rtld runtime environment.
+		 */
+		errno_t rtld_init_result = rtld_init_static();
+		assert(rtld_init_result == EOK);
 	} else {
-		if (rtld_init_static() != EOK)
-			abort();
+		assert(__pcb->rtld_runtime != NULL);
+		runtime_env = (rtld_t *) __pcb->rtld_runtime;
 	}
 #endif
 

--- a/uspace/lib/c/generic/rtld/module.c
+++ b/uspace/lib/c/generic/rtld/module.c
@@ -54,46 +54,56 @@
 
 #include "../private/libc.h"
 
-/** Create module for static executable.
+/** Create the "entrypoint" module, of the program executable
  *
+ * @param p_info Program ELF file info
  * @param rtld Run-time dynamic linker
  * @param rmodule Place to store pointer to new module or @c NULL
  * @return EOK on success, ENOMEM if out of memory
  */
-errno_t module_create_static_exec(const void *elf, rtld_t *rtld)
+errno_t module_create_entrypoint(elf_finfo_t *p_info, rtld_t *rtld, module_t **rmodule)
 {
 	module_t *module;
+	bool is_dynamic = p_info->dynamic != NULL;
+	DPRINTF("module_create_entrypoint\n");
 
 	module = calloc(1, sizeof(module_t));
-	if (module == NULL) {
-		DPRINTF("malloc failed\n");
+	if (module == NULL)
 		return ENOMEM;
+
+	uintptr_t bias = elf_get_bias(p_info->base);
+
+	/*
+	 * First we need to process dynamic sections of the executable
+	 * program and insert it into the module graph.
+	 */
+	if (is_dynamic) {
+		DPRINTF("Parse program .dynamic section at %p\n", p_info->dynamic);
+		dynamic_parse(p_info->dynamic, bias, &module->dyn);
+	} else {
+		DPRINTF("Executable is not dynamically linked\n");
 	}
 
+	module->bias = bias;
 	module->id = rtld_get_next_id(rtld);
 	module->dyn.soname = "[program]";
 
 	module->rtld = rtld;
 	module->exec = true;
-	module->local = true;
+	module->local = !is_dynamic;
 
-	const elf_segment_header_t *tls =
-	    elf_get_phdr(elf, PT_TLS);
+	module->tdata = p_info->tls.tdata;
+	module->tdata_size = p_info->tls.tdata_size;
+	module->tbss_size = p_info->tls.tbss_size;
+	module->tls_align = p_info->tls.tls_align;
 
-	if (tls) {
-		uintptr_t bias = elf_get_bias(elf);
-		module->tdata = (void *) (tls->p_vaddr + bias);
-		module->tdata_size = tls->p_filesz;
-		module->tbss_size = tls->p_memsz - tls->p_filesz;
-		module->tls_align = tls->p_align;
-	} else {
-		module->tdata = NULL;
-		module->tdata_size = 0;
-		module->tbss_size = 0;
-		module->tls_align = 1;
-	}
+	DPRINTF("prog tdata at %p size %zu, tbss size %zu\n",
+	module->tdata, module->tdata_size, module->tbss_size);
 
 	list_append(&module->modules_link, &rtld->modules);
+
+	if (rmodule != NULL)
+		*rmodule = module;
 	return EOK;
 }
 

--- a/uspace/lib/c/generic/rtld/module.c
+++ b/uspace/lib/c/generic/rtld/module.c
@@ -60,7 +60,7 @@
  * @param rmodule Place to store pointer to new module or @c NULL
  * @return EOK on success, ENOMEM if out of memory
  */
-errno_t module_create_static_exec(rtld_t *rtld, module_t **rmodule)
+errno_t module_create_static_exec(const void *elf, rtld_t *rtld)
 {
 	module_t *module;
 
@@ -78,10 +78,10 @@ errno_t module_create_static_exec(rtld_t *rtld, module_t **rmodule)
 	module->local = true;
 
 	const elf_segment_header_t *tls =
-	    elf_get_phdr(__progsymbols.elfstart, PT_TLS);
+	    elf_get_phdr(elf, PT_TLS);
 
 	if (tls) {
-		uintptr_t bias = elf_get_bias(__progsymbols.elfstart);
+		uintptr_t bias = elf_get_bias(elf);
 		module->tdata = (void *) (tls->p_vaddr + bias);
 		module->tdata_size = tls->p_filesz;
 		module->tbss_size = tls->p_memsz - tls->p_filesz;
@@ -94,9 +94,6 @@ errno_t module_create_static_exec(rtld_t *rtld, module_t **rmodule)
 	}
 
 	list_append(&module->modules_link, &rtld->modules);
-
-	if (rmodule != NULL)
-		*rmodule = module;
 	return EOK;
 }
 

--- a/uspace/lib/c/generic/thread/tls.c
+++ b/uspace/lib/c/generic/thread/tls.c
@@ -73,7 +73,7 @@ static ptrdiff_t _tcb_data_offset(void)
 #endif
 }
 
-/** Get address of static TLS block */
+/** Get address of static TLS block - only when RTLD is not initialized  */
 void *tls_get(void)
 {
 #ifdef CONFIG_RTLD

--- a/uspace/lib/c/include/rtld/module.h
+++ b/uspace/lib/c/include/rtld/module.h
@@ -40,7 +40,7 @@
 #include <types/rtld/module.h>
 #include <types/rtld/rtld.h>
 
-extern errno_t module_create_static_exec(const void *, rtld_t *);
+extern errno_t module_create_entrypoint(elf_finfo_t *, rtld_t *, module_t **);
 extern void module_process_relocs(module_t *);
 extern module_t *module_find(rtld_t *, const char *);
 extern module_t *module_load(rtld_t *, const char *, mlflags_t);

--- a/uspace/lib/c/include/rtld/module.h
+++ b/uspace/lib/c/include/rtld/module.h
@@ -40,7 +40,7 @@
 #include <types/rtld/module.h>
 #include <types/rtld/rtld.h>
 
-extern errno_t module_create_static_exec(rtld_t *, module_t **);
+extern errno_t module_create_static_exec(const void *, rtld_t *);
 extern void module_process_relocs(module_t *);
 extern module_t *module_find(rtld_t *, const char *);
 extern module_t *module_load(rtld_t *, const char *, mlflags_t);

--- a/uspace/lib/c/include/rtld/rtld.h
+++ b/uspace/lib/c/include/rtld/rtld.h
@@ -44,7 +44,6 @@
 
 extern rtld_t *runtime_env;
 
-extern errno_t rtld_init_static(elf_finfo_t *, rtld_t **);
 extern errno_t rtld_prog_process(elf_finfo_t *, rtld_t **);
 extern tcb_t *rtld_tls_make(rtld_t *);
 extern unsigned long rtld_get_next_id(rtld_t *);

--- a/uspace/lib/c/include/rtld/rtld.h
+++ b/uspace/lib/c/include/rtld/rtld.h
@@ -44,7 +44,7 @@
 
 extern rtld_t *runtime_env;
 
-extern errno_t rtld_init_static(void);
+extern errno_t rtld_init_static(elf_finfo_t *, rtld_t **);
 extern errno_t rtld_prog_process(elf_finfo_t *, rtld_t **);
 extern tcb_t *rtld_tls_make(rtld_t *);
 extern unsigned long rtld_get_next_id(rtld_t *);

--- a/uspace/srv/loader/main.c
+++ b/uspace/srv/loader/main.c
@@ -299,11 +299,8 @@ static int ldr_load(ipc_call_t *req)
 	DPRINTF("Loaded.\n");
 
 #ifdef CONFIG_RTLD
-	if (prog_info.env) {
-		pcb.tcb = rtld_tls_make(prog_info.env);
-	} else {
-		pcb.tcb = tls_make(prog_info.finfo.base);
-	}
+	assert(prog_info.env != NULL);
+	pcb.tcb = rtld_tls_make(prog_info.env);
 #else
 	pcb.tcb = tls_make(prog_info.finfo.base);
 #endif


### PR DESCRIPTION
Another TLS issue, surprisingly completely unrelated to #240

This is about running static binaries, but with CONFIG_RTLD enabled

## What's the current issue

Let's look at the loader code:  
(just keep the code links for reference, I explain the sequence below)

https://github.com/HelenOS/helenos/blob/eff458dc0610e2e236a23436d7688091d3843237/uspace/srv/loader/main.c#L288-L317

The `elf_load` call:
https://github.com/HelenOS/helenos/blob/eff458dc0610e2e236a23436d7688091d3843237/uspace/lib/c/generic/elf/elf_load.c#L57-L87

So, the when the loader is started and runs ldr_load, it first loads the ELF with `elf_load`. After loading the file, for static binaries, `elf_load` simply fills `prog_info.env = NULL`, and `rtld_prog_process` is not called.

So afterwards, back in `ldr_load`, `env == NULL` means that `tls_make` will be called. Let’s look at `tls_make`:

https://github.com/HelenOS/helenos/blob/eff458dc0610e2e236a23436d7688091d3843237/uspace/lib/c/generic/thread/tls.c#L162-L172

So it just defers to `rtld_tls_make` anyways. But this time, with `runtime_env` (a static (=global) variable defined in `lib/c/generic/rtld/rtld.c`. But remember – we are still running the loader, not the program itself. So this runtime_env is the env of the loader, and it contains a pointer to the loader's ELF. So this will create a TLS with the parameters that the loader wants, not the program itself. This is clearly wrong.

---

Later, at startup time, there is this code in `__libc_main`:

https://github.com/HelenOS/helenos/blob/eff458dc0610e2e236a23436d7688091d3843237/uspace/lib/c/generic/libc.c#L97-L104

`__pcb->rtld_runtime` is set to `elf_info->env` in function `elf_set_pcb`, which is called in the `ldr_load` snippet at the top. So the rtld_runtime will be NULL here, and the static initialization is called. This sounds kind of right - but even though this will read the parameters for the TLS and fill it into the environment, `rtld_tls_make` won't be called anymore. This TLS will only be used for any further fibrils. For the main fibril, the TLS+TCB was already created by the broken `tls_make()` call in the loader, and it is used just a few lines earlier in `__libc_main`:

https://github.com/HelenOS/helenos/blob/eff458dc0610e2e236a23436d7688091d3843237/uspace/lib/c/generic/libc.c#L91

(`main_fibril.tcb = __pcb->tcb` earlier, and recall `pcb.tcb = tls_make()` earlier in the loader)

Bonus link:  
how I feel after explaining all of this  
![image](https://github.com/user-attachments/assets/82b3e84f-7f0d-4447-bfe7-cef27176bf3e)


## The solution

`rtld_init_static` needs to run in the loader whenever possible (to then correctly create TLS with rtld).

However, it also needs to be able to run in __libc_main, to initialize the runtime even for tasks that don't go through the loader.

## A bit of history

After looking into the history, I found out that `rtld_init_static` was added in its current form in 153c7a29e3a8082bd7b08d69177e32d48d1873a7. At this time, TCB was created in __libc_main even for dynamically linked binaries, so this was probably an obvious choice.

Then later in 40abf56ae4263cdef7e6b8d2a4f5f794c32dedf3, the creation of TCB/TLS was moved from __libc_main to loader, but initialization of static binaries was forgotten here.

Therefore, looking at it with this perspective, this PR just finishes the incomplete movement of the functionality, just over 6 years later.