### PR TITLE
ext4: small write refactor + block leak fix

### DIFF
--- a/uspace/lib/ext4/src/ops.c
+++ b/uspace/lib/ext4/src/ops.c
@@ -63,6 +63,8 @@ static errno_t ext4_read_file(ipc_call_t *, aoff64_t, size_t, ext4_instance_t *,
     ext4_inode_ref_t *, size_t *);
 static bool ext4_is_dots(const uint8_t *, size_t);
 static errno_t ext4_instance_get(service_id_t, ext4_instance_t **);
+static errno_t handle_sparse_or_unallocated_fblock(ext4_filesystem_t *,
+    ext4_inode_ref_t *, uint32_t, uint32_t, uint32_t *, int *);
 
 /* Forward declarations of ext4 libfs operations. */
 
@@ -157,10 +159,6 @@ errno_t ext4_global_fini(void)
 	return EOK;
 }
 
-/*
- * Ext4 libfs operations.
- */
-
 /** Get instance from internal table by service_id.
  *
  * @param service_id Device identifier
@@ -169,7 +167,7 @@ errno_t ext4_global_fini(void)
  * @return Error code
  *
  */
-errno_t ext4_instance_get(service_id_t service_id, ext4_instance_t **inst)
+static errno_t ext4_instance_get(service_id_t service_id, ext4_instance_t **inst)
 {
 	fibril_mutex_lock(&instance_list_mutex);
 
@@ -189,6 +187,10 @@ errno_t ext4_instance_get(service_id_t service_id, ext4_instance_t **inst)
 	fibril_mutex_unlock(&instance_list_mutex);
 	return EINVAL;
 }
+
+/*
+ * Ext4 libfs operations.
+ */
 
 /** Get root node of filesystem specified by service_id.
  *
@@ -1321,48 +1323,14 @@ static errno_t ext4_write(service_id_t service_id, fs_index_t index, aoff64_t po
 		goto exit;
 	}
 
-	/* Check for sparse file */
+	/* Handle sparse or unallocated block */
 	if (fblock == 0) {
-		if ((ext4_superblock_has_feature_incompatible(fs->superblock,
-		    EXT4_FEATURE_INCOMPAT_EXTENTS)) &&
-		    (ext4_inode_has_flag(inode_ref->inode, EXT4_INODE_FLAG_EXTENTS))) {
-			uint32_t last_iblock =
-			    ext4_inode_get_size(fs->superblock, inode_ref->inode) /
-			    block_size;
-
-			while (last_iblock < iblock) {
-				rc = ext4_extent_append_block(inode_ref, &last_iblock,
-				    &fblock, true);
-				if (rc != EOK) {
-					async_answer_0(&call, rc);
-					goto exit;
-				}
-			}
-
-			rc = ext4_extent_append_block(inode_ref, &last_iblock,
-			    &fblock, false);
-			if (rc != EOK) {
-				async_answer_0(&call, rc);
-				goto exit;
-			}
-		} else {
-			rc = ext4_balloc_alloc_block(inode_ref, &fblock);
-			if (rc != EOK) {
-				async_answer_0(&call, rc);
-				goto exit;
-			}
-
-			rc = ext4_filesystem_set_inode_data_block_index(inode_ref,
-			    iblock, fblock);
-			if (rc != EOK) {
-				ext4_balloc_free_block(inode_ref, fblock);
-				async_answer_0(&call, rc);
-				goto exit;
-			}
+		rc = handle_sparse_or_unallocated_fblock(fs, inode_ref,
+		    block_size, iblock, &fblock, &flags);
+		if (rc != EOK) {
+			async_answer_0(&call, rc);
+			goto exit;
 		}
-
-		flags = BLOCK_FLAGS_NOREAD;
-		inode_ref->dirty = true;
 	}
 
 	/* Load target block */
@@ -1403,6 +1371,62 @@ static errno_t ext4_write(service_id_t service_id, fs_index_t index, aoff64_t po
 exit:
 	rc2 = ext4_node_put(fn);
 	return rc == EOK ? rc2 : rc;
+}
+
+/** Handle sparse or unallocated block.
+ *
+ * @param fs		Filesystem handle
+ * @param inode_ref	I-node reference
+ * @param block_size	Filesystem block size
+ * @param iblock	Logical block
+ * @param fblock	Place to store allocated block address
+ * @param flags		BLOCK_FLAGS to update
+ *
+ * @return Error code
+ *
+ */
+static errno_t handle_sparse_or_unallocated_fblock(ext4_filesystem_t *fs,
+    ext4_inode_ref_t *inode_ref, uint32_t block_size, uint32_t iblock,
+    uint32_t *fblock, int *flags)
+{
+	errno_t rc;
+
+	/* Check for sparse file */
+	if ((ext4_superblock_has_feature_incompatible(fs->superblock,
+	    EXT4_FEATURE_INCOMPAT_EXTENTS)) &&
+	    (ext4_inode_has_flag(inode_ref->inode, EXT4_INODE_FLAG_EXTENTS))) {
+		uint32_t last_iblock =
+		    ext4_inode_get_size(fs->superblock, inode_ref->inode) /
+		    block_size;
+
+		while (last_iblock < iblock) {
+			rc = ext4_extent_append_block(inode_ref, &last_iblock,
+			    fblock, true);
+			if (rc != EOK)
+				return rc;
+		}
+
+		rc = ext4_extent_append_block(inode_ref, &last_iblock, fblock,
+		    false);
+		if (rc != EOK)
+			return rc;
+	} else { /* Allocate new block */
+		rc = ext4_balloc_alloc_block(inode_ref, fblock);
+		if (rc != EOK)
+			return rc;
+
+		rc = ext4_filesystem_set_inode_data_block_index(inode_ref,
+		    iblock, *fblock);
+		if (rc != EOK) {
+			ext4_balloc_free_block(inode_ref, *fblock);
+			return rc;
+		}
+	}
+
+	*flags = BLOCK_FLAGS_NOREAD;
+	inode_ref->dirty = true;
+
+	return EOK;
 }
 
 /** Truncate file.


### PR DESCRIPTION
Pull request includes 2 commits:

- [ext4: write: sparse/unallocated block helper fcn](https://github.com/HelenOS/helenos/commit/f62c901cedddc0f126df491f8b76d51aa9377ed9):
  - put handling of sparse or unallocated blocks into a helper function
  - this small refactor will help with implementing multi-block writes
  - also while at it put `static` in `ext4_instance_get()` definition, as it should be, see the prototype

- [ext4: write: fix block leak](https://github.com/HelenOS/helenos/commit/d91d076d05636b96ee75642cf2ec2d5885a27328):
  - extends the helper function with `allocated` bool hint, based on which we can free
the allocated block on later error paths, which previously didn't free it


I am putting this PR up earlier without waiting until I finish my multi-block read/write feature proposals, in hope that this will get merged faster as it's not a big change.

Feedback/improvements/edits are welcome.