### PR TITLE
Add CLOCK_MONOTONIC, implemented using uptime

### DIFF
--- a/uspace/lib/posix/include/posix/time.h
+++ b/uspace/lib/posix/include/posix/time.h
@@ -41,6 +41,7 @@
 #include <libc/time.h>
 
 #define CLOCK_REALTIME ((clockid_t) 0)
+#define CLOCK_MONOTONIC ((clockid_t) 1)
 
 #define ASCTIME_BUF_LEN  26
 

--- a/uspace/lib/posix/src/time.c
+++ b/uspace/lib/posix/src/time.c
@@ -205,7 +205,7 @@ char *ctime(const time_t *timep)
 }
 
 /**
- * Get clock resolution. Only CLOCK_REALTIME is supported.
+ * Get clock resolution.
  *
  * @param clock_id Clock ID.
  * @param res Pointer to the variable where the resolution is to be written.
@@ -217,6 +217,7 @@ int clock_getres(clockid_t clock_id, struct timespec *res)
 
 	switch (clock_id) {
 	case CLOCK_REALTIME:
+	case CLOCK_MONOTONIC:
 		res->tv_sec = 0;
 		res->tv_nsec = USEC2NSEC(1); /* Microsecond resolution. */
 		return 0;
@@ -227,7 +228,7 @@ int clock_getres(clockid_t clock_id, struct timespec *res)
 }
 
 /**
- * Get time. Only CLOCK_REALTIME is supported.
+ * Get time.
  *
  * @param clock_id ID of the clock to query.
  * @param tp Pointer to the variable where the time is to be written.
@@ -244,6 +245,9 @@ int clock_gettime(clockid_t clock_id, struct timespec *tp)
 		gettimeofday(&tv, NULL);
 		tp->tv_sec = tv.tv_sec;
 		tp->tv_nsec = USEC2NSEC(tv.tv_usec);
+		return 0;
+	case CLOCK_MONOTONIC:
+		getuptime(tp);
 		return 0;
 	default:
 		errno = EINVAL;
@@ -266,6 +270,7 @@ int clock_settime(clockid_t clock_id,
 
 	switch (clock_id) {
 	case CLOCK_REALTIME:
+	case CLOCK_MONOTONIC:
 		// TODO: setting clock
 		// FIXME: HelenOS doesn't actually support hardware
 		//        clock yet


### PR DESCRIPTION
According to docstring, `getuptime` guarantees monotonicity, so we can use it to implement `CLOCK_MONOTONIC` from `posix/time.h`. Monotonic clock is useful, and needed for Rust support. (I had this code in my branch for a while, but figured I could merge this upstream.)