### PR TITLE
add shared libraries to export-dev

### DIFF
--- a/meson/part/exports/copy-export.sh
+++ b/meson/part/exports/copy-export.sh
@@ -44,6 +44,11 @@ while [ "$#" -gt 0 ]; do
         staticlib)
             ar -t "$2" | xargs ar crs "${target_dir}/lib/$3"
             ;;
+        sharedlib)
+            filename="$(basename "$2")"
+            cp -L "$2" "${target_dir}/lib/$filename"
+            ln -s "$filename" "${target_dir}/lib/$3"
+            ;;
         include)
             mkdir -p "${target_dir}/include/$3"
             cp -r -L -t "${target_dir}/include/$3" "$2"/*

--- a/uspace/lib/inet/meson.build
+++ b/uspace/lib/inet/meson.build
@@ -49,3 +49,4 @@ test_src = files(
 	'test/eth_addr.c',
 	'test/main.c',
 )
+allow_shared = true

--- a/uspace/lib/meson.build
+++ b/uspace/lib/meson.build
@@ -242,7 +242,8 @@ foreach l : libs
 
 	if src.length() > 0
 		if not always_static
-			_libname = 'lib' + l + '.so.' + version.split('.')[0]
+			_libname_unversioned = 'lib' + l + '.so'
+			_libname = _libname_unversioned + '.' + version.split('.')[0]
 
 			_shared_lib = shared_library(l, src,
 				# TODO: Include private headers using #include "quoted",
@@ -287,6 +288,7 @@ foreach l : libs
 				include_directories: includes,
 				dependencies: _shared_deps,
 			)
+			exported_devel_files += ['sharedlib', _shared_lib, _libname_unversioned]
 		endif
 
 		_static_lib = static_library(l, src,

--- a/uspace/lib/posix/meson.build
+++ b/uspace/lib/posix/meson.build
@@ -70,3 +70,4 @@ uspace_lib_devel_install_script_text += 'ln -s -r "${DESTDIR}include/libc" "${DE
 
 exported_devel_files += [ 'include', meson.current_source_dir() / 'include' / 'posix', 'libposix' ]
 exported_devel_files += [ 'includesymlink', 'libc', 'libposix' ]
+allow_shared = true


### PR DESCRIPTION
this makes external program development easier, since you can just `cp -P export-dev/lib/* ~/.local/share/HelenOS/cross/<arch>-helenos/lib/`