### PR TITLE
fix incorrect syscall usage in tester/mapping1 test

### DIFF
--- a/kernel/arch/amd64/src/asm.S
+++ b/kernel/arch/amd64/src/asm.S
@@ -72,7 +72,7 @@ FUNCTION_BEGIN(memcpy_to_uspace)
 	rep movsb               /* copy the rest byte by byte */
 
 	0:
-		ret                 /* return MEMCPY_SRC, success */
+		ret                 /* return MEMCPY_DST, success */
 FUNCTION_END(memcpy_from_uspace)
 FUNCTION_END(memcpy_to_uspace)
 

--- a/uspace/app/tester/mm/mapping1.c
+++ b/uspace/app/tester/mm/mapping1.c
@@ -72,7 +72,8 @@ static bool verify_mapping(void *area, int page_count, errno_t expected_rc,
 	int i;
 	for (i = 0; i < page_count; i++) {
 		void *page_start = ((char *) area) + PAGE_SIZE * i;
-		errno_t rc = as_get_physical_mapping(page_start, NULL);
+		uintptr_t phys_dummy;
+		errno_t rc = as_get_physical_mapping(page_start, &phys_dummy);
 		if (rc != expected_rc) {
 			TPRINTF("as_get_physical_mapping() = %s != %s\n",
 			    str_error_name(rc), str_error_name(expected_rc));


### PR DESCRIPTION
In the `/app/tester`'s `mapping1` test case, `NULL` is passed into the `as_get_physical_mapping` syscall.
This results in the syscall correctly returning `EPERM`, as down the call stack the return value is determined by

```c
// uspace_dst is our incoming NULL
rc = !memcpy_to_uspace(uspace_dst, src, size) ? EPERM : EOK;
```
 (as `memcpy_to_uspace` returns `0` on failure) and the (unexpected) failure of the test case.

As this use of the syscall (passing `NULL` as the only `out` argument) is not reflective of real usage, 
I only adjusted the call site. I also fixed a comment in the assembly which seems incorrect according 
to System V x86-64 ABI.

