### PR TITLE
mkfile: use DATA_XFER_LIMIT

### DIFF
--- a/uspace/app/bdsh/cmds/modules/mkfile/mkfile.c
+++ b/uspace/app/bdsh/cmds/modules/mkfile/mkfile.c
@@ -47,7 +47,7 @@
 #include "cmds.h"
 
 /** Number of bytes to write at a time */
-#define BUFFER_SIZE 16384
+#define BUFFER_SIZE (1024 * 64)
 
 static const char *cmdname = "mkfile";
 


### PR DESCRIPTION
We should try to use the maximum allowed IPC transfer buffer size. Can possibly save 4 calls.