### PR TITLE
meson/cross/mips32eb: fix compiler name

### DIFF
--- a/meson/cross/mips32eb
+++ b/meson/cross/mips32eb
@@ -15,7 +15,7 @@ ld = '@COMPPREFIX@ld'
 has_function_printf = true
 needs_exe_wrapper = true
 
-cc_arch = 'mips'
+cc_arch = 'mipsel'
 bits = 32
 
 [host_machine]


### PR DESCRIPTION
When **Big Endian** mips32 is selected in configure.sh, the script tries to find compiler named `mips-helenos-gcc` which is not installed by `toolchain.sh`. Instead it should be `mipsel-helenos-gcc`, the Little Endian and MSIM targets have correct compiler name set.

```
ERROR: $CROSS_PREFIX is not defined and mips-helenos-gcc is not present in any of the following standard locations.
```